### PR TITLE
Werewolf Neet Mode

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -17,14 +17,14 @@
                     owner.current.playsound_local(get_turf(owner.current), 'sound/music/wolfintro.ogg', 80, FALSE, pressure_affected = FALSE)
                     H.flash_fullscreen("redflash3")
                     transforming = world.time // timer
-    
+
     // Begin transformation
     else if(transforming)
         if (world.time >= transforming + 35 SECONDS) // Stage 3
             H.werewolf_transform()
             transforming = FALSE
             transformed = TRUE // Mark as transformed
-            
+
         else if (world.time >= transforming + 25 SECONDS) // Stage 2
             H.flash_fullscreen("redflash3")
             H.emote("agony", forced = TRUE)
@@ -35,27 +35,30 @@
         else if (world.time >= transforming + 10 SECONDS) // Stage 1
             H.emote("")
             to_chat(H, span_warning("I can feel my muscles aching, it feels HORRIBLE..."))
-        
+
 
     // Werewolf reverts to human form during the day
     else if(transformed)
         H.real_name = wolfname
         H.name = wolfname
 
-        if(GLOB.tod != "night")
-            if(!untransforming)
-                untransforming = world.time // Start untransformation phase
+        if(GLOB.tod != "night" && !untransforming) // Is it day and we arnt already turning back.
+            if(isturf(H.loc))
+                var/turf/loc = H.loc
+                if(loc.can_see_sky())
+                    untransforming = world.time // Start untransformation phase
 
+        if(untransforming)
             if (world.time >= untransforming + 25 SECONDS) // Untransform
                 H.emote("rage", forced = TRUE)
                 H.werewolf_untransform()
                 transformed = FALSE
                 untransforming = FALSE // Reset untransforming phase
-                
+
             else if (world.time >= untransforming + 10 SECONDS) // Alert player
                 H.flash_fullscreen("redflash1")
                 to_chat(H, span_warning("Daylight shines around me... the curse begins to fade."))
-			
+
 
 /mob/living/carbon/human/species/werewolf/death(gibbed)
 	werewolf_untransform(TRUE, gibbed)


### PR DESCRIPTION
Stops werewolves from changing back into a human during the day if they are not under view of the sky.

![Untitled](https://github.com/Tree445/Hearthstone/assets/13492089/1e9e19ed-4931-4388-8a8e-3d1588c25fd7)


If you have any changes or comments please ping "Lyric Lothlace" on the discord. I don't catch them here.