### PR TITLE
Racial Redux Part One

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -4,10 +4,18 @@
 /datum/species/anthromorph
 	name = "Wild-Kin"
 	id = "anthromorph"
-	desc = "Wild-Kin; a name for a furred creacher that does not fall under any particular race. \
-	It is sometimes difficult to tell one of us from another race at a glance; one of Wild-Kin ancestry may look very similar to a Tabaxi or Vulpkanin. \
-	Due to the fact we are so numerous, we are welcome almost anywhere, along with our Half-Kin sister-race \
-	We are average of constitution, strength, and intellegence."
+	desc = "<b>Wild-Kin</b><br>\
+	The Wild Volk are the errant children of Dendor, to whom they all share an innate connection. \
+	Wild-Kin arise in all the lands of Grimoria and are nearly as widespread as Humens.<br>\
+	Wild-Kin are humanoid animals, sometimes limited to one specific species or a hybrid of multiple. \
+	Of all the races, Wild-Kin has the most variety in appearance.<br>\
+	Despite the Wild Folk’s connection to Dendor, he is not the most favored god of their kind. \
+	Many Wild-Kin believe that remaining civilized is of the utmost importance to keep their humanity and differentiate them from the beasts of the wilderness. \
+	They fear that they will be unable to resist Dendor’s Call when the time comes for him to gather his children.<br>\
+	<br>\
+	We are highly perceptive and skilled with a bow but slow to learn new skills and ideas."
+
+	skin_tone_wording = "Habitat"
 	default_color = "444"
 	species_traits = list(
 		MUTCOLORS,
@@ -17,6 +25,7 @@
 	)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	use_skintones = 1
 	attack_verb = "slash"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	possible_ages = ALL_AGES_LIST
@@ -38,8 +47,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = -1, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 1, "fortune" = 0)
+	specstats = list("strength" = 1, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = -1, "speed" = 0, "fortune" = 0)
+	specstats_f = list("strength" = 0, "perception" = 2, "intelligence" = -1, "constitution" = 0, "endurance" = 0, "speed" = 0, "fortune" = 0)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,
@@ -130,6 +139,19 @@
 
 /datum/species/anthromorph/qualifies_for_rank(rank, list/features)
 	return TRUE
+
+/datum/species/anthromorph/get_skin_list()
+	return list(
+		"the Grand Forests" = "271f1b",
+		"the Crimson Lands" = "271f1c",
+		"the Terrorbog" = "271f1d",
+		"the Highlands" = "271f1e",
+		"the Western Mountains" = "271f1f",
+		"the Frostlands" = "271f2a",
+		"the Unknown Lands" = "271f2b",
+		"the Valorian Deserts" = "271f2c",
+		"the Eastern Plains" = "271f2c",
+	)
 
 /datum/species/anthromorph/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -13,7 +13,7 @@
 	Many Wild-Kin believe that remaining civilized is of the utmost importance to keep their humanity and differentiate them from the beasts of the wilderness. \
 	They fear that they will be unable to resist Dendor’s Call when the time comes for him to gather his children.<br>\
 	<br>\
-	We are highly perceptive and skilled with a bow but slow to learn new skills and ideas."
+	We are highly perceptive but slow to learn new skills and ideas."
 
 	skin_tone_wording = "Habitat"
 	default_color = "444"
@@ -47,8 +47,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 1, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = -1, "speed" = 0, "fortune" = 0)
-	specstats_f = list("strength" = 0, "perception" = 2, "intelligence" = -1, "constitution" = 0, "endurance" = 0, "speed" = 0, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = -1, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 1, "fortune" = 0)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -9,7 +9,7 @@
 	Wild-Kin arise in all the lands of Grimoria and are nearly as widespread as Humens.<br>\
 	Wild-Kin are humanoid animals, sometimes limited to one specific species or a hybrid of multiple. \
 	Of all the races, Wild-Kin has the most variety in appearance.<br>\
