### PR TITLE
Celibate Churchlings

### DIFF
--- a/code/modules/jobs/job_types/roguetown/apprentices/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/apprentices/churchling.dm
@@ -20,6 +20,7 @@
 
 /datum/outfit/job/roguetown/churchling/pre_equip(mob/living/carbon/human/H)
 	..()
+	H.virginity = TRUE
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)


### PR DESCRIPTION
## About The Pull Request

Churchlings are now virgins.

This is mostly to test making PRs.

## Why It's Good For The Game

Updated to match acolyte and priest (which are also both virgins).
