### PR TITLE
Rain cloak nerf

### DIFF
--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -123,7 +123,7 @@
 				/obj/item/natural/fibers = 1)
 
 /obj/item/clothing/cloak/raincloak/brown
-	sellprice = 20
+	sellprice = 3
 
 /datum/crafting_recipe/roguetown/leather/cloakfur
 	name = "fur cloak"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
CHANGE: Reduces Rain Cloak Brown from 20 mammon to 3 mammon
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Came on to a merchant, nothing in peddler, nothing on shelves.

This has been a long time coming.  New systems of supply/demand being worked on, but this needs to stop now.

Merchant should be trading, not hiding with the balloon

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
