### PR TITLE
Inquisitors Can Be Any of the Ten Now

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/church/puritan.dm
@@ -18,8 +18,8 @@
 		/datum/patron/divine/xylix,
 		/datum/patron/divine/pestra,
 		/datum/patron/divine/malum,
-	) //gets set to old god anyways
-	tutorial = "As an Inquisitor, the Queen has emboldened your radical sect to root out cultists and the cursed night beasts, using your practice of extracting involuntary 'sin confessions' as a guise to spy on the local populace. Witch Hunters are hired for their extreme paranoia and religious fervor."
+	)
+	tutorial = "As an Inquisitor you represent a more radical sect of the Church, using your practice of extracting involuntary 'sin confessions' as a method of rooting out heretics and heathens alike. Witch Hunters are hired for their extreme paranoia and religious fervor."	
 	whitelist_req = TRUE
 
 	outfit = /datum/outfit/job/roguetown/puritan
@@ -40,7 +40,6 @@
 /datum/outfit/job/roguetown/puritan
 	name = "Inquisitor"
 	jobtype = /datum/job/roguetown/puritan
-	allowed_patrons = list(/datum/patron/old_god)
 
 /datum/outfit/job/roguetown/puritan/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Allows Inquisitors to worship any one of the Ten, now. This is more accurate to our lore. It also makes the tutorial text actually tell people what they are now instead of referencing an indeterminate "queen".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This just makes the code allow for what was intended for in the lore. Inquisitors are part of the church here, not outsiders who are imposing themselves upon the community. This will also allow the Priest to better utilize them as a tool.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
