### PR TITLE
Fixes Maniac

### DIFF
--- a/code/modules/antagonists/roguetown/villain/maniac/maniac.dm
+++ b/code/modules/antagonists/roguetown/villain/maniac/maniac.dm
@@ -27,11 +27,9 @@
 		TRAIT_HARDDISMEMBER,
 		TRAIT_NOSLEEP,
 		TRAIT_SHOCKIMMUNE,
-		TRAIT_STABLEHEART,
 		TRAIT_STABLELIVER,
 		TRAIT_ANTIMAGIC,
 		TRAIT_SCHIZO_AMBIENCE,
-		TRAIT_BLOODLOSS_IMMUNE,
 	)
 	/// Traits that only get applied in the final sequence
 	var/static/list/final_traits = list(
@@ -101,9 +99,10 @@
 			STASTR = dreamer.STASTR
 			STACON = dreamer.STACON
 			STAEND = dreamer.STAEND
-			dreamer.STASTR = 20
-			dreamer.STACON = 20
-			dreamer.STAEND = 20
+			dreamer.STASTR = 15		//15 strength; was 20, seemed too strong (Reminder strong-er mobs have ~14, plus this scales with weapons used)
+			dreamer.STACON = 16		//16 con; was 20, seemed too strong
+			dreamer.STAEND = 16		//16 endurance; was 20, semed too strong
+			dreamer.STASPD = 14		//Added in exchange for lowered other stats; this makes them a bit faster than normal likely. Helps dodging. Equal to goblin.
 		for(var/trait in applied_traits)
 			ADD_TRAIT(owner.current, trait, "[type]")
 		hallucinations = owner.current.overlay_fullscreen("maniac", /atom/movable/screen/fullscreen/maniac)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Didn't really want to do many PRs here but throwing this one up due to other maniac nerf someone put up was a bit overly harsh and a bunch of people asked for a lighter-version.

## Why It's Good For The Game

Basically reduces stats a tiny bit as they were higher than most antags/mobs, but gave them some speed to make up for it. He can move as fast as base-goblin now, which is up from ~10 to 14; will be a tad noticable, can down-scale to 12-13 if issue.

Made the maniac able to bleed and he needs a working heart to live; so don't get your heart cut out or injured. (Wear decent armor, parry, or dodge!)

Still remains immune to magic and pain so I feel this is pretty OK.
