### PR TITLE
Zombie touchup

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -35,7 +35,6 @@
 		TRAIT_NOPAIN,
 		TRAIT_NOPAINSTUN,
 		TRAIT_NOBREATH,
-		TRAIT_NOBREATH,
 		TRAIT_TOXIMMUNE,
 		TRAIT_CHUNKYFINGERS,
 		TRAIT_NOSLEEP,
@@ -44,7 +43,6 @@
 		TRAIT_BLOODLOSS_IMMUNE,
 		TRAIT_ZOMBIE_SPEECH,
 		TRAIT_ZOMBIE_IMMUNE,
-		TRAIT_EMOTEMUTE,
 		TRAIT_ROTMAN,
 		TRAIT_NORUN
 	)
@@ -157,6 +155,7 @@
 		qdel(src)
 		return
 	revived = TRUE //so we can die for real later
+	zombie.remove_client_colour(/datum/client_colour/monochrome)
 	for(var/trait_applied in traits_zombie)
 		ADD_TRAIT(zombie, trait_applied, "[type]")
 	if(zombie.mind)
@@ -174,7 +173,7 @@
 	zombie.mode = AI_IDLE
 	zombie.handle_ai()
 	ambushable = zombie.ambushable
-	zombie.ambushable = FALSE
+	zombie.ambushable = TRUE
 
 	if(zombie.charflaw)
 		zombie.charflaw.ephemeral = TRUE
@@ -224,9 +223,13 @@
 	if(!user || user.stat >= DEAD || !has_turned)
 		return
 	var/mob/living/carbon/human/zombie = user
-	if(world.time > next_idle_sound)
-		zombie.emote("idle")
-		next_idle_sound = world.time + rand(5 SECONDS, 10 SECONDS)
+	if(!zombie.eyesclosed && zombie.resting)
+		if(world.time > next_idle_sound)
+			zombie.emote("idle")
+			next_idle_sound = world.time + rand(10 SECONDS, 20 SECONDS)
+	if(zombie.client)
+		zombie.mode = AI_OFF
+	else zombie.mode = AI_ON
 
 //Infected wake param is just a transition from living to zombie, via zombie_infect()
 //Previously you just died without warning in 3 minutes, now you just become an antag

--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -28,7 +28,7 @@
 	return
 
 /mob/living/rogstam_add(added as num)
-	if(HAS_TRAIT(src, TRAIT_NOROGSTAM))
+	if(HAS_TRAIT(src, TRAIT_NOROGSTAM) || HAS_TRAIT(src, TRAIT_ZOMBIE_SPEECH))
 		return TRUE
 	if(m_intent == MOVE_INTENT_RUN)
 		mind.adjust_experience(/datum/skill/misc/athletics, (STAINT*0.02))
@@ -98,7 +98,7 @@
 	var/heart_attacking = FALSE
 
 /mob/living/carbon/proc/heart_attack()
-	if(HAS_TRAIT(src, TRAIT_NOROGSTAM))
+	if(HAS_TRAIT(src, TRAIT_NOROGSTAM) || HAS_TRAIT(src, TRAIT_ZOMBIE_SPEECH))
 		return
 	if(!heart_attacking)
 		heart_attacking = TRUE
@@ -136,7 +136,7 @@
 		var/matrix/skew = matrix()
 		skew.Scale(2)
 		//skew.Translate(-224,0)
-		var/matrix/newmatrix = skew 
+		var/matrix/newmatrix = skew
 		for(var/C in hud_used.plane_masters)
 			var/atom/movable/screen/plane_master/whole_screen = hud_used.plane_masters[C]
 			if(whole_screen.plane == HUD_PLANE)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -591,22 +591,23 @@
 			limb.color = "#[draw_color]"
 			if(aux_zone && !hideaux)
 				aux.color = "#[draw_color]"
-	
+
 	// Markings overlays
 	if(!skeletonized)
 		var/list/marking_overlays = get_markings_overlays(override_color)
 		if(marking_overlays)
 			. += marking_overlays
-	
+
 	// Organ overlays
-	if(!rotted && !skeletonized)
+	//if(!rotted && !skeletonized) //Original way. This was causing parts to vanish when rotted.
+	if(!skeletonized)
 		for(var/obj/item/organ/organ as anything in get_organs())
 			if(!organ.is_visible())
 				continue
 			var/mutable_appearance/organ_appearance = organ.get_bodypart_overlay(src)
 			if(organ_appearance)
 				. += organ_appearance
-	
+
 	// Feature overlays
 	if(!skeletonized)
 		for(var/datum/bodypart_feature/feature as anything in bodypart_features)


### PR DESCRIPTION
Touches up Zombies to be less bugged and have a few QOL changes.
ISSUES / FIXES:
Parts disappearing when rotted / Altered the check for rotted parts to cause them to be drawn.
Zombies not regenerating any fatigue or stamina / Zombie AI now checks for a client, allowing fatigue regen (green bar). Stamina dropping checks changed to prevent zombies from losing more stamina (blue bar)
Zombies can have heart attacks / TRAIT_ZOMBIE_SPEECH added to heart attack check to prevent heart failure.
Zombies cant trigger ambushes / Single variable changed to allow zombies to trigger ambushes.
Monochrome vision is hard to see / Removes Monochrome vision on turning, better shows when you've turned as a nice side effect.
Extra no breath trait / Deletes the extra TRAIT.
Can't emote on a HRP server / Removes the TRAIT preventing emoting. We have a rule about people interacting before killing others so this is to aid zombies with server rules and promoting RP.
Moaning vary frequently / Alters zombie moans to be every 10 to 20 seconds instead of 5 to 10. Also Zombies given ability to stop moaning all together (play dead) by closing eyes and resting