### PR TITLE
Sus Milk Cheese & Butter

### DIFF
--- a/code/datums/sexcon/sex_actions/force/force_suck_nipples.dm
+++ b/code/datums/sexcon/sex_actions/force/force_suck_nipples.dm
@@ -38,7 +38,7 @@
 
 	var/milk_to_add = min(max(user.getorganslot(ORGAN_SLOT_BREASTS).breast_size, 1), user.getorganslot(ORGAN_SLOT_BREASTS).milk_stored)
 	if(user.getorganslot(ORGAN_SLOT_BREASTS).lactating && milk_to_add > 0 && prob(25))
-		target.reagents.add_reagent(/datum/reagent/consumable/milk, milk_to_add)
+		target.reagents.add_reagent(/datum/reagent/consumable/breastmilk, milk_to_add)
 		user.getorganslot(ORGAN_SLOT_BREASTS).milk_stored -= milk_to_add
 		to_chat(target, span_notice("I can taste milk."))
 		to_chat(user, span_notice("I can feel milk leak from my buds."))

--- a/code/datums/sexcon/sex_actions/oral/suck_nipples.dm
+++ b/code/datums/sexcon/sex_actions/oral/suck_nipples.dm
@@ -32,7 +32,7 @@
 
 	var/milk_to_add = min(max(target.getorganslot(ORGAN_SLOT_BREASTS).breast_size, 1), target.getorganslot(ORGAN_SLOT_BREASTS).milk_stored)
 	if(target.getorganslot(ORGAN_SLOT_BREASTS).lactating && milk_to_add > 0 && prob(25))
-		user.reagents.add_reagent(/datum/reagent/consumable/milk, milk_to_add)
+		user.reagents.add_reagent(/datum/reagent/consumable/breastmilk, milk_to_add)
 		target.getorganslot(ORGAN_SLOT_BREASTS).milk_stored -= milk_to_add
 		to_chat(user, span_notice("I can taste milk."))
 		to_chat(target, span_notice("I can feel milk leak from my buds."))

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -213,6 +213,30 @@
 			H.blood_volume = min(H.blood_volume+10, BLOOD_VOLUME_NORMAL)
 	..()
 
+/datum/reagent/consumable/breastmilk
+	name = "Breast milk"
+	description = "An opaque white liquid produced by the mammary glands of mammals."
+	color = "#f8f8f5" // rgb: 248, 248, 245
+	taste_description = "milk"
+	glass_icon_state = "glass_white"
+	glass_name = "glass of milk"
+	glass_desc = ""
+
+/datum/reagent/consumable/breastmilk/on_mob_life(mob/living/carbon/M)
+	if(M.getBruteLoss() && prob(20))
+		M.heal_bodypart_damage(1,0, 0)
+		. = 1
+	if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
+		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
+			H.adjust_hydration(10)
+		if(H.blood_volume < BLOOD_VOLUME_NORMAL)
+			H.blood_volume = min(H.blood_volume+10, BLOOD_VOLUME_NORMAL)
+	..()
+
+
 /datum/reagent/consumable/soymilk
 	name = "Soy Milk"
 	description = "An opaque white liquid made from soybeans."

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -47,7 +47,7 @@
 							if(reagents.total_volume < volume)
 								var/milk_to_take = min(humanized.getorganslot(ORGAN_SLOT_BREASTS).milk_stored, max(humanized.getorganslot(ORGAN_SLOT_BREASTS).breast_size, 1), volume - reagents.total_volume)
 								if(do_after(user, 20, target = M))
-									reagents.add_reagent(/datum/reagent/consumable/milk, milk_to_take)
+									reagents.add_reagent(/datum/reagent/consumable/breastmilk, milk_to_take)
 									humanized.getorganslot(ORGAN_SLOT_BREASTS).milk_stored -= milk_to_take
 									user.visible_message(span_notice("[user] milks [M] using \the [src]."), span_notice("I milk [M] using \the [src]."))
 							else

