### PR TITLE
Allows small stones to be ground in a millstone to get salt

### DIFF
--- a/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
@@ -16,4 +16,9 @@
 				new S.mill_result(get_turf(loc))
 				qdel(S)
 			return
+	if(istype(W, /obj/item/natural/stone))
+		if(do_after(user, 10, target = src))
+			new /obj/item/reagent_containers/powder/flour/salt(get_turf(loc))
+			qdel(W)
+		return
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Does exactly what the title says.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Salt is very common in theory ingame, and actually appears at a few static salt mines, but nobody who does any bulk cooking ever goes there, even assuming any of them actually know how to get to these specific locations. It is also not valuable enough in the stockpile to crash the economy with the inability for one person to produce large quantities of it quickly, so, ultimately this should be a nice QoL for those roleplayers who like homesteading and/or cooking, or anyone else wanting to supply themselves or others with salted meats, butter, and other goods that consume salt to make.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
