### PR TITLE
Maneater damage change

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -62,7 +62,7 @@
 			playsound(src.loc, list('sound/vo/mobs/plant/attack (1).ogg','sound/vo/mobs/plant/attack (2).ogg','sound/vo/mobs/plant/attack (3).ogg','sound/vo/mobs/plant/attack (4).ogg'), 100, FALSE, -1)
 			if(iscarbon(L))
 				var/mob/living/carbon/C = L
-				src.visible_message(span_danger("[src] starts to rip apart [C]!"))
+				src.visible_message(span_danger("[src] starts to crush [C]!"))
 				spawn(50)
 					if(C && (C.buckled == src))
 						var/obj/item/bodypart/limb
@@ -71,6 +71,10 @@
 							limb = C.get_bodypart(zone)
 							if(limb)
 								playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
+								C.apply_damage(rand(10, 20), BRUTE, limb)
+								if(C.reagents)
+									L.reagents.add_reagent(/datum/reagent/toxin/venom, 1)
+								/* --- Old code for dismembering instead of doing damage.
 								limb.dismember()
 								qdel(limb)
 								return
@@ -84,9 +88,9 @@
 						if(limb)
 							if(!limb.dismember())
 								C.gib()
-							return
+							return */
 			else
-				src.visible_message(span_danger("[src] starts to rip apart [L]!"))
+				src.visible_message(span_danger("[src] starts to smash apart [L]!"))
 				spawn(50)
 					if(L && (L.buckled == src))
 						L.gib()


### PR DESCRIPTION
Alters maneaters to inflict some weak brute damage to limbs instead of dismembering.
Maneaters now apply a WEAK STACKING POISON.
Removes Gibbing of players. Mobs that arn't people will still gib.

Tested on a private server. Because you no longer lose limbs it felt easier to escape. But if they get a hit or two in, youll take damage over time.
If the numbers need to be adjusted it can easily be done.