### PR TITLE
freshcheese Desc: Mozzarella to Farmer's Cheese

### DIFF
--- a/code/modules/roguetown/roguejobs/cook/ingredients/misc.dm
+++ b/code/modules/roguetown/roguejobs/cook/ingredients/misc.dm
@@ -35,7 +35,7 @@
 
 /obj/item/reagent_containers/food/snacks/rogue/cheese
 	name = "cheese"
-	desc = "A wheel of mozzarella cheese, adorned with a little bit of mold."
+	desc = "A ball of unaged farmer's cheese, plain but pleasant."
 	icon = 'icons/roguetown/items/food.dmi'
 	icon_state = "freshcheese"
 	bitesize = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Mozzarella being a specific Italian style, I have redesc'd mozzarella cheese to farmer's cheese, a much more generic home-made style common across pre-industrial Europe and colonial or frontier America. Its milk, salt, and either a bit of calf's stomach or an acid (in our case probably abstracted apple cider vinegar) to curdle it, squeezed out in a cheesecloth or press. From this you could make other sorts or use it immediately.

This PR makes no code changes beyond a slight alteration of the description text.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mozzarella is an Italian-language term specific to an Italian cheese style (made with water buffalo milk if we get very particular), while our setting is not specifically Italian. Farmer's cheese is an extremely generic English-language term for homemade cheeses made by the same abstracted recipe and a plausible precursor step for the other cheeses in game.  In this way it furthers immersion through the removal of a specific Italian term in a game otherwise using the English language.

_This is not the start of a case to rename things like flamberges, since that would be a specific regional styles of weapon with its specific regional name attached._

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->