### PR TITLE
Lord/Lady both sexes, Goblins allraces, goblin bogguard

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 10
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = RACES_SHUNNED_UP
+	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "You've handed your resume, which mostly consisted of showing up, and in exchange you have a spot among the Bog Guards. You have a roof over your head, coin in your pocket, and a thankless job protecting the outskirts of town against bandits and volfs."
 	display_order = JDO_TOWNGUARD

--- a/code/modules/jobs/job_types/roguetown/goblin/goblincook.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblincook.dm
@@ -1,13 +1,13 @@
 /datum/job/roguetown/goblincook
-	title = "Goblin Cook"
+	title = "Tribal Cook"
 	flag = GOBLINCOOK
 	department_flag = GOBLIN
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list(RACES_DESPISED)
-	allowed_patrons = list(/datum/patron/inhumen/graggar)
+	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = ALL_DIVINE_PATRONS
 	tutorial = "Cook, farm, butcher. Make king happy with apple pies! Don't forget about your brothers."
 
 

--- a/code/modules/jobs/job_types/roguetown/goblin/goblinguard.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinguard.dm
@@ -1,13 +1,13 @@
 /datum/job/roguetown/goblinguard
-	title = "Goblin Guard"
+	title = "Tribal Guard"
 	flag = GOBLINGUARD
 	department_flag = GOBLIN
 	faction = "Station"
-	total_positions = 9
-	spawn_positions = 9
+	total_positions = 5
+	spawn_positions = 5
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list(RACES_DESPISED)
-	allowed_patrons = list(/datum/patron/inhumen/graggar)
+	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = ALL_DIVINE_PATRONS
 	tutorial = "Goblin Guards rensposible for their kingdom and his majesty King."
 	display_order = JDO_GOBLINGUARD
 	outfit = /datum/outfit/job/roguetown/goblinguard

--- a/code/modules/jobs/job_types/roguetown/goblin/goblinking.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinking.dm
@@ -1,6 +1,6 @@
 
 /datum/job/roguetown/goblinking
-	title = "Goblin King"
+	title = "Tribal King"
 	f_title = "Goblin Queen"
 	flag = GOBLINKING
 	department_flag = GOBLIN
@@ -8,8 +8,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list(RACES_DESPISED)
-	allowed_patrons = list(/datum/patron/inhumen/graggar)
+	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = ALL_DIVINE_PATRONS
 	tutorial = "Goblin King or Queen is a fatty lazy pig who wishes to do nothing but eat apple pies and fart while sitting on his stone throne."
 	whitelist_req = FALSE
 	outfit = /datum/outfit/job/roguetown/goblinking

--- a/code/modules/jobs/job_types/roguetown/goblin/goblinsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinsmith.dm
@@ -1,13 +1,13 @@
 /datum/job/roguetown/goblinsmith
-	title = "Goblin Smith"
+	title = "Tribal Smith"
 	flag = GOBLINSMITH
 	department_flag = GOBLIN
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list(RACES_DESPISED)
-	allowed_patrons = list(/datum/patron/inhumen/graggar)
+	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = ALL_DIVINE_PATRONS
 	tutorial = "Goblin rensposible for fresh iron and steel"
 	display_order = JDO_GOBLINSMITH
 	outfit = /datum/outfit/job/roguetown/goblinsmith

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -1,12 +1,12 @@
 /datum/job/roguetown/lady
-	title = "Queen Consort"
+	title = "Consort"
 	flag = LADY
 	department_flag = NOBLEMEN
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(FEMALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Picked out of your political value rather than likely any form of love, you have become the King's most trusted confidant and likely friend throughout your marriage. Your loyalty and, perhaps, love; will be tested this day. For the daggers that threaten your beloved are as equally pointed at your own throat."
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -10,8 +10,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	total_positions = 0
 	spawn_positions = 1
 	selection_color = JCOLOR_NOBLE
-	allowed_races = RACES_ALL_KINDS
-	allowed_sexes = list(MALE)
+	allowed_races = RACES_SHUNNED_UP
+	allowed_sexes = list(MALE, FEMALE)
 
 	spells = list(
 		/obj/effect/proc_holder/spell/self/grant_title,


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Allows goblins to become bog guards,

Makes all goblin roles all races and all patrons. decreases the amount of positions for all roles. 5 for guards, 3 cooks, 3 smiths and one king. Changes Names to Tribal instead of Goblin.

King and Queen Consort are now both genders, queen Consort Name is changed to consort.


## Why It's Good For The Game

makes the goblin fort more assessable and more playable for multiple variations of character, allows goblins to play bog guard. makes the king/queen both sexes, places in the consort for both sexes with a funni look.
