### PR TITLE
Genitals part 3: Bug Fixing Part 1

### DIFF
--- a/code/modules/client/preferences_customizers.dm
+++ b/code/modules/client/preferences_customizers.dm
@@ -149,6 +149,9 @@
 		if("toggle_missing")
 			if(customizer.allows_disabling)
 				entry.disabled = !entry.disabled
+			if(ishuman(user))
+				var/mob/living/carbon/human/humanized = user
+				humanized.update_body_parts(TRUE)
 		if("change_choice")
 			var/list/choice_list = list()
 			for(var/choice_type in customizer.customizer_choices)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -486,6 +486,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	S["customizer_entries"] >> customizer_entries
 	validate_customizer_entries()
+	if(!S["is_updated_for_genitalia"]) //Vrell - should fix loading old characters giving all genitals.
+		genderize_customizer_entries()
 
 	return TRUE
 
@@ -555,6 +557,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	
 	WRITE_FILE(S["update_mutant_colors"] , update_mutant_colors)
 	WRITE_FILE(S["headshot_link"] , headshot_link)
+
+	WRITE_FILE(S["is_updated_for_genitalia"], TRUE)
 
 	return TRUE
 

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3501,5 +3501,4 @@
 #include "modular\code\modules\maturity-prompt\code\config_entries.dm"
 #include "modular\code\modules\maturity-prompt\code\maturity_prompt.dm"
 #include "modular\code\modules\maturity-prompt\code\maturity_subsystem.dm"
-#include "modular_hearthstone\code\game\objects\structures\fluff.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

CHANGELOG:
- Saves made before this gets merged will now have the genital selection default to the gender's default instead of all bits being enabled.
- Disabling genitals in the character creator now always updates the sprite visible on the character creation screen.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fixes!!!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
