### PR TITLE
Ports Ratwood PR: "Movementspeed is now a gradual change per point of SPD"

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -52,10 +52,10 @@
 			mod = CONFIG_GET(number/movedelay/run_delay)
 		if(MOVE_INTENT_SNEAK)
 			mod = 6
-	if(STASPD < 6)
-		mod = mod+1
-	if(STASPD > 14)
-		mod = mod-0.5
+	var/spdchange = (10-STASPD)*0.1
+	spdchange = clamp(spdchange, -0.5, 1)  //if this is not clamped, maniacs will run at unfathomable speed
+	mod = mod+spdchange
+	//maximum speed is achieved at 15spd, everything else results in insanity
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Ports Ratwood PR:
https://github.com/Rotwood-Vale/Ratwood-Keep/pull/502

## Why It's Good For The Game

Basically makes speed dynamic but still caps at the same fastest speed and lowest speed of before.

Prior, if you had less than 6 speed? +1 to slowdown modifier. If you have more than 14 speed? -0.5 to slowdown modifier. 
This keeps that same cap, at 6 you get +1, and at 15 you get -0.5. But, the rest of speed? Congrats! It scales. So, at 12 speed you'll get a roughly -0.2 modifier or so.
