### PR TITLE
Anti Poison Potions

### DIFF
--- a/code/modules/cargo/packsrogue/food.dm
+++ b/code/modules/cargo/packsrogue/food.dm
@@ -21,6 +21,15 @@
 					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
 				)
 
+/datum/supply_pack/rogue/food/antipoisonpot
+	name = "Anti Poison Potion"
+	cost = 22
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,
+					/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,
+					/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,
+				)
+
 /datum/supply_pack/rogue/food/wineb
 	name = "Wine"
 	cost = 45

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -34,3 +34,15 @@
 	result = list(/datum/supply_pack/rogue/food/healthpot)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 4, /obj/item/reagent_containers/food/snacks/fish/clownfish = 1)
 	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/alchemy/antipoison_pot
+	name = "Anti Poison Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot)
+	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/rogue/honey = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/alchemy/antipoison_pot_3x
+	name = "3x Anti Poison Potion"
+	result = list(/datum/supply_pack/rogue/food/antipoisonpot)
+	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/rogue/honey = 2)
+	craftdiff = 5

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -5,6 +5,9 @@
 /obj/item/reagent_containers/glass/bottle/rogue/manapot
 	list_reagents = list(/datum/reagent/medicine/manapot = 45)
 
+/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot
+	list_reagents = list(/datum/reagent/medicine/antipoisonpot = 45)
+
 /obj/item/reagent_containers/glass/bottle/rogue/poison
 	list_reagents = list(/datum/reagent/toxin/killersice = 1)
 

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -37,6 +37,28 @@
 	..()
 	. = 1
 
+/datum/reagent/medicine/antipoisonpot
+	name = "Anti Poison Potion"
+	description = "Quickly nullifies toxins."
+	reagent_state = LIQUID
+	color = "#64bf49"
+	taste_description = "ashes"
+	overdose_threshold = 60
+	metabolization_rate = REAGENTS_METABOLISM
+	alpha = 200
+
+/datum/reagent/medicine/antipoisonpot/on_mob_life(mob/living/carbon/M)
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		if(R != src)
+			M.reagents.remove_reagent(R.type,0.5)
+	M.adjustToxLoss(-0.5*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/antipoisonpot/overdose_process(mob/living/carbon/M)
+	M.add_nausea(9)
+	M.adjustToxLoss(3, 0)
+
 /datum/reagent/berrypoison
 	name = "Berry Poison"
 	description = "Contains a poisonous thick, dark purple liquid."


### PR DESCRIPTION
Adds a green potion that removes toxins and fixes toxin damage.
Overdoses if you rapid drink more then 2 bottles at once.
Overdose causes puking and toxin damage
Lasts about 3 seconds per unit in the bottle. So a 15 unit bottle (what you buy it from or make) will last about 45 seconds.
Gives merchant the ability to buy 3 of them for around 22 mammon.
Gives alchemy the ability to make them using ash, honey and empty bottles.


Was designed with the intent of it giving a buffer after drinking to prevent re-poisoning.
Intended to help with spider based dungeons and the maneater change to brute and poison damage.
Also a semi light counter to archers using poison arrows if you planned ahead for it.