--- a/code/modules/roguetown/roguejobs/cook/ingredients/fat.dm
+++ b/code/modules/roguetown/roguejobs/cook/ingredients/fat.dm
@@ -48,6 +48,47 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
 	slices_num = 0
 
+/obj/item/reagent_containers/food/snacks/breastmilkbutter
+	icon = 'icons/roguetown/items/food.dmi'
+	name = "breastmilk butter"
+	desc = "A small crock of butter, with a creamy surface."
+	icon_state = "butter6"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	foodtype = DAIRY
+	slice_path = /obj/item/reagent_containers/food/snacks/breastmilkbutterslice
+	slices_num = 6
+	slice_batch = FALSE
+	bitesize = 6
+
+/obj/item/reagent_containers/food/snacks/breastmilkbutter/update_icon()
+	if(slices_num)
+		icon_state = "butter[slices_num]"
+	else
+		icon_state = "butter_slice"
+
+/obj/item/reagent_containers/food/snacks/breastmilkbutter/On_Consume(mob/living/eater)
+	..()
+	if(slices_num)
+		if(bitecount == 1)
+			slices_num = 5
+		if(bitecount == 2)
+			slices_num = 4
+		if(bitecount == 3)
+			slices_num = 3
+		if(bitecount == 4)
+			slices_num = 2
+		if(bitecount == 5)
+			changefood(slice_path, eater)
+
+/obj/item/reagent_containers/food/snacks/breastmilkbutterslice
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "butter_slice"
+	name = "breastmilk butter"
+	desc = "A small slice of creamy butter!"
+	foodtype = DAIRY
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
+	slices_num = 0
+
 /obj/item/reagent_containers/food/snacks/fat
 	icon = 'icons/roguetown/items/food.dmi'
 	name = "fat"

--- a/code/modules/roguetown/roguejobs/cook/ingredients/misc.dm
+++ b/code/modules/roguetown/roguejobs/cook/ingredients/misc.dm
@@ -125,6 +125,97 @@
 	become_rot_type = null
 	rotprocess = null
 
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheese
+	name = "breastmilk cheese"
+	desc = "A wheel of mozzarella cheese, adorned with a little bit of mold."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "freshcheese"
+	bitesize = 1
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	w_class = WEIGHT_CLASS_TINY
+	tastes = list("cheese" = 1)
+	foodtype = GRAIN
+	eat_effect = null
+	rotprocess = 20 MINUTES
+	become_rot_type = null
+	slice_path = null
+
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheesewheel
+	name = "wheel of breastmilk cheddar"
+	desc = "A golden wheel of cheddar cheese."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "cheesewheel"
+	bitesize = 6
+	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("cheese" = 1)
+	eat_effect = null
+	rotprocess = 20 MINUTES
+	slices_num = 6
+	slice_batch = TRUE
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarwedge
+	become_rot_type = /obj/item/reagent_containers/food/snacks/rogue/breastmilkcheesewheel/aged
+
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheesewheel/aged
+	name = "wheel of aged breastmilk cheese"
+	desc = "A wheel with intricate patterns of several types of mold with a pungent aroma."
+	icon_state = "blue_cheese"
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/breastmilkcheesewheel/aged
+	become_rot_type = null
+	rotprocess = null
+
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarwedge
+	name = "wedge of breastmilk cheese"
+	desc = "An invigorating wedge of cheddar cheese."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "cheese_wedge"
+	bitesize = 3
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	w_class = WEIGHT_CLASS_TINY
+	tastes = list("cheese" = 1)
+	eat_effect = null
+	rotprocess = 20 MINUTES
+	slices_num = 3
+	slice_batch = TRUE
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarslice
+	become_rot_type = /obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarwedge/aged
+	baitchance = 100
+	fishloot = list(/obj/item/reagent_containers/food/snacks/fish/carp = 10,
+					/obj/item/reagent_containers/food/snacks/fish/eel = 5,
+					/obj/item/reagent_containers/food/snacks/fish/angler = 1)
+
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarwedge/aged
+	name = "wedge of aged breastmilk cheese"
+	desc = "A dangerous piece of cheese for the brave."
+	icon_state = "blue_cheese_wedge"
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/cheddarslice/aged
+	become_rot_type = null
+	rotprocess = null
+
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarslice
+	name = "slice of breastmilk cheese"
+	desc = "A soft, creamy slice of cheddar cheese."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "cheese_slice"
+	bitesize = 1
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	w_class = WEIGHT_CLASS_TINY
+	tastes = list("cheese" = 1)
+	eat_effect = null
+	rotprocess = 20 MINUTES
+	slices_num = null
+	slice_path = null
+	become_rot_type = null
+	baitchance = 100
+	fishloot = list(/obj/item/reagent_containers/food/snacks/fish/carp = 10,
+					/obj/item/reagent_containers/food/snacks/fish/eel = 5)
+
+/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheddarslice/aged
+	name = "slice of aged breastmilk cheese"
+	desc = "A dangerous slice of cheese."
+	icon_state = "blue_cheese_slice"
+	become_rot_type = null
+	rotprocess = null
 
 /obj/item/reagent_containers/food/snacks/rogue/honey
 	name = "honey"

