### PR TITLE
Rockhill becomes literate

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
@@ -30,6 +30,7 @@
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	cloak = /obj/item/clothing/cloak/raincloak/brown
 	H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -28,7 +28,7 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, pick(5,6), TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/reading, pick(0,1,1), TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, pick(0,1), TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 5, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -24,6 +24,7 @@
 			to_chat(H, span_warning("Warriors are well rounded fighters, experienced often in many theaters of warfare and battle they are capable of rising to any challenge that might greet them on the path."))
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, rand(1,2), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, rand(1,2), TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
@@ -25,6 +25,7 @@
 		backpack_contents = list(/obj/item/storage/pill_bottle/dice = 1, /obj/item/toy/cards/deck = 1, /obj/item/reagent_containers/glass/bottle/rogue/wine = 1)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
@@ -23,7 +23,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, pick(0,0,1), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/butchering, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -30,6 +30,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -31,7 +31,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, pick(0,1), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/engineering, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, pick(0,1), TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
@@ -10,6 +10,7 @@
 /datum/outfit/job/roguetown/adventurer/peasant/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, rand(2,3), TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodcutter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodcutter.dm
@@ -15,6 +15,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE) 
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -94,6 +94,7 @@
 	bogger.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	bogger.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	bogger.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+	bogger.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	bogger.change_stat("strength", 2)
 	bogger.change_stat("perception", 2)
 	bogger.change_stat("constitution", 1)

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -41,6 +41,7 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.change_stat("strength", 3)
 	H.change_stat("intelligence", -2)
 	H.change_stat("endurance", 2)

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -34,6 +34,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/music, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
 
 // Washing Implements

--- a/code/modules/jobs/job_types/roguetown/peasants/bogprisoner.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bogprisoner.dm
@@ -32,6 +32,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.change_stat("intelligence", 1)
 		H.change_stat("fortune", 2)
 		var/datum/antagonist/new_antag = new /datum/antagonist/prisoner()

--- a/code/modules/jobs/job_types/roguetown/peasants/hostage.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/hostage.dm
@@ -35,6 +35,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.change_stat("intelligence", 1)
 		H.change_stat("fortune", 2)
 		var/datum/antagonist/new_antag = new /datum/antagonist/prisoner()

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -35,6 +35,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("constitution", 1)
 		H.change_stat("speed", 1)

--- a/code/modules/jobs/job_types/roguetown/yeomen/mason.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/mason.dm
@@ -21,6 +21,7 @@
 	..()
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, rand(1,3), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, rand(1,3), TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/lumberjacking, rand(2,3), TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/mining, rand(2,3), TRUE)

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -57,7 +57,6 @@
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
-	var/canread = user.can_read(src, TRUE)
 	var/contents
 	if(SSticker.rulertype == "King")
 		contents += "<center>KING'S DECREES<BR>"
@@ -66,8 +65,6 @@
 	contents += "-----------<BR><BR></center>"
 	for(var/i = GLOB.lord_decrees.len to 1 step -1)
 		contents += "[i]. <span class='info'>[GLOB.lord_decrees[i]]</span><BR>"
-	if(!canread)
-		contents = stars(contents)
 	var/datum/browser/popup = new(user, "VENDORTHING", "", 370, 220)
 	popup.set_content(contents)
 	popup.open()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
CHANGE: Grants reading level 1 to:  Dwarf Ranger, Rogue, Warrior, Drunkard, Fisher, Hunter, Miner, Peasant, Woodcutter, Bog Guard, Dungeoneer, Bathmaid, Bog Prisoner, Hostage, Soilson, Mason

Beggars, Barbarians, Lunatics, Amazons, Tribal Goblins ( Except for King ), etc. are still unable to read

Allows even those who cannot read to use the SCOM to see the current laws
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows any player to view current laws at the SCOM so even late join illiterate's can see what current laws are

Encourages more use of mail, book crafting, note taking, leaving orders, keeping contracts between businesses, increased scribe role activity, leaving advertisements, keeping gate tally, prisoner tally/confessions, increased interaction between towners / adventurers and peddler use
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
