### PR TITLE
No More Bad Name

### DIFF
--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -1,5 +1,5 @@
 /obj/structure/roguemachine/atm
-	name = "SHYLOCK"
+	name = "MEISTER"
 	desc = "Stores and withdraws currency for accounts managed by the Kingdom of Rockhill."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "atm"

--- a/code/modules/roguetown/roguemachine/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile.dm
@@ -96,7 +96,7 @@
 					playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)
 				var/amt = R.payout_price * B.amount
 				if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
-					say("No account found. Submit your fingers to a shylock for inspection.")
+					say("No account found. Submit your fingers to a meister for inspection.")
 			continue
 		else if(istype(I,R.item_type))
 			if(!R.check_item(I))
@@ -125,7 +125,7 @@
 					playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
 			if(amt)
 				if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
-					say("No account found. Submit your fingers to a shylock for inspection.")
+					say("No account found. Submit your fingers to a meister for inspection.")
 			return
 
 /obj/structure/roguemachine/stockpile/attackby(obj/item/P, mob/user, params)

--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -109,6 +109,7 @@
 		"wolves": "volfs",
 		"lolth": "graggar",
 		"wolfpit": "volfpit",
-		"PQ": "reputation"
+		"PQ": "reputation",
+		"shylock": "Miester"
 	}
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Was requested by coders to make this; was an easy port since it was done elsewhere.

Re-names Shylock given it's a really strange reference. At best, poor taste, at worst - well, there was Swastika sprites/code so.. 

Renames it to a fitting name and corrects anyone using the old name in game to the new one.

## Why It's Good For The Game

People made complaints how it feels weird to borderline anti-Semitic given the term of Shylock, even if it derives from a Shakespearian play (which is controversial normally anyway). This hopefully fixes that without a hassle for players.
