### PR TITLE
Removes Job Genderlocking

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/barbarian.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/barbarian.dm
@@ -2,7 +2,7 @@
 /datum/advclass/barbarian
 	name = "Barbarian"
 	tutorial = "A jack-of-all-trades warrior sort. Is skilled in all weapons, but master of none"
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/barbarian
 	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_STEELHEARTED)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelt.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelt.dm
@@ -1,9 +1,10 @@
 	
 /datum/advclass/heartfeltlord
 	name = "Lord of Heartfelt"
+	f_title = "Lady of Heartfelt"
 	tutorial = "You are the proud lord of heartfelt \
 	but why did you come to the isle of enigma?"
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_TOLERATED_UP
 	outfit = /datum/outfit/job/roguetown/adventurer/heartfeltlord
 	maximum_possible_slots = 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelthand.dm
@@ -2,7 +2,7 @@
 	name = "Hand of Heartfelt"
 	tutorial = "You serve your lord as the royal hand, taking care of all diplomatic actions in your relm. \
 	maybe one day you will become lord too."
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_TOLERATED_UP
 	outfit = /datum/outfit/job/roguetown/adventurer/heartfelthand
 	maximum_possible_slots = 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
@@ -4,7 +4,7 @@
 	tutorial = "Witch Hunters belong to a special sect of the One-God Church that believe all magyk \
 	use is inherently sinful. They are extremely devoted to hunting necromancers and often preach \
 	to magyk users to end their sinful ways."
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_TOLERATED_UP
 	outfit = /datum/outfit/job/roguetown/adventurer/puritan
 	maximum_possible_slots = 2

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
@@ -3,7 +3,7 @@
 /datum/advclass/minermaster
 	name = "Master Miner"
 	tutorial = "A master miner, you are capable of cutting stone like butter, and forging rocks into anything you can think of"
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/minermaster
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/whitecheesemaker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/whitecheesemaker.dm
@@ -1,6 +1,6 @@
 /datum/advclass/whitecheese
 	name = "WHITE CHEESE"
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list(/datum/species/human/northern)
 	outfit = /datum/outfit/job/roguetown/adventurer/whitecheese
 	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_BREADY, TRAIT_STEELHEARTED)

--- a/code/modules/jobs/job_types/roguetown/church/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/confessor.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 0
 
 	allowed_races = RACES_ALL_KINDS
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	tutorial = "Confessors are shady agents of the church hired to spy on the populace and keep them moral. As the most fanatical members of the clergy, their main concern is assisting the local Puritan with their work in extracting confessions of sin as well as hunting night beasts and cultists that hide in plain sight."
 
 	outfit = /datum/outfit/job/roguetown/shepherd

--- a/code/modules/jobs/job_types/roguetown/church/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/church/puritan.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_patrons = list(
 		/datum/patron/old_god,

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_patrons = ALL_DIVINE_PATRONS
 	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -6,7 +6,7 @@
 	total_positions = 8
 	spawn_positions = 8
 
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the Royal Family and their Court, trained regularly in combat and siege warfare you stand a small chance of surviving the King's reign."

--- a/code/modules/jobs/job_types/roguetown/garrison/sheriff.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sheriff.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	allowed_races = RACES_ALL_KINDS
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 	display_order = JDO_SHERIFF
 	tutorial = "Crime has always been a constant of your life, and you always chose the side of justice. You rose up through the ranks as a watchman, and now rule over them - Ensure that they enforce the laws of this land properly."

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(MALE) //same as town guard
+	allowed_sexes = list(MALE, FEMALE) //same as town guard
 	allowed_races = RACES_ALL_KINDS // same as town guard
 	tutorial = "You've known combat your entire life. There isn't a way to kill a man you havent practiced in the tapestries of war itself. You wouldn't call yourself a hero, those belong to the men left rotting in the fields of where you practiced your ancient trade. You don't sleep well at night anymore, you don't like remembering what you've had to do to survive. Trading adventure for stable pay was the only logical solution, and maybe someday you'll get to lay down the blade..."
 	allowed_ages = list(AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 	display_order = JDO_BAILIFF

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDS
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "Your lineage is noble, and generations of strong, loyal knights have come before you. You served your time gracefully as a knight of his royal majesty, and now you've grown into a role which many men dream to become. Lead your men to victory and keep them in line and you will see this kingdom prosper under a thousand suns."
 	display_order = JDO_GUARD_CAPTAIN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

CHANGELOG:
- Jobs that had genderlocking without a strong lore reason are now unisex.
  - Included jobs:
    - Barbarian
    - Heartfelt Lord
    - Heartfelt Hand
    - Master Miner
    - Witchhunter
    - White Cheesemaker (Unused atm iirc)
    - Confessor (Unused atm iirc)
    - Inquisitor
    - Gatemaster
    - Man at Arms
    - Sheriff
    - Veteran
    - Bailiff
    - Guard Captain
  - Excluded jobs:
    - Amazon (Bikini armor doesn't work on men rn)
    - Sorceress (Lore blurb says they are all women)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Given the lower server population currently and lack of concrete lore to force these roles to be gender-locked, opening these up will be a good way to give players more options. Additionally, it encourages more players to play these roles (there's a reason you barely ever see a Bailiff but constantly see Councillors) by allowing them to play more types of characters in said roles, which means we should see more people fulfilling important roles like gatemaster, sheriff, and guard captain.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
