### PR TITLE
Reflavours Prince to Scion

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -2638,7 +2638,7 @@
 /obj/structure/mineral_door/wood{
 	locked = 1;
 	lockid = "manor";
-	name = "Prince's Room"
+	name = "Scion's Room"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -255,8 +255,8 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 
 
 /datum/game_mode/chaosmode/proc/pick_aspirants()
-	var/list/possible_jobs_aspirants = list("Prince", "Princess", "Guard Captain", "Steward", "Hand", "Knight")
-	var/list/possible_jobs_helpers = list("Guard Captain", "Prince", "Princess", "Hand",  "Steward", "Knight")
+	var/list/possible_jobs_aspirants = list("Scion", "Guard Captain", "Steward", "Hand", "Knight")
+	var/list/possible_jobs_helpers = list("Guard Captain", "Scion", "Hand",  "Steward", "Knight")
 	var/list/rolesneeded = list("Aspirant","Loyalist","Supporter")
 
 	antag_candidates = get_players_for_role(ROLE_ASPIRANT)

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -922,7 +922,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /datum/objective/vampirelord/infiltrate/two/check_completion()
 	var/datum/game_mode/chaosmode/C = SSticker.mode
-	var/list/noblejobs = list("King", "Queen Consort", "Prince", "Princess", "Hand", "Steward")
+	var/list/noblejobs = list("King", "Queen Consort", "Scion", "Hand", "Steward")
 	for(var/datum/mind/V in C.vampires)
 		if(V.current.job in noblejobs)
 			return TRUE

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -10,7 +10,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
 
-	tutorial = "Born into the royal family or at least into its good graces, your heritage has bought you a \"free\" ride through life. You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain in their favourable position: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
+	tutorial = "Born into the royal family, your heritage has bought you a \"free\" ride through life. You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain in their favourable position: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
 
 	outfit = /datum/outfit/job/roguetown/prince
 	display_order = JDO_PRINCE

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -1,17 +1,16 @@
 /datum/job/roguetown/prince
-	title = "Prince"
-	f_title = "Princess"
+	title = "Scion"
+	f_title = "Scion"
 	flag = PRINCE
 	department_flag = YOUNGFOLK
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
-	f_title = "Princess"
 	allowed_races = RACES_ALL_KINDS //Maybe a system to force-pick lineage based on king and queen should be implemented.
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
 
-	tutorial = "You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain upon the throne: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
+	tutorial = "Born into the royal family or at least into its good graces, your heritage has bought you a \"free\" ride through life. You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain in their favourable position: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
 
 	outfit = /datum/outfit/job/roguetown/prince
 	display_order = JDO_PRINCE
@@ -22,7 +21,8 @@
 /datum/job/roguetown/prince/after_spawn(mob/living/H, mob/M, latejoin)
 	. = ..()
 	if(GLOB.lordsurname && H)
-		give_lord_surname(H)
+		if(input("Take the surname of the current ruler and be a Prince/Princess?"))
+			give_lord_surname(H)
 
 /datum/outfit/job/roguetown/prince/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -10,7 +10,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
 
-	tutorial = "Born into the royal family, your heritage has bought you a \"free\" ride through life. You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain in their favourable position: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
+	tutorial = "Born into the royal family or to parents in its good graces, your heritage has bought you a \"free\" ride through life. You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain in their favourable position: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
 
 	outfit = /datum/outfit/job/roguetown/prince
 	display_order = JDO_PRINCE

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -62,7 +62,7 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 GLOBAL_LIST_INIT(noble_positions, list(
 	"King",
 	"Queen Consort",
-	"Prince",
+	"Scion",
 	"Guard Captain",
 	"Bailiff",
 	"Councillor",


### PR DESCRIPTION
## About The Pull Request

Relabels and redescribes the Prince to the Scion, someone born into the royal family or nobility but not necessarily descended from the monarch. This is purely a flavour text change. It also allows newly spawning Scions the _option_ to take the ruler's surname.

## Why It's Good For The Game

~~Players now have a reason to hardly know their supposed parent/child~~
Having a family of people who obviously don't know each other and clearly come from different lands can be a little bit immersion-breaking, not least for the ones playing those characters. Sometimes it's fun - which is why you can still take the lord's surname - and sometimes it's not. This PR provides a level of ambiguity that can be used to patch over that hole, while also allowing a wider range of character dynamics - for example, a nephew-twice-removed who's in the hospitality of the monarch will likely have a different relationship to them than the king's own son.