### PR TITLE
Fix for adventurer trait not being added properly

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -123,7 +123,7 @@
 	max_blade_int = 300
 	smeltresult = /obj/item/ingot/steel
 	gripped_intents = list(/datum/intent/axe/cut/battle ,/datum/intent/axe/chop/battle)
-	minstr = 12
+	minstr = 10
 	wdefense = 4
 
 /obj/item/rogueweapon/stoneaxe/battle/getonmobprop(tag)

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -123,7 +123,7 @@
 	max_blade_int = 300
 	smeltresult = /obj/item/ingot/steel
 	gripped_intents = list(/datum/intent/axe/cut/battle ,/datum/intent/axe/chop/battle)
-	minstr = 10
+	minstr = 12
 	wdefense = 4
 
 /obj/item/rogueweapon/stoneaxe/battle/getonmobprop(tag)

--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -47,7 +47,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 /mob/living/carbon/human/proc/adv_hugboxing_start()
 	to_chat(src, span_warning("I will be in danger once I start moving."))
 	status_flags |= GODMODE
-	ADD_TRAIT(src, TRAIT_PACIFISM, HUGBOX_TRAIT)
+	ADD_TRAIT(src, TRAIT_PACIFISM, TRAIT_GENERIC)
+	ADD_TRAIT(src, HUGBOX_TRAIT, TRAIT_GENERIC)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(adv_hugboxing_moved))
 	//Lies, it goes away even if you don't move after enough time
 	if(GLOB.adventurer_hugbox_duration_still)
@@ -65,5 +66,6 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	if(!(status_flags & GODMODE))
 		return
 	status_flags &= ~GODMODE
-	REMOVE_TRAIT(src, TRAIT_PACIFISM, HUGBOX_TRAIT)
+	REMOVE_TRAIT(src, TRAIT_PACIFISM, TRAIT_GENERIC)
+	REMOVE_TRAIT(src, HUGBOX_TRAIT, TRAIT_GENERIC)
 	to_chat(src, span_danger("My joy is gone! Danger surrounds me."))

--- a/code/modules/mob/living/carbon/human/npc/searaider.dm
+++ b/code/modules/mob/living/carbon/human/npc/searaider.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 	H.hair_color = pick ("4f4f4f", "61310f", "faf6b9")
 	H.facial_hair_color = H.hair_color
 	if(H.gender == FEMALE)
-		H.STASTR = rand(9,12)
+		H.STASTR = rand(11,12)
 		H.hairstyle = pick("Ponytail (Country)","Braid (Low)", "Braid (Short)", "Messy (Rogue)")
 	else
 		H.STASTR = rand(14,16)


### PR DESCRIPTION
## About The Pull Request

A little tweak on the adventurer traits that ensure the player has immunity during the class selection - to prevent being killed off by zombies or other hostiles. 

Additionally lowers requirement for battle axes so that female sea raiders may use them.

## Why It's Good For The Game

Stops unnecessary deaths.

Tested 7/18/24 on local server.
