### PR TITLE
removes the funny instakill pit

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -4829,6 +4829,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
+"fJD" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "fJM" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
@@ -5277,12 +5281,6 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
-"gpW" = (
-/obj/structure/lever{
-	redstone_id = "thronegrille"
-	},
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/indoors/town/manor)
 "gqc" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -7519,6 +7517,12 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/right,
+/area/rogue/indoors/town/manor)
+"jdJ" = (
+/obj/structure/floordoor{
+	redstone_id = "thronegrille"
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "jdK" = (
 /obj/structure/stairs{
@@ -10403,6 +10407,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ngX" = (
+/obj/structure/lever{
+	redstone_id = "thronegrille"
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "nhC" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph5"
@@ -14681,12 +14691,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"sPY" = (
-/obj/structure/floordoor{
-	redstone_id = "thronegrille"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
 "sPZ" = (
 /obj/item/paper/confession,
 /obj/item/paper/confession,
@@ -184983,7 +184987,7 @@ vRu
 txa
 iTw
 txa
-iTw
+fJD
 cBf
 iTw
 iTw
@@ -288696,7 +288700,7 @@ hcW
 hcW
 ltM
 sHm
-gpW
+ngX
 ohU
 qsZ
 ohU
@@ -289101,7 +289105,7 @@ sHm
 kQW
 wxB
 eTM
-sPY
+jdJ
 sqd
 miX
 wxB

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -918,11 +918,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "aRA" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/wolf{
-	del_on_deaggro = 0;
-	name = "Aruzhan"
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "aRU" = (
 /obj/structure/table/wood{
@@ -5280,6 +5277,12 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
+"gpW" = (
+/obj/structure/lever{
+	redstone_id = "thronegrille"
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "gqc" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -9768,9 +9771,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mkk" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/wolf{
-	del_on_deaggro = 0;
-	name = "Beatrix"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -9893,10 +9895,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "msE" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/wolf{
-	del_on_deaggro = 0;
-	name = "Rowena"
-	},
+/obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mtF" = (
@@ -14682,6 +14681,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"sPY" = (
+/obj/structure/floordoor{
+	redstone_id = "thronegrille"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "sPZ" = (
 /obj/item/paper/confession,
 /obj/item/paper/confession,
@@ -186182,9 +186187,9 @@ pUz
 iTw
 egU
 jvC
-iTw
-cBf
 aRA
+cBf
+cBf
 iTw
 iTw
 ida
@@ -186986,7 +186991,7 @@ sKU
 iTw
 nZt
 txa
-iTw
+mkk
 iTw
 cBf
 iTw
@@ -187794,7 +187799,7 @@ iTw
 cBf
 iTw
 iTw
-msE
+iTw
 ida
 iTw
 iTw
@@ -188192,8 +188197,8 @@ aEN
 iTw
 tjU
 txa
+msE
 iTw
-mkk
 cBf
 iTw
 iTw
@@ -188594,7 +188599,7 @@ nda
 iTw
 mMO
 txa
-iTw
+msE
 iTw
 iTw
 iTw
@@ -288691,7 +288696,7 @@ hcW
 hcW
 ltM
 sHm
-ohU
+gpW
 ohU
 qsZ
 ohU
@@ -289096,7 +289101,7 @@ sHm
 kQW
 wxB
 eTM
-wxB
+sPY
 sqd
 miX
 wxB

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -5047,9 +5047,6 @@
 "fZJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"fZO" = (
-/turf/open/lava/acid,
-/area/rogue/under/town/sewer)
 "gas" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -17036,12 +17033,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"vRn" = (
-/obj/structure/bars{
-	alpha = 150
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
 "vRu" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cave)
@@ -185016,10 +185007,10 @@ vRu
 vRu
 vRu
 vRu
-sYw
-sYw
-sYw
-sYw
+vRu
+vRu
+vRu
+vRu
 vRu
 rSC
 rSC
@@ -185418,11 +185409,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-vRn
-vRn
-sYw
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -185820,11 +185811,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-fZO
-fZO
-fZO
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -186222,11 +186213,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-fZO
-fZO
-fZO
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -186624,11 +186615,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-fZO
-fZO
-fZO
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -187026,11 +187017,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-fZO
-fZO
-fZO
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -187428,11 +187419,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-fZO
-fZO
-fZO
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -187830,11 +187821,11 @@ vRu
 vRu
 vRu
 vRu
-sYw
-vRn
-vRn
-sYw
-sYw
+vRu
+vRu
+vRu
+vRu
+vRu
 rSC
 rSC
 rSC
@@ -188232,10 +188223,10 @@ vRu
 vRu
 vRu
 vRu
-sYw
-sYw
-sYw
-sYw
+vRu
+vRu
+vRu
+vRu
 vRu
 rSC
 rSC

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -2302,6 +2302,10 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cFQ" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "cFR" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/naturalstone,
@@ -2825,6 +2829,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"dkI" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "dkS" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/roguecoin/gold/pile,
@@ -4629,6 +4637,12 @@
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"fye" = (
+/obj/structure/lever{
+	redstone_id = "thronegrille"
+	},
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors/town/manor)
 "fyi" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -4829,10 +4843,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
-"fJD" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement)
 "fJM" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
@@ -7518,12 +7528,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
-"jdJ" = (
-/obj/structure/floordoor{
-	redstone_id = "thronegrille"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
 "jdK" = (
 /obj/structure/stairs{
 	dir = 4
@@ -9300,6 +9304,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"lAy" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "lBP" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/wood,
@@ -9778,6 +9786,9 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 18
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mkO" = (
@@ -9899,7 +9910,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "msE" = (
-/obj/structure/fermenting_barrel,
+/obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mtF" = (
@@ -10407,12 +10418,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"ngX" = (
-/obj/structure/lever{
-	redstone_id = "thronegrille"
-	},
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/indoors/town/manor)
 "nhC" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph5"
@@ -15011,6 +15016,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"tjo" = (
+/obj/structure/floordoor{
+	redstone_id = "thronegrille"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manor)
 "tjU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/flail/sflail,
@@ -18852,6 +18863,12 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
+"yes" = (
+/obj/structure/fluff/walldeco/chains{
+	pixel_x = 23
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "yeM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile{
@@ -184987,7 +185004,7 @@ vRu
 txa
 iTw
 txa
-fJD
+cFQ
 cBf
 iTw
 iTw
@@ -185387,7 +185404,7 @@ txa
 txa
 txa
 txa
-iTw
+syh
 cBf
 iTw
 iTw
@@ -186593,11 +186610,11 @@ dfS
 iTw
 jMA
 txa
+mkk
 iTw
 iTw
 iTw
-iTw
-cBf
+lAy
 txa
 cBf
 iTw
@@ -186995,11 +187012,11 @@ sKU
 iTw
 nZt
 txa
-mkk
+msE
 iTw
 cBf
 iTw
-iTw
+dkI
 txa
 iTw
 iTw
@@ -187397,7 +187414,7 @@ tHU
 iTw
 mdI
 txa
-iTw
+msE
 cBf
 iTw
 cBf
@@ -187799,7 +187816,7 @@ qlD
 iTw
 wZJ
 jvC
-iTw
+msE
 cBf
 iTw
 iTw
@@ -188201,7 +188218,7 @@ aEN
 iTw
 tjU
 txa
-msE
+dkI
 iTw
 cBf
 iTw
@@ -188603,9 +188620,9 @@ nda
 iTw
 mMO
 txa
-msE
+dkI
 iTw
-iTw
+yes
 iTw
 cBf
 txa
@@ -288700,7 +288717,7 @@ hcW
 hcW
 ltM
 sHm
-ngX
+fye
 ohU
 qsZ
 ohU
@@ -289105,7 +289122,7 @@ sHm
 kQW
 wxB
 eTM
-jdJ
+tjo
 sqd
 miX
 wxB

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1444,11 +1444,7 @@
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
 	},
-/obj/structure/kybraxor{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
@@ -3382,10 +3378,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dYd" = (
-/obj/structure/floordoor{
-	redstone_id = "thronegrille"
+/obj/structure/floordoor/gatehatch/outer{
+	redstone_id = "gatelava"
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "dYj" = (
 /obj/structure/chair/bench{
@@ -4284,12 +4280,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"eZm" = (
-/obj/structure/lever{
-	redstone_id = "thronegrille"
-	},
-/turf/open/floor/rogue/carpet/lord/left,
-/area/rogue/indoors/town/manor)
 "eZy" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger/steel,
@@ -8971,7 +8961,7 @@
 /obj/structure/floordoor/gatehatch/outer{
 	redstone_id = "gatelava"
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "lfz" = (
 /obj/structure/fluff/railing/border{
@@ -16827,7 +16817,7 @@
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "vBH" = (
 /obj/item/reagent_containers/food/snacks/crow{
@@ -288710,7 +288700,7 @@ hcW
 hcW
 ltM
 sHm
-eZm
+ohU
 ohU
 qsZ
 ohU
@@ -289115,7 +289105,7 @@ sHm
 kQW
 wxB
 eTM
-dYd
+wxB
 sqd
 miX
 wxB
@@ -289549,8 +289539,8 @@ wbg
 wbg
 xXq
 leV
-vAF
-leV
+byB
+dYd
 xXq
 czO
 czO

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -9,8 +9,8 @@
 	var/living_transformation_time = 30
 	var/converts_living = FALSE
 
-	var/revive_time_min = 450
-	var/revive_time_max = 700
+	var/revive_time_min = 900
+	var/revive_time_max = 1400
 	var/timer_id
 
 /obj/item/organ/zombie_infection/Initialize()


### PR DESCRIPTION
## About The Pull Request

Removes the acid pit instakill. This was done by request of an admin. Additionally removes the trapdoor for the wolf pit in the king's hall.

## Why It's Good For The Game

The acid pit has been used exactly once and it was for griefing. ~~The King's wulf pit has been used exactly once, and it was by accident before they fell down it during a goblin invasion. Very funny, but not exactly useful. We're trying to cultivate an atmosphere where the cost of life is slightly higher than blackstone.~~

Trapdoor is back in, but without woofs.