### PR TITLE
Xylix Miracles + Acolytes of the Ten for future expansion

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -165,3 +165,15 @@
 /atom/movable/screen/alert/status_effect/buff/vitae
 	name = "Invigorated"
 	desc = "I have supped on the finest of delicacies: life!"
+
+
+/datum/status_effect/buff/Speedy
+	id = "Speedy"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/Speedy
+	effectedstats = list("strength" = -3, "speed" = 3)
+	duration = 1 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/Speedy
+	name = "Speedy"
+	desc = "Must go faster!"
+	icon_state = "muscles"

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -20,7 +20,7 @@
 /datum/outfit/job/roguetown/monk
 	name = "Acolyte"
 	jobtype = /datum/job/roguetown/monk
-	allowed_patrons = ALL_DIVINE_PATRONS //Eora content from Stonekeep
+	allowed_patrons = ALL_DIVINE_PATRONS
 
 /datum/outfit/job/roguetown/monk/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 4
 
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = ALL_ACOLYTE_PATRONS
+	allowed_patrons = ALL_DIVINE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/monk
 	tutorial = "Chores, some more chores- Even more chores.. Oh how the life of a humble cleric is exhausting… You have faith, but even you know you gave up a life of adventure for that of the security in the Church. Assist the Priest in their daily tasks, maybe today will be the day something interesting happens."
@@ -20,7 +20,7 @@
 /datum/outfit/job/roguetown/monk
 	name = "Acolyte"
 	jobtype = /datum/job/roguetown/monk
-	allowed_patrons = list(/datum/patron/divine/pestra, /datum/patron/divine/astrata, /datum/patron/divine/eora) //Eora content from Stonekeep
+	allowed_patrons = ALL_DIVINE_PATRONS //Eora content from Stonekeep
 
 /datum/outfit/job/roguetown/monk/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -64,11 +64,10 @@
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
 		else
-			head = /obj/item/clothing/head/roguetown/roguehood/astrata
-			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
-			wrists = /obj/item/clothing/wrists/roguetown/wrappings
+			head = /obj/item/clothing/head/roguetown/roguehood
+			neck = /obj/item/clothing/neck/roguetown/psicross
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
+			armor = /obj/item/clothing/suit/roguetown/shirt/robe
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -49,9 +49,9 @@
 
 /obj/effect/proc_holder/spell/invoked/Laughing_god/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
-		if(prob(85))
+		if(prob(75))
 			var/mob/living/target = targets[1]
-			var/giggle_to_public = pick("[target] giggles!", "[target] struggles to not chuckle!", "[target] starts to laugh!", "[target]' frowns, as if they don't get the joke")
+			var/giggle_to_public = pick("[target] giggles!", "[target] struggles to not chuckle!", "[target] starts to laugh!", "[target] frowns, as if they don't get the joke")
 			var/giggle_to_target = pick("That is so funny!", "You start to giggle!", "Your mouth turns upwards in a smile!", "What a horrible thing to say...")
 			target.visible_message(span_warning("[giggle_to_public]"), span_warning("[giggle_to_target]"))
 			target.Stun(10)
@@ -60,7 +60,7 @@
 				target.emote(pick("giggle","laugh","chuckle"))
 		else 
 			user.Stun(40) 
-			user.visible_message(span_user(Looks like I'm the fool..."))
+			user.visible_message(span_userdanger("Looks like I am the fool..."))
 
 
 /obj/effect/proc_holder/spell/invoked/Smokebomb

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -1,0 +1,91 @@
+// Xylixan
+/obj/effect/proc_holder/spell/invoked/Joy_takes_flight
+	name = "Joy takes flight"
+	overlay_state = "Joy Takes Flight"
+	releasedrain = 30
+	chargedrain = 0
+	chargetime = 0
+	range = 0
+	warnie = "sydwarning"
+	movement_interrupt = FALSE
+	chargedloop = null
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/magic/heal.ogg'
+	invocation = "My trick is done, I'll speed from sight! I'll move so fast that joy takes flight!"
+	invocation_type = "shout"
+	associated_skill = /datum/skill/magic/holy
+	antimagic_allowed = TRUE
+	charge_max = 5 SECONDS
+	miracle = TRUE
+	devotion_cost = 30
+
+/obj/effect/proc_holder/spell/invoked/Joy_takes_flight/cast(list/targets, mob/living/user)
+	if(isliving(targets[1]))
+		var/mob/living/carbon/target = targets[1]
+		target.apply_status_effect(/datum/status_effect/buff/Speedy)
+		target.visible_message("<span class='info'>The feet of [target] begin to glow gold!</span>", "<span class='notice'>I feel much faster.</span>")
+		return TRUE
+	return FALSE
+
+/obj/effect/proc_holder/spell/invoked/Laughing_god
+	name = "Laughing god"
+	desc = ""
+	overlay_state = "Laughing God"
+	releasedrain = 30
+	chargedrain = 0
+	chargetime = 0
+	range = 5
+	warnie = "sydwarning"
+	movement_interrupt = FALSE
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/magic/heal.ogg'
+	invocation = "The Trickster skirts the edges of the rule, whilst witless louts are made to act the fool!"
+	invocation_type = "shout"
+	associated_skill = /datum/skill/magic/holy
+	antimagic_allowed = TRUE
+	charge_max = 10 SECONDS
+	miracle = TRUE
+	devotion_cost = 30
+
+/obj/effect/proc_holder/spell/invoked/Laughing_god/cast(list/targets, mob/living/user)
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		var/giggle_to_public = pick("[target] giggles!", "[target] struggles to not chuckle!", "[target] starts to laugh!", "[target]' frowns, as if they don't get the joke")
+		var/giggle_to_target = pick("That is so funny!", "You start to giggle!", "Your mouth turns upwards in a smile!", "What a horrible thing to say...")
+		target.visible_message(span_warning("[giggle_to_public]"), span_warning("[giggle_to_target]"))
+		target.Stun(10)
+		target.Jitter(rand(5))
+		if(prob(66))
+			target.emote(pick("giggle","laugh","chuckle"))
+
+
+/obj/effect/proc_holder/spell/invoked/Smokebomb
+	name = "Smoke Bomb"
+	overlay_state = "Smoke Bomb"
+	releasedrain = 30
+	chargedrain = 0
+	chargetime = 0
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	charge_max = 30 SECONDS
+	range = 0
+	warnie = "sydwarning"
+	movement_interrupt = FALSE
+	invocation = "The Trickster is a clever chap, it's time to hide under his cap!"
+	invocation_type = "whisper"
+	sound = 'sound/misc/area.ogg'
+	associated_skill = /datum/skill/magic/holy
+	antimagic_allowed = TRUE
+	miracle = TRUE
+	devotion_cost = 25
+
+/obj/effect/proc_holder/spell/invoked/Smokebomb/cast(list/targets, mob/living/user)
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(target.anti_magic_check(TRUE, TRUE))
+			return FALSE
+		target.visible_message(span_warning("[target] vanishes in a puff of smoke!"), span_notice("You vanish in a puff of smoke!"))
+		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
+		target.mob_timers[MT_INVISIBILITY] = world.time + 25 SECONDS
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), 25 SECONDS)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), 25 SECONDS)
+	return FALSE

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -10,7 +10,7 @@
 	movement_interrupt = FALSE
 	chargedloop = null
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	sound = 'sound/magic/heal.ogg'
+	sound = 'sound/magic/webspin.ogg'
 	invocation = "My trick is done, I'll speed from sight! I'll move so fast that joy takes flight!"
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
@@ -33,12 +33,12 @@
 	overlay_state = "Laughing God"
 	releasedrain = 30
 	chargedrain = 0
