### PR TITLE
Tribe fort fixes

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -4403,6 +4403,14 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"ecU" = (
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors)
 "edc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -11395,6 +11403,8 @@
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /obj/structure/rack/rogue,
+/obj/item/rogueweapon/whip,
+/obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "mOE" = (
@@ -19092,6 +19102,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"wzL" = (
+/obj/effect/landmark/start/goblinsmith,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors)
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church)
@@ -280215,7 +280234,7 @@ sxp
 sue
 sue
 jQc
-yjW
+wzL
 ddv
 ddv
 ddv
@@ -280617,7 +280636,7 @@ sue
 sue
 sue
 jQc
-ddv
+ecU
 yjW
 ddv
 yjW
@@ -289061,7 +289080,7 @@ snX
 snX
 snX
 snX
-fPm
+oVs
 snX
 snX
 snX
@@ -289463,7 +289482,7 @@ lPu
 lPu
 lPu
 lPu
-oVs
+fPm
 kXN
 kXN
 kXN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added five iron bars and five steel bars to the forge.
Added two whips near the prisoners' cage.
Repositioned the east door of the fort in the correct direction.
## Why It's Good For The Game

Small fixes on the tribe fort, now the forge has resources for the blacksmiths to forge armor, tools, and weapons for the kins since there is no mine nearby, only in the far north, a territory where the tribe is not welcome.