--- a/code/modules/roguetown/roguejobs/cook/recipes/misc.dm
+++ b/code/modules/roguetown/roguejobs/cook/recipes/misc.dm
@@ -20,6 +20,16 @@
 
 	subtype_reqs = FALSE
 
+/datum/crafting_recipe/roguetown/cooking/breastmilkbutter
+	name = "butter"
+	reqs = list(
+		/datum/reagent/consumable/breastmilk = 15,
+		/obj/item/reagent_containers/powder/flour/salt = 1)
+	result = /obj/item/reagent_containers/food/snacks/breastmilkbutter
+	tools = list(/obj/item/reagent_containers/glass/bucket/wooden)
+
+	subtype_reqs = FALSE
+
 /datum/crafting_recipe/roguetown/cooking/cheese
 	name = "fresh cheese"
 	reqs = list(
@@ -36,6 +46,25 @@
 	name = "cheese wheel"
 	reqs = list(/obj/item/reagent_containers/food/snacks/rogue/cheese = 6)
 	result = /obj/item/reagent_containers/food/snacks/rogue/cheddar
+
+	subtype_reqs = FALSE
+
+/datum/crafting_recipe/roguetown/cooking/breastmilkcheese
+	name = "breast milk cheese"
+	reqs = list(
+		/datum/reagent/consumable/breastmilk = 5,
+		/obj/item/reagent_containers/powder/flour/salt = 1)
+	result = list(/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheese,
+				/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheese,
+				/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheese)
+	tools = list(/obj/item/reagent_containers/glass/bucket/wooden)
+
+	subtype_reqs = FALSE
+
+/datum/crafting_recipe/roguetown/cooking/breastmilkcheesewheel
+	name = "cheese wheel"
+	reqs = list(/obj/item/reagent_containers/food/snacks/rogue/breastmilkcheese = 6)
+	result = /obj/item/reagent_containers/food/snacks/rogue/breastmilkcheesewheel
 
 	subtype_reqs = FALSE
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
ADD: Adds in Breastmilk Cheese ( and their aged variants ), Adds in Breastmilk butter
CHANGE: Milk from breasts is changed to Breastmilk
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lactation was setup to give milk... this was a terrible oversight as it is crashing the economy, causing awkward moments, and overall being abused.  This PR changes it so lactated milk is considered breastmilk and that can be still be used to make breastmilk cheese, and breastmilk butter, however, these breastmilk variants cannot be sold or used in cooking.  Breastmilk cheese can still be used as bait, and can be consumed akin to food, same as the butter.

This keeps it from still being RP for others while not breaking the economy and tricking people into eating sus cheese/butter
(I can't do anything about the liquid milk, you gotta RP that out my wayward son )
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
