### PR TITLE
Allows players to leave the round via the latejoin boat (AKA cryo)

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -20241,6 +20241,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wPt" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/outdoors/beach)
 "wPU" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/woodturned,
@@ -208949,7 +208955,7 @@ dKV
 dKV
 qQV
 xjC
-rEg
+wPt
 rEg
 kzz
 bIl

--- a/modular_hearthstone/code/game/objects/structures/longsleep.dm
+++ b/modular_hearthstone/code/game/objects/structures/longsleep.dm
@@ -1,0 +1,60 @@
+//AKA cryosleep.
+
+/obj/structure/long_sleep //Shamelessly jury-rigged from the way Fallout13 handles this.
+	name = "long-sleeper cabins"
+	desc = "A door to the lower levels of the ship, where weary souls rest until another voyage.\n(Drag your sprite onto this to exit the round!)"
+	icon = 'icons/roguetown/misc/doors.dmi'
+	icon_state = "woodhandle"
+	layer = ABOVE_MOB_LAYER
+	density = TRUE
+	anchored = TRUE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	var/in_use = FALSE
+
+/obj/structure/long_sleep/MouseDrop_T(atom/dropping, mob/user)
+	. = ..()
+	if(!isliving(user) || user.incapacitated())
+		return //No ghosts or incapacitated folk allowed to do this.
+	if(!ishuman(dropping))
+		return //Only humans have job slots to be freed.
+	if(in_use) // Someone's already going in.
+		return
+	var/mob/living/carbon/human/departing_mob = dropping
+	var/datum/job/mob_job = SSjob.GetJob(departing_mob.mind.assigned_role)
+	if(departing_mob != user && departing_mob.client)
+		to_chat(user, "<span class='warning'>This one retains their free will. It's their choice if they want to leave the round or not.</span>")
+		return
+	if(alert("Are you sure you want to [departing_mob == user ? "depart the round for good (you" : "send this person away (they"] will be removed from the current round, the job slot freed)?", "Going to Bed", "Confirm", "Cancel") != "Confirm")
+		return
+	if(user.incapacitated() || QDELETED(departing_mob) || (departing_mob != user && departing_mob.client) || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
+		return //Things have changed since the alert happened.
+	if(departing_mob.mind && considered_afk(departing_mob.mind))
+		to_chat(user, "<span class='warning'>This mind has only recently departed. Wait at most two minutes before sending this character out of the round.</span>")
+		return
+	user.visible_message("<span class='warning'>[user] [departing_mob == user ? "is trying to leave for the lower decks!" : "is trying to send [departing_mob] to the lower decks!"]</span>", "<span class='notice'>You [departing_mob == user ? "are trying to go to the lower decks." : "are trying to send [departing_mob] to the lower decks."]</span>")
+	in_use = TRUE
+	if(!do_after(user, 50, target = src))
+		in_use = FALSE
+		return
+	in_use = FALSE
+	update_icon()
+	var/dat = "[key_name(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"
+	if(departing_mob.mind && mob_job)
+		mob_job.current_positions = max(0, mob_job.current_positions - 1)
+	if(!length(departing_mob.contents))
+		dat += " none."
+	else
+		var/atom/movable/content = departing_mob.contents[1]
+		dat += " [content.name]"
+		for(var/i in 2 to length(departing_mob.contents))
+			content = departing_mob.contents[i]
+			dat += ", [content.name]"
+		dat += "."
+	message_admins(dat)
+	log_admin(dat)
+	if(departing_mob.stat == DEAD)
+		departing_mob.visible_message("<span class='notice'>[user] pushes the body of [departing_mob] down the stairs. They're someone else's problem now.</span>")
+	else
+		departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] heads downstairs to the ship's cabins.</span>")
+	qdel(departing_mob)
+

--- a/modular_hearthstone/code/game/objects/structures/longsleep.dm
+++ b/modular_hearthstone/code/game/objects/structures/longsleep.dm
@@ -20,7 +20,7 @@
 	if(in_use) // Someone's already going in.
 		return
 	var/mob/living/carbon/human/departing_mob = dropping
-	var/datum/job/mob_job = SSjob.GetJob(departing_mob.mind.assigned_role)
+	var/datum/job/mob_job
 	if(departing_mob != user && departing_mob.client)
 		to_chat(user, "<span class='warning'>This one retains their free will. It's their choice if they want to leave the round or not.</span>")
 		return
@@ -28,9 +28,6 @@
 		return
 	if(user.incapacitated() || QDELETED(departing_mob) || (departing_mob != user && departing_mob.client) || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
 		return //Things have changed since the alert happened.
-	if(departing_mob.mind && considered_afk(departing_mob.mind))
-		to_chat(user, "<span class='warning'>This mind has only recently departed. Wait at most two minutes before sending this character out of the round.</span>")
-		return
 	user.visible_message("<span class='warning'>[user] [departing_mob == user ? "is trying to leave for the lower decks!" : "is trying to send [departing_mob] to the lower decks!"]</span>", "<span class='notice'>You [departing_mob == user ? "are trying to go to the lower decks." : "are trying to send [departing_mob] to the lower decks."]</span>")
 	in_use = TRUE
 	if(!do_after(user, 50, target = src))
@@ -39,7 +36,8 @@
 	in_use = FALSE
 	update_icon()
 	var/dat = "[key_name(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"
-	if(departing_mob.mind && mob_job)
+	if(departing_mob.mind)
+		mob_job = SSjob.GetJob(departing_mob.mind.assigned_role)
 		mob_job.current_positions = max(0, mob_job.current_positions - 1)
 	if(!length(departing_mob.contents))
 		dat += " none."

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3506,5 +3506,6 @@
 #include "modular\code\modules\maturity-prompt\code\maturity_subsystem.dm"
 #include "modular_hearthstone\code\game\area\roguetownareas.dm"
 #include "modular_hearthstone\code\game\objects\structures\fluff.dm"
+#include "modular_hearthstone\code\game\objects\structures\longsleep.dm"
 #include "modular_hearthstone\code\modules\mob\living\simple_animal\rogue\creacher\volf.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a "door to the lower decks" to Sophia's Cry, the boat latejoiners spawn on. A player can drag themself onto this door to exit the round, freeing up a job slot and making an SCOM announcement. 

## Why It's Good For The Game

Right now, there's no way for a player to properly leave the round on their own. They need an admin to remove them and in the process open a slot. There are good reasons that almost every server has a cryosleep mechanic.