### PR TITLE
Makes frills Toggleable(?)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -49,7 +49,7 @@
 		ORGAN_SLOT_TAIL = /obj/item/organ/tail/lizard,
 		ORGAN_SLOT_SNOUT = /obj/item/organ/snout/lizard,
 		ORGAN_SLOT_TAIL_FEATURE = /obj/item/organ/tail_feature/lizard_spines,
-		ORGAN_SLOT_FRILLS = /obj/item/organ/frills/lizard,
+		ORGAN_SLOT_FRILLS = /obj/item/organ/frills/anthro,
 		ORGAN_SLOT_HORNS = /obj/item/organ/horns,
 		ORGAN_SLOT_WINGS = /obj/item/organ/wings/dracon,
 		)
@@ -62,7 +62,7 @@
 		/datum/customizer/organ/tail/lizard,
 		/datum/customizer/organ/tail_feature/lizard_spines,
 		/datum/customizer/organ/snout/lizard,
-		/datum/customizer/organ/frills/lizard,
+		/datum/customizer/organ/frills/anthro,
 		/datum/customizer/organ/horns/humanoid,
 		/datum/customizer/organ/testicles/anthro,
 		/datum/customizer/organ/penis/lizard,


### PR DESCRIPTION
## About The Pull Request
Simply changed the "ORGAN_SLOT_FRILLS = /obj/item/organ/frills/lizard," and the "/datum/customizer/organ/frills/lizard,", to be /anthro instead, it's functionally no different other than not being toggleable. I may make a PR for Sissian to have the same change as again, it's functionally no different outside of a quality of life change.

## Why It's Good For The Game
Dragons vary greatly in terms of their descriptions based on culture. Instead of adding various different races to accommodate this, a minimalistic change that let's you not be some kind of fish-dragon with frills is a good quality of life change for those wanting to play the race. This was a request by two people, maybe more on the discord to change things. <!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