-	Despite the Wild Folk’s connection to Dendor, he is not the most favored god of their kind. \
+	Despite the Wild Volk’s connection to Dendor, he is not the most favored god of their kind. \
 	Many Wild-Kin believe that remaining civilized is of the utmost importance to keep their humanity and differentiate them from the beasts of the wilderness. \
 	They fear that they will be unable to resist Dendor’s Call when the time comes for him to gather his children.<br>\
 	<br>\

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -5,11 +5,11 @@
 	name = "Half-Kin"
 	id = "demihuman"
 	desc = "<b>Half-Kin</b><br>\
-	A halfbreed that arises in Humens with Wild-Kin in their lineage. \
-	They are children of Dendor by blood, but their Humen heritage makes this connection powerless. \
-	Half-Kin are said to be the only ones of Dendor’s kin that can resist his Call of the Wild.<br>\
+	A half-breed that arises in Humens with Wild-Kin in their lineage. \
+	They are children of Dendor by blood, but their Humen heritage makes this connection impotent. \
+	Half-Kin are said to be the only ones of Dendor’s progeny who can resist his Call of the Wild.<br>\
 	They bear animalistic features, most commonly bestial ears and tails modifying their base Humen form. \
-	These features that mark Half-Kin apart can skip generations, and many halfbreeds are born to Humen parents with only a distant Wild-Kin ancestor.<br>\
+	These features that mark Half-Kin apart can skip generations, and many half-breeds are born to Humen parents with only a distant Wild-Kin ancestor.<br>\
 	As they are typically born to Humens, most Half-Kin worship the Divine Pantheon.<br>\
 	<br>\
 	Our bodies bear the flaws and benefits of both Humens and Wild-Kin, to a lesser degree. \

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -44,8 +44,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = 0, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 2, "intelligence" = -1, "constitution" = 0, "endurance" = 2, "speed" = 0, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = -1, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 1, "fortune" = 0)
 	enflamed_icon = "widefire"
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -4,10 +4,17 @@
 /datum/species/demihuman
 	name = "Half-Kin"
 	id = "demihuman"
-	desc = "Half-Kin, earth-borne, magyck-touched. Many names exist for my race, characterized by our varied appearance. \
-	Wild-Kin are by far the most numerous people due to the fact we are, usually, compatible with almost all other races. \
-	Due to the fact we are so numerous, we are welcome almost anywhere, along with our Wild-Kin sister race \
-	We are average of constitution, strength, and intellegence."
+	desc = "<b>Half-Kin</b><br>\
+	A halfbreed that arises in Humens with Wild-Kin in their lineage. \
+	They are children of Dendor by blood, but their Humen heritage makes this connection powerless. \
+	Half-Kin are said to be the only ones of Dendor’s kin that can resist his Call of the Wild.<br>\
+	They bear animalistic features, most commonly bestial ears and tails modifying their base Humen form. \
+	These features that mark Half-Kin apart can skip generations, and many halfbreeds are born to Humen parents with only a distant Wild-Kin ancestor.<br>\
+	As they are typically born to Humens, most Half-Kin worship the Divine Pantheon.<br>\
+	<br>\
+	Our bodies bear the flaws and benefits of both Humens and Wild-Kin, to a lesser degree. \
+	We are skilled with bows and have great endurance. However, we adapt slowly to new ideas."
+
 	skin_tone_wording = "Ancestry"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS_PARTSONLY)
