### PR TITLE
Adds missing knife skills to ranger.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
@@ -30,6 +30,7 @@
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	cloak = /obj/item/clothing/cloak/raincloak/brown
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -33,6 +33,7 @@
 			backpack_contents = list(/obj/item/bait = 1, /obj/item/rogueweapon/huntingknife = 1)
 			beltl = /obj/item/quiver/arrows
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, pick(4,5,5,6), TRUE)
@@ -67,6 +68,7 @@
 			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 			beltl = /obj/item/quiver/arrows
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)


### PR DESCRIPTION
Ranger has no knife skills and instead has sword and axe skills? Seems really strange considering all the variants start with a **_dagger_** or a hunting knife, adding 2 to knives. If we think it's appropriate I can remove the sword skills instead but I don't think knives really adds that much.



## Why It's Good For The Game

A ranger being worse than anyone else with the dagger they start with seems kind of silly.
