### PR TITLE
Re-enables the Bad Sight flaw for everyone

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 	"Cyclops (L)"=/datum/charflaw/noeyel,
 	"Wood Arm (R)"=/datum/charflaw/limbloss/arm_r,
 	"Wood Arm (L)"=/datum/charflaw/limbloss/arm_l,
+	"Bad Sight"=/datum/charflaw/badsight,
 	"Paranoid"=/datum/charflaw/paranoid,
 	"Clingy"=/datum/charflaw/clingy,
 	"Isolationist"=/datum/charflaw/isolationist,

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2030,8 +2030,6 @@ Slots: [job.spawn_positions]</span>
 	character.jumpsuit_style = jumpsuit_style
 
 	if(charflaw)
-		if(istype(charflaw, /datum/charflaw/badsight))
-			charflaw = new /datum/charflaw/randflaw()
 		character.charflaw = new charflaw.type()
 		character.charflaw.on_mob_creation(character)
 


### PR DESCRIPTION
## About The Pull Request

Bad Sight is a currently-unavailable character flaw that blurs a character's vision without their glasses (which they spawn with) and grants 1 rank in the Reading skill. Without glasses, their vision is blurred and they recieve a major debuff to perception and speed.

## Why It's Good For The Game

More character variety is good and this is a unique flaw with much potential to lead to interesting situations.
_But why does it grant a skill rank in reading?_
I don't know, it was like that when I got here. I didn't remove it for two reasons: this is potentially a far harsher debuff than most of the existing traits, and it allows players to "buy" literacy in the few roles that don't have it, at a cost. (Also, I'm biased by my desire to play a smart Barbarian.)