### PR TITLE
Adds Craftable Papakha

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -223,6 +223,13 @@
 	icon_state = "hatfur"
 	sewrepair = TRUE
 
+/obj/item/clothing/head/roguetown/papakha
+	name = "papakha"
+	icon_state = "papakha"
+	item_state = "papakha"
+	sewrepair = TRUE
+	flags_inv = HIDEEARS
+
 /obj/item/clothing/head/roguetown/hatblu
 	name = "fur hat"
 	icon_state = "hatblu"

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -133,6 +133,14 @@
 /obj/item/clothing/cloak/raincloak/furcloak/crafted
 	sellprice = 55
 
+/datum/crafting_recipe/roguetown/leather/papakha
+	name = "papakha hat"
+	result = /obj/item/clothing/head/roguetown/papakha/crafted
+	reqs = list(/obj/item/natural/fur = 1, /obj/item/natural/fibers = 2)
+
+/obj/item/clothing/head/roguetown/papakha/crafted
+	sellprice = 10
+
 /datum/crafting_recipe/roguetown/leather/saddle
 	name = "saddle"
 	result = /obj/item/natural/saddle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Basically a port of a PR I did on Stonekeep to here upon request.

Uses papakha sprite that already exists and makes it a craftable hat that can be useful for export + drippy wearing.
![image](https://github.com/user-attachments/assets/52825dce-586c-43f6-a063-af2b1683263f)

## Why It's Good For The Game

It's a cosmetic hat that fits very well with the setting's theme, plus can act as a 'cheap' made hat (requiring fur and fiber rather than leather, so very good if you end up having to kill volves). Seems some people liked its idea anyway.