### PR TITLE
Don't Touch ME! A Anti ERP Option

### DIFF
--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -517,6 +517,8 @@
 	var/datum/sex_action/action = SEX_ACTION(current_action)
 	action.on_start(user, target)
 	while(TRUE)
+		if(target.client.prefs.sexable == FALSE)
+			break
 		if(!user.rogfat_add(action.stamina_cost * get_stamina_cost_multiplier()))
 			break
 		if(!do_after(user, (action.do_time / get_speed_multiplier()), target = target))

--- a/code/datums/sexcon/sexcon_helpers.dm
+++ b/code/datums/sexcon/sexcon_helpers.dm
@@ -49,6 +49,10 @@
 	if(!user.can_do_sex())
 		to_chat(user, "<span class='warning'>I can't do this.</span>")
 		return
+	if(!target.client || !target.client.prefs || (target.client.prefs.sexable == FALSE)) // Don't bang someone that dosn't want it.
+		to_chat(user, "<span class='warning'>[target] dosn't wish to be touched. (Thier ERP prefrence under options)</span>")
+		to_chat(target, "<span class='warning'>[user] failed to touch you. (Your ERP prefrence under options)</span>")
+		return
 	user.sexcon.start(src)
 
 /mob/living/proc/can_do_sex()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -92,6 +92,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/list/friendlyGenders = list("Male" = "male", "Female" = "female")
 	var/phobia = "spiders"
 	var/shake = TRUE
+	var/sexable = FALSE
 
 	var/list/custom_names = list()
 	var/preferred_ai_core_display = "Blue"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -36,6 +36,15 @@
 		prefs.shake = !prefs.shake
 		to_chat(src, "Screen shake toggled")
 
+/client/verb/toggle_ERP() // Alters if other people can use the ERP panel ON you.
+	set category = "Options"
+	set name = "Toggle ERP Panel"
+	if(prefs)
+		prefs.sexable = !prefs.sexable
+		if(prefs.sexable)
+			to_chat(src, "Others can play with you.")
+		else to_chat(src, "Others can't touch you.")
+
 /client/verb/stop_sounds_rogue()
 	set name = "StopSounds"
 	set category = "Options"


### PR DESCRIPTION
Adds a toggle to the options menu that stops people from being able to use the ERP panel on you.
This will stop ERP half way thru if turned on part way thru.
Gives a notification in chat if someone has it on and where the option is (So they can find it even if they are a new player)
It is set to not allow it by default. You will have to ALLOW people to touch you.