### PR TITLE
Surgery Buff

### DIFF
--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -59,9 +59,9 @@
 	/// Modifiers to success chance when you're above the median
 	var/list/skill_bonuses = list(
 		1 = 0.4,
-		2 = 0.6,
-		3 = 0.8,
-		4 = 1,
+		2 = 0.8,
+		3 = 1,
+		4 = 1.2,
 		5 = 1.5,
 		6 = 2,
 	)

--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -55,14 +55,14 @@
 	/// Necessary skill MINIMUM to perform this surgery step, of skill_used
 	var/skill_min = SKILL_LEVEL_NOVICE
 	/// Skill median used to apply success and speed bonuses
-	var/skill_median = SKILL_LEVEL_JOURNEYMAN
+	var/skill_median = SKILL_LEVEL_NOVICE
 	/// Modifiers to success chance when you're above the median
 	var/list/skill_bonuses = list(
-		1 = 0.2,
-		2 = 0.4,
-		3 = 0.6,
-		4 = 0.8,
-		5 = 1,
+		1 = 0.4,
+		2 = 0.6,
+		3 = 0.8,
+		4 = 1,
+		5 = 1.5,
 		6 = 2,
 	)
 	/// Modifiers to success chance when you're below the median


### PR DESCRIPTION
I don't really know anything about surgery, but apparently legendary surgery only has around a 50% success rate for some surgeries.

Moved down the median from level 3 to level 1, giving earlier modifiers to success chances, and doubled the bonuses. Surgery is infinitely worse than miracles so this is a start.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
