### PR TITLE
Lowers biggest combat roles total slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -3,8 +3,8 @@
 	flag = BOGGUARD
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 10
-	spawn_positions = 10
+	total_positions = 4
+	spawn_positions = 4
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
@@ -16,7 +16,7 @@
 	give_bank_account = 16
 	min_pq = 0
 	max_pq = null
-	
+
 	cmode_music = 'sound/music/combat_bog.ogg'
 
 	/// Chance to be spawned as a crossbowman instead

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -3,8 +3,8 @@
 	flag = MANATARMS
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 3
+	spawn_positions = 3
 
 	allowed_sexes = list(MALE)
 	allowed_races = RACES_ALL_KINDS
@@ -61,7 +61,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE) 
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
 		H.change_stat("strength", 2)

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -3,8 +3,8 @@
 	flag = GUARDSMAN
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 9
-	spawn_positions = 9
+	total_positions = 4
+	spawn_positions = 4
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
@@ -47,7 +47,7 @@
 			if(!index)
 				index = H.real_name
 			S.name = "watchman tabard ([index])"
-			
+
 /datum/outfit/job/roguetown/guardsman
 	name = "Watchman"
 	/// Whether or not we are a bowman
@@ -82,7 +82,7 @@
 /datum/outfit/job/roguetown/guardsman/proc/assign_skills(mob/living/carbon/human/guard)
 	guard.mind.adjust_skillrank(/datum/skill/combat/maces, pick(3,4), TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
-	guard.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE) 
+	guard.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
@@ -91,13 +91,13 @@
 	guard.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-	guard.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE) 
+	guard.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 	guard.change_stat("strength", 1)
-	guard.change_stat("perception", 2) 
+	guard.change_stat("perception", 2)
 	guard.change_stat("constitution", 1)
 	guard.change_stat("endurance", 1)
 	guard.change_stat("speed", 1)
@@ -116,7 +116,7 @@
 	guard.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-	guard.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE) 
+	guard.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	guard.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
@@ -9,8 +9,8 @@
 	display_order = JDO_DESERT_RIDER
 	selection_color = JCOLOR_MERCENARY
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 3
+	spawn_positions = 3
 	give_bank_account = 3
 	min_pq = 0 //good fragger role
 	max_pq = null

--- a/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
@@ -9,8 +9,8 @@
 	display_order = JDO_GRENZELHOFT
 	selection_color = JCOLOR_MERCENARY
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 3
+	spawn_positions = 3
 	min_pq = 0 //good fragger role
 	max_pq = null
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
previously, there were 36 guard slots total
ive lowered this
Bog Guard: 10 -> 4
Watchmen 9 -> 4
Men-At-Arms 8 -> 3
also mercs
Grenzelhoft: 5 -> 3
Desert Rider 5 -> 3
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
*some* antags are struggling, this will help
furthermore, this de-blackstones the game by lowering the total amount of combat capable people in game at one time <!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
