### PR TITLE
Makes it easier for admins to adjust the PQ of mentors.

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -46,6 +46,7 @@
 #define ADMIN_QUE(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminmoreinfo=[REF(user)]'>?</a>)"
 #define ADMIN_FLW(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminplayerobservefollow=[REF(user)]'>FLW</a>)"
 #define ADMIN_PP(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminplayeropts=[REF(user)]'>PP</a>)"
+#define ADMIN_PQADJUST(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminpqadjust=[REF(user)]'>PQADJ</a>)"
 #define ADMIN_VV(atom) "(<a href='?_src_=vars;[HrefToken(TRUE)];Vars=[REF(atom)]'>VV</a>)"
 #define ADMIN_SM(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];subtlemessage=[REF(user)]'>SM</a>)"
 #define ADMIN_TP(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];traitor=[REF(user)]'>TP</a>)"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1114,6 +1114,10 @@
 		var/mob/M = locate(href_list["adminplayeropts"])
 		show_player_panel(M)
 
+	else if(href_list["adminpqadjust"])
+		var/mob/living/M = locate(href_list["adminpqadjust"])
+		adjustpq(M)
+
 	else if(href_list["adminplayerobservefollow"])
 		if(!isobserver(usr) && !check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/schizohelp.dm
+++ b/code/modules/admin/verbs/schizohelp.dm
@@ -100,7 +100,7 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 	for(var/client/admin in GLOB.admins)
 		if(!(admin.prefs.chat_toggles & CHAT_PRAYER))
 			continue
-		to_chat(admin, span_info("<i>[voice] ([voice.key || "NO KEY"]) [ADMIN_FLW(owner)] [ADMIN_SM(owner)] answered [owner] ([owner.key || "NO KEY"])'s [ADMIN_FLW(owner)] [ADMIN_SM(owner)] meditation:</i>\n[answer]"))
+		to_chat(admin, span_info("<i>[voice] ([voice.key || "NO KEY"]) [ADMIN_FLW(owner)] [ADMIN_SM(owner)] answered [owner] ([owner.key || "NO KEY"])'s [ADMIN_FLW(owner)] [ADMIN_SM(owner)] meditation:</i>\n[answer] \nAdjust mentor's PQ? [ADMIN_PQADJUST(voice)]"))
 	answers[voice.key] = answer
 	if(length(answers) >= max_answers)
 		qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a "PQADJ" button to the end of logged meditation answers, which allows any admin seeing it (with the required permissions) to instantly call the AdjustPQ proc on that player and increase/decrease their player quality with a note. 

## Why It's Good For The Game

The text shown when choosing to be a voice says that admins may grant PQ for good answers, but there's not really any way for them to do that without going through a number of submenus. It's not something that tends to happen as a result. But making it easier incentivises people to give good answers to meditations.