### PR TITLE
Gatekeepening-Girlbossening (PQ Requirement Adjustments)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 
 	display_order = JDO_ADVENTURER
 	show_in_credits = FALSE
-	min_pq = -20
+	min_pq = -10
 	max_pq = null
 	
 	advclass_cat_rolls = list(CTAG_ADVENTURER = 10)

--- a/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
@@ -14,7 +14,7 @@
 	bypass_jobban = FALSE
 	display_order = JDO_VILLAGER
 	give_bank_account = TRUE
-	min_pq = -15
+	min_pq = -20
 	max_pq = null
 	wanderer_examine = FALSE
 	advjob_examine = TRUE

--- a/code/modules/jobs/job_types/roguetown/apprentices/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/apprentices/mage_apprentice.dm
@@ -17,7 +17,7 @@
 	display_order = JDO_MAGEAPPRENTICE
 	give_bank_account = TRUE
 
-	min_pq = 3
+	min_pq = 0		//Learning role
 	max_pq = null
 
 /datum/outfit/job/roguetown/wapprentice/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -17,7 +17,7 @@
 	outfit = /datum/outfit/job/roguetown/magician
 	whitelist_req = TRUE
 	give_bank_account = 47
-	min_pq = 5
+	min_pq = 3
 	max_pq = null
 
 /datum/outfit/job/roguetown/magician

--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -17,7 +17,7 @@
 	outfit = /datum/outfit/job/roguetown/bogmaster
 
 	give_bank_account = 35
-	min_pq = 4
+	min_pq = 3
 	max_pq = null
 	cmode_music = 'sound/music/combat_bog.ogg'
 

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -13,7 +13,7 @@
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/woodsman
 	display_order = JDO_CHIEF
-	min_pq = 0
+	min_pq = 3
 	max_pq = null
 	give_bank_account = 16
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -15,7 +15,7 @@
 
 	display_order = JDO_LADY
 	give_bank_account = TRUE
-	min_pq = 2
+	min_pq = 5
 	max_pq = null
 
 /datum/job/roguetown/exlady //just used to change the ladys title

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -12,7 +12,7 @@
 	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the King's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy and your rats alive, the'yre the only two things you can weigh any trust into anymore."
 	outfit = /datum/outfit/job/roguetown/steward
 	give_bank_account = 17
-	min_pq = 0
+	min_pq = 1
 	max_pq = null
 
 /datum/outfit/job/roguetown/steward/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
@@ -18,7 +18,7 @@
 	outfit = /datum/outfit/job/roguetown/nightman
 	display_order = JDO_NIGHTMASTER
 	give_bank_account = TRUE
-	min_pq = -10
+	min_pq = 0
 	max_pq = null
 
 /datum/outfit/job/roguetown/nightman/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Was told some roles had too low of a PQ requirement (adventurer, queen, etc) and others had too high (i.e mage apprentice)

Tried to standardize PQ a bit more as a stop-gap; to summarize the PR:

**Adventurer** - From -20 PQ -> -10 PQ minimum
Reason: Combat classes. Behave.

**Villager/Pilgrim (Towner)** - From -15 PQ -> -20 PQ
Reason: Non-combat classes, leeway.

**Mage Apprentice** - From 3 PQ -> 0 PQ
Reason: It's a learning role; squire is -5. You get some stuff so - 0 PQ is fine; just behave.

**Court Mage** - From 5 PQ -> 3 PQ
Reason: May be a weird one, but Captain only takes 4 PQ.. and Hand is only 3, as well as manor guards. And - adventurers have mages just without AoE fireball. I honestly think this is fine. (Bit weak, only issue is scrying orb; handled by staff anyway given people steal it non-stop.)

**Bog Master** - From 4 PQ -> 3 PQ
Reason: Shouldn't require same PQ as Captain, but is a 'leadership role'. Give some leeway, but behave.

**Village Elder** - From 0 PQ -> 3 PQ
Reason: Maybe could lower to 2 or 1? Mainly doing because leadership role; even if it's non-combat.

**Queen** - From 2 PQ -> 5 PQ (Same as king)
Reason: Queen is king if no king is around anyway basically, should be same PQ then.

**Steward** - From 0 PQ -> 1 PQ
Reason: Noble role, 1 may seem low but tbh no one players steward. Just doing this for future-proof to avoid someone rando-joining and taking the role.

**Nightman** - From -10 PQ -> 0 PQ
Reason: Kinda.. leadership-ish role? I think just not getting admin-punished is enough to be a pimp.

## Why It's Good For The Game

Various issues reported such as weird 'why can i play x before y?' which didn't make sense at times, and other roles causing minor issues to do with low PQ playing the role still.