@@ -37,8 +44,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = -1, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 1, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = 0, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 2, "intelligence" = -1, "constitution" = 0, "endurance" = 2, "speed" = 0, "fortune" = 0)
 	enflamed_icon = "widefire"
 	bodypart_features = list(
 		/datum/bodypart_feature/hair/head,
@@ -112,15 +119,15 @@
 
 /datum/species/demihuman/get_skin_list()
 	return list(
-		"Grenzelhoft" = SKIN_COLOR_GRENZELHOFT,
-		"Hammerhold" = SKIN_COLOR_HAMMERHOLD,
-		"Avar" = SKIN_COLOR_AVAR,
+		"Frostlander" = SKIN_COLOR_GRENZELHOFT,
+		"Umberite" = SKIN_COLOR_HAMMERHOLD,
+		"Grenzelhoft" = SKIN_COLOR_AVAR,
 		"Rockhill" = SKIN_COLOR_ROCKHILL,
-		"Otava" = SKIN_COLOR_OTAVA,
-		"Etrusca" = SKIN_COLOR_ETRUSCA,
-		"Gronn" = SKIN_COLOR_GRONN,
-		"Giza" = SKIN_COLOR_GIZA,
-		"Shalvistine" = SKIN_COLOR_SHALVISTINE,
-		"Lalvestine" = SKIN_COLOR_LALVESTINE,
-		"Ebon" = SKIN_COLOR_EBON,
+		"Heartfell" = SKIN_COLOR_OTAVA,
+		"Highlander" = SKIN_COLOR_ETRUSCA,
+		"Moravian" = SKIN_COLOR_GRONN,
+		"Forester" = SKIN_COLOR_GIZA,
+		"Zybantine" = SKIN_COLOR_SHALVISTINE,
+		"Merkite" = SKIN_COLOR_LALVESTINE,
+		"Valorian" = SKIN_COLOR_EBON,
 	)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -45,8 +45,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = -1, "perception" = 1, "intelligence" = 2, "constitution" = -1, "endurance" = -1, "speed" = 2, "fortune" = 0)
-	specstats_f = list("strength" = -2, "perception" = 2, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 2, "fortune" = 0)
+	specstats = list("strength" = -2, "perception" = 1, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 2, "fortune" = 0)
+	specstats_f = list("strength" = -4, "perception" = 1, "intelligence" = 2, "constitution" = -2, "endurance" = 0, "speed" = 3, "fortune" = 0)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -5,17 +5,14 @@
 	name = "Elf"
 	id = "elfw"
 	desc = "<b>Elf</b><br>\
-	Elves, or Wood-Elf by the Elder races, are a generic term for tall, pointy-eared \
-	humanoids that trace their original heritage to the ancient mysterious Snow Elves. \
-	Considering their diverse history, it is extremely difficult for other mortals \
-	to even concept the various intricacies found in elven society, and the hundreds \
-	if not thousands of tribes that exist within their culture! \
-	Elves tend to be looked poorly upon by humans, as historically the two races have \
-	been rivals in various conflicts and territorial disputes. This however does not stop \
-	many humans and elves from forming relationships, which are capable of producing child.\
-	Elves are known for their intelligence and sharp eyes, but their graceful nature does \
-	not lend itself to the concepts of strength or durability... \
-	There are elves from a small smattering of tribes in these parts."
+	The Elves are marked apart from other races by their ethereal grace and long lives. \
+	Like Humens, they live throughout the lands of Grimoria. \
+	Yet, unlike other races, they prefer to dwell in lands untouched by civilization.<br>\
+	Elves can be hard to tell apart from Humens at a glance but can be easily distinguished once acquainted. \
+	They are lighter and often more slender than men and bear fairy-like features upon their faces and ears.<br>\
+	The Elves worship the Divine Pantheon in the same manner as Humens, though they often practice a much older variation of the religion.<br>\
+	<br>\
+	Magic comes easily to us, and we are swifter than other races. However, our bodies are weak and fragile."
 
 	skin_tone_wording = "Tribal Identity"
 
