### PR TITLE
Alchemy difficulty and x3 fix

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -19,7 +19,7 @@
 
 /datum/crafting_recipe/roguetown/alchemy/manna_pot_3x
 	name = "3x Manna Potion"
-	result = list(/datum/supply_pack/rogue/food/manapot)
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/manapot,/obj/item/reagent_containers/glass/bottle/rogue/manapot,/obj/item/reagent_containers/glass/bottle/rogue/manapot)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/fish/eel = 2)
 	craftdiff = 4
 
@@ -27,22 +27,22 @@
 	name = "Health Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/healthpot)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 1, /obj/item/reagent_containers/food/snacks/fish/clownfish = 1)
-	craftdiff = 5
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/health_pot_3x
 	name = "3x Health Potion"
-	result = list(/datum/supply_pack/rogue/food/healthpot)
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/healthpot,/obj/item/reagent_containers/glass/bottle/rogue/healthpot,/obj/item/reagent_containers/glass/bottle/rogue/healthpot)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 4, /obj/item/reagent_containers/food/snacks/fish/clownfish = 1)
-	craftdiff = 5
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/antipoison_pot
 	name = "Anti Poison Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/rogue/honey = 1)
-	craftdiff = 5
+	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/alchemy/antipoison_pot_3x
 	name = "3x Anti Poison Potion"
-	result = list(/datum/supply_pack/rogue/food/antipoisonpot)
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot)
 	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/rogue/honey = 2)
-	craftdiff = 5
+	craftdiff = 0


### PR DESCRIPTION
Bug/Issue: All x3 alchemy recipies make nothing. Consuming materials despite not making anything.
Fix:  Fixes the x3 recipies to not try to spawn a datum (runtimes and produced nothing)
Changes: Alters the level requirements for potions to not be stupidly high.
Thanks to @Sarah on the discord for reporting this in #bug-report.