### PR TITLE
Limits adventurer slots, lowers mercenary slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = -1
-	spawn_positions = -1
+	total_positions = 8
+	spawn_positions = 8
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Hero of nothing, adventurer by trade. Whatever led you to this fate is up to the wind to decide, and you've never fancied yourself for much other than the thrill. Someday your pride is going to catch up to you, and you're going to find out why most men don't end up in the annals of history."
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
@@ -9,8 +9,8 @@
 	display_order = JDO_DESERT_RIDER
 	selection_color = JCOLOR_MERCENARY
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 2
+	spawn_positions = 2
 	give_bank_account = 3
 	min_pq = 0 //good fragger role
 	max_pq = null

--- a/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
@@ -9,8 +9,8 @@
 	display_order = JDO_GRENZELHOFT
 	selection_color = JCOLOR_MERCENARY
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 2
+	spawn_positions = 2
 	min_pq = 0 //good fragger role
 	max_pq = null
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Swaps adventurer roles from infinite to 8, wanted to do 6 like old RT but this way there can be parties. Pilgrim is still an infinite slot midround respawn role. Limited merc slots from 5 each to 2 each. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Limits slots that are 'town role but better' or 'guard role but better' so the actual town and guard roles are played
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