@@ -48,8 +45,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = -2, "perception" = 1, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 2, "fortune" = 0)
-	specstats_f = list("strength" = -4, "perception" = 1, "intelligence" = 2, "constitution" = -2, "endurance" = 0, "speed" = 3, "fortune" = 0)
+	specstats = list("strength" = -1, "perception" = 1, "intelligence" = 2, "constitution" = -1, "endurance" = -1, "speed" = 2, "fortune" = 0)
+	specstats_f = list("strength" = -2, "perception" = 2, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 2, "fortune" = 0)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,
@@ -92,14 +89,14 @@
 
 /datum/species/elf/wood/get_skin_list()
 	return list(
-		"Dandelion Creek" = SKIN_COLOR_DANDELION_CREEK,
-		"Roseveil" = SKIN_COLOR_ROSEVEIL,
-		"Azuregrove" = SKIN_COLOR_AZUREGROVE,
-		"Arborshome" = SKIN_COLOR_ARBORSHOME,
-		"Almondvalle" = SKIN_COLOR_ALMONDVALLE,
-		"Walnut Woods" = SKIN_COLOR_WALNUT_WOODS,
-		"Timberborn" = SKIN_COLOR_TIMBERBORN,
-		"Ashen" 	= SKIN_COLOR_ASHEN,
+		"Snow Scion" = SKIN_COLOR_DANDELION_CREEK,
+		"Shadewood" = SKIN_COLOR_ROSEVEIL,
+		"Emberfall" = SKIN_COLOR_AZUREGROVE,
+		"Vandendor" = SKIN_COLOR_ARBORSHOME,
+		"Fablefield" = SKIN_COLOR_ALMONDVALLE,
+		"Nevor" = SKIN_COLOR_WALNUT_WOODS,
+		"Merkite" = SKIN_COLOR_TIMBERBORN,
+		"Weso" 	= SKIN_COLOR_ASHEN,
 	)
 
 /datum/species/elf/wood/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -8,9 +8,9 @@
 	The Elves are marked apart from other races by their ethereal grace and long lives. \
 	Like Humens, they live throughout the lands of Grimoria. \
 	Yet, unlike other races, they prefer to dwell in lands untouched by civilization.<br>\
-	Elves can be hard to tell apart from Humens at a glance but can be easily distinguished once acquainted. \
+	Elves can be difficult to distinguish from Humens at a glance until one is better acquainted with them. \
 	They are lighter and often more slender than men and bear fairy-like features upon their faces and ears.<br>\
-	The Elves worship the Divine Pantheon in the same manner as Humens, though they often practice a much older variation of the religion.<br>\
+	The Elves commonly worship the Divine Pantheon in much the same way that Humens do, though they tend towards older practices and beliefs about the Ten.<br>\
 	<br>\
 	Magic comes easily to us, and we are swifter than other races. However, our bodies are weak and fragile."
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -10,9 +10,7 @@
 	However, despite differences in appearance and geographical origin, all Humens have the same capabilities.<br>\
 	Humens hold dear the belief that they are the firstborn children of Psydon, \
 	Knowledge of good and evil is his divine gift bestowed upon them. \
-	The Divine Pantheon is the predominant religion of their kind.<br>\
-	<br>\
-	We have a well of endurance that other races lack."
+	The Divine Pantheon is the predominant religion of their kind."
 
 	skin_tone_wording = "Ancestry"
 
@@ -44,8 +42,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = -1, "intelligence" = 1, "constitution" = 0, "endurance" = 1, "speed" = 0, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 1, "constitution" = 0, "endurance" = 2, "speed" = 0, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = -1, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 1, "fortune" = 0)
 	enflamed_icon = "widefire"
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -5,13 +5,14 @@
 	name = "Humen"
 	id = "humen"
 	desc = "<b>Humen</b><br>\
-	Humen (or Human) are the eldest of the weeping gods creation. Noted for their\
-	tenacity and overwhelming population, humans tend to outnumber the other races. \
-	at a rate of about ten to one in regions such as Grenzelhoft. Althrough to the west \
-	the opposite is true. Humen come from a vast swathe of cultures and ethnicity, most of which\
-	have historically been at odds with one another. Being the eldest of the weeping God, humen\
-	tend to find fortune easier than the other races, and are so diverse that no other racial trait\
-	are dominant in their species..."
+	The most widespread race in Grimoria, Humens are found in nearly every civilized place on land. \
+	This extensive distribution of their kind has led to variations between Humens in custom and appearance. \
+	However, despite differences in appearance and geographical origin, all Humens have the same capabilities.<br>\
+	Humens hold dear the belief that they are the firstborn children of Psydon, \
+	Knowledge of good and evil is his divine gift bestowed upon them. \
+	The Divine Pantheon is the predominant religion of their kind.<br>\
+	<br>\
+	We have a well of endurance that other races lack."
 
 	skin_tone_wording = "Ancestry"
 
