### PR TITLE
Bandit look fix

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -74,7 +74,7 @@
 	H.cmode_music = 'sound/music/combat_bandit2.ogg'
 
 	addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, choose_name_popup), "BANDIT"), 5 SECONDS)
-//	H.job = "Bandit"
+	H.job = "Bandit"
 //	H.advjob = pick("Cheesemaker", "Mercenary", "Barbarian", "Ranger", "Rogue")
 	H.equipOutfit(/datum/outfit/job/roguetown/bandit)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -62,6 +62,9 @@
 			var/used_title =  "King or Queen of the Tribe"
 		// Use the possibly modified title in the output
 			. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the [used_title].")
+		if(job == "Bandit")
+			var/used_title = "bandit"
+			. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the [used_title].")
 		else
 			var/datum/job/J = SSjob.GetJob(job)
 			var/used_title = J.title

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -62,7 +62,7 @@
 			var/used_title =  "King or Queen of the Tribe"
 		// Use the possibly modified title in the output
 			. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the [used_title].")
-		if(job == "Bandit")
+		else if(job == "Bandit")
 		// Easiest way to fix this goddamned bandit thing.
 			var/used_title = "bandit"
 			. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the [used_title].")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -63,6 +63,7 @@
 		// Use the possibly modified title in the output
 			. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the [used_title].")
 		if(job == "Bandit")
+		// Easiest way to fix this goddamned bandit thing.
 			var/used_title = "bandit"
 			. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the [used_title].")
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes bandits runtiming whenever you look at them. Allows you to see everything about bandits instead of literally nothing.
Bandit originally gave you a NULL job and thus had no title. I make applying bandit to a player give them a job (H.job = "Bandit") and then gives an IF bandit then display.
Examine.dm 
Looking at normal players still works, looking at the tribal chieftain still works, looking at bandits works.
Proof of work: 
Looking at generic jobbed player: 
![H6eWa8Xa_o](https://github.com/user-attachments/assets/c4cb93ce-a146-4638-9e34-ed1793657394)
Looking at bandit: 
![rMaI3AlI_o](https://github.com/user-attachments/assets/b11c69d2-2a59-49ad-ae72-c2578030be8b)
Looking at Chieftain (Just since why not) : 
![g4AwKxpM_o](https://github.com/user-attachments/assets/78c1922d-3d9d-4923-8fd8-c5de29ae5ed4)
Looking at vampire (Making sure I haven't broken other antags views)
![image](https://github.com/user-attachments/assets/a10568b8-30d5-4234-9155-fa46d8f75cff)

If you know a BETTER, CLEANER way to make this work, do let me know.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it so you can actually see a bandit player's looks, and not spamming the server with more runtimes. We need to fix bugs and I'm trying my best.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