-	chargetime = 0
+	chargetime = 5
 	range = 5
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	sound = 'sound/magic/heal.ogg'
+	sound = 'sound/magic/webspin.ogg'
 	invocation = "The Trickster skirts the edges of the rule, whilst witless louts are made to act the fool!"
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
@@ -49,14 +49,18 @@
 
 /obj/effect/proc_holder/spell/invoked/Laughing_god/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
-		var/mob/living/target = targets[1]
-		var/giggle_to_public = pick("[target] giggles!", "[target] struggles to not chuckle!", "[target] starts to laugh!", "[target]' frowns, as if they don't get the joke")
-		var/giggle_to_target = pick("That is so funny!", "You start to giggle!", "Your mouth turns upwards in a smile!", "What a horrible thing to say...")
-		target.visible_message(span_warning("[giggle_to_public]"), span_warning("[giggle_to_target]"))
-		target.Stun(10)
-		target.Jitter(rand(5))
-		if(prob(66))
-			target.emote(pick("giggle","laugh","chuckle"))
+		if(prob(85))
+			var/mob/living/target = targets[1]
+			var/giggle_to_public = pick("[target] giggles!", "[target] struggles to not chuckle!", "[target] starts to laugh!", "[target]' frowns, as if they don't get the joke")
+			var/giggle_to_target = pick("That is so funny!", "You start to giggle!", "Your mouth turns upwards in a smile!", "What a horrible thing to say...")
+			target.visible_message(span_warning("[giggle_to_public]"), span_warning("[giggle_to_target]"))
+			target.Stun(10)
+			target.Jitter(rand(5))
+			if(prob(66))
+				target.emote(pick("giggle","laugh","chuckle"))
+		else 
+			user.Stun(40) 
+			user.visible_message(span_user(Looks like I'm the fool..."))
 
 
 /obj/effect/proc_holder/spell/invoked/Smokebomb
@@ -76,7 +80,7 @@
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	miracle = TRUE
-	devotion_cost = 25
+	devotion_cost = 40
 
 /obj/effect/proc_holder/spell/invoked/Smokebomb/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
@@ -85,7 +89,7 @@
 			return FALSE
 		target.visible_message(span_warning("[target] vanishes in a puff of smoke!"), span_notice("You vanish in a puff of smoke!"))
 		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
-		target.mob_timers[MT_INVISIBILITY] = world.time + 25 SECONDS
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), 25 SECONDS)
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), 25 SECONDS)
+		target.mob_timers[MT_INVISIBILITY] = world.time + 20 SECONDS
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), 20 SECONDS)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), 20 SECONDS)
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR adds three miracles for Xylix, a T1, T2, and T3 miracle.

T1: Joy Takes Flight: This spell is made to get the actual fuck out of dodge. It decreases your strength by 3, but gives you +3 speed. This spell is self-target only.

T2: The Laughing God: This spell stuns a target temporarily by causing them to laugh. It is similar to Eora's curse, without the sexual aspect. A relatively short range, of only 5 tiles, does stop you from cross-map stunning people.

T3: Smoke bomb: Why does Noc get the invisibility? This spell is a longer invisibility, self-cast only, giving you 25 seconds of chaos and freedom!


In addition, this also allows Acolytes of all of the Divine Pantheon, to set up for future spells to be added.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For quite a while, I have hoped for Xylix Acolytes to actually be playable. Unfortunately, without actual spells, they're just a churchling with extra devotion and different skills. Put simply, this takes them from "A really bad acolyte" to an acolyte with their own varied spells. In terms of healing, it does not truly help, but it adds more depth to any acolyte of Xylix, and gives them new abilities to cause a bit of mischief with.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