@@ -43,8 +44,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = 1, "intelligence" = -1, "constitution" = 0, "endurance" = 1, "speed" = -1, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 2, "constitution" = -1, "endurance" = 0, "speed" = 1, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = -1, "intelligence" = 0, "constitution" = 0, "endurance" = 2, "speed" = 0, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 0, "constitution" = 0, "endurance" = 3, "speed" = 0, "fortune" = 0)
 	enflamed_icon = "widefire"
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,
@@ -67,17 +68,17 @@
 
 /datum/species/human/northern/get_skin_list()
 	return list(
-		"Grenzelhoft" = SKIN_COLOR_GRENZELHOFT,
-		"Hammerhold" = SKIN_COLOR_HAMMERHOLD,
-		"Avar" = SKIN_COLOR_AVAR,
+		"Frostlander" = SKIN_COLOR_GRENZELHOFT,
+		"Umberite" = SKIN_COLOR_HAMMERHOLD,
+		"Grenzelhoft" = SKIN_COLOR_AVAR,
 		"Rockhill" = SKIN_COLOR_ROCKHILL,
-		"Otava" = SKIN_COLOR_OTAVA,
-		"Etrusca" = SKIN_COLOR_ETRUSCA,
-		"Gronn" = SKIN_COLOR_GRONN,
-		"Giza" = SKIN_COLOR_GIZA,
-		"Shalvistine" = SKIN_COLOR_SHALVISTINE,
-		"Lalvestine" = SKIN_COLOR_LALVESTINE,
-		"Ebon" = SKIN_COLOR_EBON,
+		"Heartfell" = SKIN_COLOR_OTAVA,
+		"Highlander" = SKIN_COLOR_ETRUSCA,
+		"Moravian" = SKIN_COLOR_GRONN,
+		"Forester" = SKIN_COLOR_GIZA,
+		"Zybantine" = SKIN_COLOR_SHALVISTINE,
+		"Merkite" = SKIN_COLOR_LALVESTINE,
+		"Valorian" = SKIN_COLOR_EBON,
 	)
 
 /datum/species/human/northern/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -44,8 +44,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = -1, "intelligence" = 0, "constitution" = 0, "endurance" = 2, "speed" = 0, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 0, "constitution" = 0, "endurance" = 3, "speed" = 0, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = -1, "intelligence" = 1, "constitution" = 0, "endurance" = 1, "speed" = 0, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 0, "intelligence" = 1, "constitution" = 0, "endurance" = 2, "speed" = 0, "fortune" = 0)
 	enflamed_icon = "widefire"
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -44,8 +44,8 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = 0, "intelligence" = 1, "constitution" = -1, "endurance" = 1, "speed" = 0, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = 1, "intelligence" = 1, "constitution" = -1, "endurance" = 2, "speed" = 0, "fortune" = 0)
+	specstats = list("strength" = 0, "perception" = 1, "intelligence" = 1, "constitution" = -1, "endurance" = -1, "speed" = 1, "fortune" = -1)
+	specstats_f = list("strength" = -1, "perception" = 1, "intelligence" = 1, "constitution" = -2, "endurance" = 0, "speed" = 2, "fortune" = -1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -5,15 +5,15 @@
 	name = "Half-Elf"
 	id = "helf"
 	desc = "<b>Half Elf</b><br>\
-	The child of an Elf and Humen, Half-Elves are generally frowned \
-	upon by more conservative peoples, although as racial tensions lower, \
-	more and more half-elves are being born. To the point that some scholars \
-	worry that someday, it may be impossible to distinguish the two species. \
-	Half-Elves are extremely diverse, as they bring in human and elvish culture\
-	and it is widely considered that Half-Elf culture is simply a melting pot of \
-	various other cultures condensing into one vibrant entity. \
-	Due to their heritage, Half-Elves tend to gain racial traits depending on how strong their fathers, or mothers, genes were. \
-	Half-Elves also typically try to find identity in one of two regions they have similarities towards."
+	Any Humen with a portion of elven blood is considered a Half-Elf. \
+	They inherit the grace and fairy features of elven-kind yet often bear a taller and thicker body more akin to a Humen.<br>\
+	Whether a Half-Elf resides with Humens or Elves affects how they age. \
+	Half-Elves living in the home of the Elves are said to be nearly indistinguishable from their Elven kin and enjoy the eternal youth of a full-blooded Elf. \
+	Yet most Half-Elves reside in Humen cities and age as Men do.<br>\
+	Half-Elves follow the Divine Pantheon by either Humen or Elven tradition.<br>\
+	<br>\
+	Our bodies bear the flaws and benefits of both Humens and Elves, to a lesser degree. \
+	We quickly learn new skills and run for long distances, but our bodies are frail."
 
 	skin_tone_wording = "Identity"
 	default_color = "FFFFFF"
@@ -44,15 +44,15 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
 		)
