### PR TITLE
no more dreamer

### DIFF
--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -110,5 +110,6 @@
 		"lolth": "graggar",
 		"wolfpit": "volfpit",
 		"PQ": "reputation"
-	}
+		"Dreamer": "maniac"
+    }
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds dreamer to the accent list. Dreamer -> maniac
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People calling the maniac, a maniac, is reasonable.
People calling the maniac the dreamer, of which has absolutely no bearing on what the antagonist is presented as towards other people in game, is not! It's insanely moronic and utterly fueled by OOC knowledge of the dreamer antag in lifeweb. Ideally you just make a ruling for it to improve the standard here globally but, instead, this is a method that may actually be implemented in a timely manner instead of the administration dragging their feet on things like this and similar rp quality issues. Fuck off with the dreamer shit, I'm going to go fucking insane if people are allowed to continue doing this kind of thing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
