### PR TITLE
Fixes a bug where Lupians are forced to be hermaphrodites.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
@@ -58,10 +58,6 @@
 		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
 		ORGAN_SLOT_TAIL = /obj/item/organ/tail/lupian,
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/lupian,
-		ORGAN_SLOT_TESTICLES = /obj/item/organ/testicles,
-		ORGAN_SLOT_PENIS = /obj/item/organ/penis,
-		ORGAN_SLOT_BREASTS = /obj/item/organ/breasts,
-		ORGAN_SLOT_VAGINA = /obj/item/organ/vagina,
 		)
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,
@@ -112,7 +108,7 @@
 		/datum/descriptor_choice/prominent_one,
 		/datum/descriptor_choice/prominent_two,
 	)
-	
+
 /datum/species/lupian/check_roundstart_eligible()
 	return TRUE
 
@@ -127,7 +123,7 @@
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)
 
-/datum/species/lupian/get_skin_list() 
+/datum/species/lupian/get_skin_list()
 	return list(
 		"Vakran" = "271f1b",
 		"Lanarain" = "271f1c",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This bug was caused by listing all of the sexual organs in the list of organs the species is supposed to start with, which adds them with complete disregard to the player's preferences.

For future reference for coders making new species, sexual organs only need to be listed in the customization list, as that system handles whether or not to add the organs themselves to a character.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->