-	specstats = list("strength" = 0, "perception" = 1, "intelligence" = 1, "constitution" = -1, "endurance" = -1, "speed" = 1, "fortune" = -1)
-	specstats_f = list("strength" = -1, "perception" = 1, "intelligence" = 1, "constitution" = -2, "endurance" = 0, "speed" = 2, "fortune" = -1)
+	specstats = list("strength" = 0, "perception" = 0, "intelligence" = 1, "constitution" = -1, "endurance" = 1, "speed" = 0, "fortune" = 0)
+	specstats_f = list("strength" = -1, "perception" = 1, "intelligence" = 1, "constitution" = -1, "endurance" = 2, "speed" = 0, "fortune" = 0)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,
 		ORGAN_SLOT_HEART = /obj/item/organ/heart,
 		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs,
 		ORGAN_SLOT_EYES = /obj/item/organ/eyes/halfelf,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears/elfw,
 		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue,
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
@@ -76,11 +76,11 @@
 
 /datum/species/human/halfelf/get_skin_list()
 	return list(
-		"Timber-Gronn" = SKIN_COLOR_TIMBER_GRONN,
-		"Giza-Azure" = SKIN_COLOR_GIZA_AZURE,
-		"Walnut-Stine" = SKIN_COLOR_WALNUT_STINE,
-		"Etrustcan-Dandelion" = SKIN_COLOR_ETRUSTCAN_DANDELION,
-		"Ebon-Born" = SKIN_COLOR_EBON_BORN,
+		"Frost-Scion" = SKIN_COLOR_TIMBER_GRONN,
+		"Shade-Forester" = SKIN_COLOR_GIZA_AZURE,
+		"Fable-Hoft" = SKIN_COLOR_WALNUT_STINE,
+		"Zybantine-Nevor" = SKIN_COLOR_ETRUSTCAN_DANDELION,
+		"Valorian-Born" = SKIN_COLOR_EBON_BORN,
 	)
 
 /datum/species/human/halfelf/get_hairc_list()


### PR DESCRIPTION
Let's get racial.

## About The Pull Request

Adjusts the lore of Humens, Elves, Half-Elves, Wild-Kin, and Half-Kin to match our setting. Racial descriptions for these races have been changed.

Humen & Half-Kin ancestries have been changed to: Frostlander, Umberite, Grenzelhoft, Rockhill, Heartfell, Highlander, Moravian, Forester, Zybantine, Merkite, and Valorian.

Elf tribal identities have been changed to: Snow Scion, Shadewood, Emberfall, Vandendor, Fablefield, Nevor, Merkite, and Weso.

Half-Elf identities have been changed to: Frost-Scion, Shade-Forester, Fable-Hoft, Zybantine-Nevor, and Valorian-Born.

Wild-Kin now have selectable habitat identities! These are: the Grand Forest, the Crimson lands, the Terrorbog, the Highlands, the Western Mountains, the Frostlands, the Unknown Lands, the Valorian Deserts, and the Eastern Plains.
These all correlate to areas on our world map and allow for further customization!

## Why It's Good For The Game

Brings our lore into the game itself! Epic!