### PR TITLE
Fixes "Fire Servant"

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -227,6 +227,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 ///called when the obj is destroyed by fire
 /obj/proc/burn()
+	for(var/mob/living/carbon/human/H in viewers(2, src))
+		if(H.has_flaw(/datum/charflaw/addiction/pyromaniac))
+			H.sate_addiction()
 	if(resistance_flags & ON_FIRE)
 		SSfire_burning.processing -= src
 	deconstruct(FALSE)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -184,7 +184,7 @@
 		qdel(src)
 		return
 
-	for(var/mob/living/carbon/human/H in view(2, H))
+	for(var/mob/living/carbon/human/H in viewers(2, get_turf(src)))
 		if(H.has_flaw(/datum/charflaw/addiction/pyromaniac))
 			H.sate_addiction()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fire Servant currently cannot be sated due to improper implementation. This fixes the the check in hotspots that handled fulfilment (which was questionable before), and makes objects getting destroyed by fire also sate it, as the flaw suggests.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Code should not be broken.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
