### PR TITLE
Removes hairstyle and ancestry restrictions for Desert Mercenaries

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -80,7 +80,6 @@
 	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/AdjustClothes(mob/user)
-/obj/item/clothing/head/roguetown/roguehood/AdjustClothes(mob/user)
 	if(loc == user)
 		if(adjustable == CAN_CADJUST)
 			adjustable = CADJUSTED

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -79,6 +79,33 @@
 	max_integrity = 100
 	sewrepair = TRUE
 
+/obj/item/clothing/head/roguetown/roguehood/shalal/AdjustClothes(mob/user)
+	//Snowflake verb for Shalal specifically.
+		if(loc == user)
+		if(adjustable == CAN_CADJUST)
+			adjustable = CADJUSTED
+			if(toggle_icon_state)
+				icon_state = "[initial(icon_state)]_t"
+			flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+			body_parts_covered = NECK|HAIR|EARS|HEAD
+			if(ishuman(user))
+				var/mob/living/carbon/H = user
+				H.update_inv_head()
+				H.update_inv_wear_mask() //Snowflake case for Desert Merc hood
+				H.update_inv_cloak()
+			block2add = FOV_BEHIND
+		else if(adjustable == CADJUSTED)
+			ResetAdjust(user)
+			flags_inv = HIDEEARS|HIDEHAIR
+			if(user)
+				if(ishuman(user))
+					var/mob/living/carbon/H = user
+					H.update_inv_head()
+					H.update_inv_wear_mask() //Snowflake case for Desert Merc hood
+					H.update_inv_cloak()
+		user.update_fov_angles()
+
+
 /obj/item/clothing/head/roguetown/roguehood/astrata
 	name = "sun hood"
 	desc = ""

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -80,8 +80,8 @@
 	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/AdjustClothes(mob/user)
-	//Snowflake verb for Shalal specifically.
-		if(loc == user)
+/obj/item/clothing/head/roguetown/roguehood/AdjustClothes(mob/user)
+	if(loc == user)
 		if(adjustable == CAN_CADJUST)
 			adjustable = CADJUSTED
 			if(toggle_icon_state)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
@@ -41,11 +41,6 @@
 		H.skin_tone = pick(canonical_heritage_check_list)
 		H.update_body()
 
-	if(H.gender == FEMALE)
-		var/acceptable = list("Tomboy", "Bob", "Curly Short")
-		if(!(H.hairstyle in acceptable))
-			H.hairstyle = pick(acceptable)
-			H.update_hair()
 	backpack_contents = list(/obj/item/roguekey/mercenary)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
@@ -30,17 +30,6 @@
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	neck = /obj/item/clothing/neck/roguetown/shalal
 
-	// A quick check to make sure the desert rider is canonical
-	var/static/list/canonical_heritage_check_list = list(
-	SKIN_COLOR_GIZA,
-	SKIN_COLOR_LALVESTINE,
-	SKIN_COLOR_SHALVISTINE,
-	SKIN_COLOR_EBON
-	)
-	if(ishumannorthern(H) && !(H.skin_tone in canonical_heritage_check_list))
-		H.skin_tone = pick(canonical_heritage_check_list)
-		H.update_body()
-
 	backpack_contents = list(/obj/item/roguekey/mercenary)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes code that limits Desert Mercenary females to only utilizing three hairstyles. Removes code and list of required ancestries as well, given request of contributors.
Proof of boot/working:  https://imgbox.com/Q3j6dfgt
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As of now, I see no "lore" reason for this to exist for the class, especially given the larger customization focus for players/characters on the server. This simply allows users to not be surprised when their hairstyle doesn't match in game.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
