### PR TITLE
Putting squires and the rest of the townwatch in the saddle

### DIFF
--- a/code/modules/jobs/job_types/roguetown/apprentices/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/apprentices/squire.dm
@@ -10,7 +10,7 @@
 	allowed_ages = list(AGE_ADULT)
 	cmode_music = 'sound/music/combat_squire.ogg'
 
-	tutorial = "Mom 'n' Da said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday. "
+	tutorial = "Mom 'n' Da said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy bags of grain. A member of the royal retinue took notice of your potential and brought you on as their personal ward. You're going to be something someday. "
 
 	outfit = /datum/outfit/job/roguetown/squire
 	display_order = JDO_SQUIRE
@@ -40,6 +40,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 			H.change_stat("strength", 1)
 			H.change_stat("perception", 1)
 			H.change_stat("constitution", 1)
@@ -64,6 +65,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 			H.change_stat("strength", 1)
 			H.change_stat("perception", 1)
 			H.change_stat("constitution", 1)

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -118,6 +118,7 @@ Archer is basically a 'bounty-catcher' in function, less specialized at close-qu
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)	//For basic crafting; you'll need it due to relegated support role.
 	H.mind.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)	//Likely hunter background; very crappy basic skill.
+	H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
 	H.change_stat("strength", 1)
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

More simple web edits. I'll actually start pulling code and _properly_ compiling and testing things when I do more then relatively simple line edits.

This simply gives the riding skill to squires and the archer variant of the townguard. As the present, _every_ person in the garrison has a riding skill, with much of the keep staff having it, too. Squires (and townwatch) being able to keep up with their masters if they opt for weird-deer-thing adventures is ideal, as well as encouraging more saiga use in general. The bog militia runs at two, so if a shitty toothless peasant levy can manage, so can their higher peers! 

The archer was only given a value of one in contrast to their melee-minded companions, as I do recognize someone with a _really_ good archery statblock being able to turn into a Mongolian menace on demand is toxic a f. At least the steppeman has it as their hat.

Also I adjusted the squire description while I was there, given it pointed to the knight still.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A more uniform faction grouping for an effectively novelty skill lets the faction do things together, especially one that is either untrainable or very impractical to do so.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
