### PR TITLE
Removes accents from races

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -146,5 +146,3 @@
 /datum/species/elf/dark/random_surname()
 	return " [pick(world.file2list("strings/rt/names/elf/elfsnf.txt"))]"
 
-/datum/species/elf/dark/get_accent(mob/living/carbon/human/H)
-	return strings("french_replacement.json", "french")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -155,6 +155,3 @@
 
 /datum/species/elf/wood/random_surname()
 	return " [pick(world.file2list("strings/rt/names/elf/elfwlast.txt"))]"
-
-/datum/species/elf/wood/get_accent(mob/living/carbon/human/H)
-	return strings("russian_replacement.json", "russian")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -143,6 +143,3 @@
 
 /datum/species/aasimar/random_surname()
 	return
-
-/datum/species/aasimar/get_accent(mob/living/carbon/human/H)
-	return strings("proper_replacement.json", "proper")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/brazillian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/brazillian.dm
@@ -92,6 +92,3 @@
 
 /datum/species/lizard/brazil/random_surname()
 	return " [pick(world.file2list("strings/rt/names/other/arglast.txt"))]"
-
-/datum/species/lizard/brazil/get_accent(mob/living/carbon/human/H)
-	return strings("brazillian_replacement.json", "brazillian")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -136,5 +136,3 @@
 /datum/species/halforc/random_surname()
 	return
 
-/datum/species/halforc/get_accent(mob/living/carbon/human/H)
-	return strings("middlespeak.json", "middle")


### PR DESCRIPTION
Sun elves, Dark elves, aasimar, argonian, and half orc has had their accents removed.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Removes accents from Sun Elves, Dark Elves, Half-Orcs Aasimaar and Argonians

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Some people do not like the accents on their characters.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

There is a desire for these changes to be made in the community.
