### PR TITLE
Viking Stat Adjusting, Viking Scom Fix, & Streamlining Battleaxe

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -100,11 +100,11 @@
 	item_d_type = "slash"
 
 /datum/intent/axe/chop/battle
-	penfactor = 70
-	damfactor = 1.2 //36 on battleaxe
+	penfactor = 40		//Was 70, 40 is near-equal to spear. This is same pen as an arrow basically; be greatful.
+	damfactor = 1.2 	//36 base damage on battleaxe; scales with strength.
 
 /datum/intent/axe/cut/battle
-	penfactor = 30
+	penfactor = 30		//10 less than chop, and 0.2 less damage than chop. But less stamina cost.
 
 /obj/item/rogueweapon/stoneaxe/battle
 	force = 25

--- a/code/modules/jobs/job_types/roguetown/viking/highking.dm
+++ b/code/modules/jobs/job_types/roguetown/viking/highking.dm
@@ -9,6 +9,7 @@
 	spawn_positions = 1
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
+	show_in_credits = FALSE		//Stops Scom from announcing their arrival.
 	allowed_patrons = list(/datum/patron/inhumen/graggar)
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/viking)
 	tutorial = "Hailing from the freezing cold Frost Lands, you lead your warband to its newest prize, Rockhill. Graggar's bloodlust must be sated. Topple the statues of the southerner's weak gods, burn their churches, take their valuables and take them as slaves so that they might be sacrificed to Graggar. May the black sun darken the sky for all time!"
@@ -59,12 +60,12 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/butchering, 3, TRUE)
 
-		H.change_stat("strength", 4)
+		H.change_stat("strength", 4)		//Same as heavy royal guard; highest of normal roles in game.
 		H.change_stat("intelligence", -2)
-		H.change_stat("constitution", 4)
+		H.change_stat("constitution", 4)	//Fucking strong; maybe consider toning down if too much still.
 		H.change_stat("endurance", 3)
 		H.change_stat("speed", -2)
-
+	
 /obj/effect/proc_holder/spell/self/convertrole/viking
 	name = "Recruit Thrall"
 	new_role = "Graggarite Thrall"

--- a/code/modules/jobs/job_types/roguetown/viking/vikingfarmer.dm
+++ b/code/modules/jobs/job_types/roguetown/viking/vikingfarmer.dm
@@ -9,6 +9,7 @@
 	spawn_positions = 2
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
+	show_in_credits = FALSE		//Stops Scom from announcing their arrival.
 
 	tutorial = "You have likely seen the brutality of the Northmen firsthand. Put aside any notion of rescue, and serve the warband well. You know they sacrifice slaves to their twisted god, Graggar, so try and at least appear somewhat useful for the cruel pillagers, tend the farm, and try not to draw too much attention."
 	whitelist_req = FALSE

--- a/code/modules/jobs/job_types/roguetown/viking/vikinggrunt.dm
+++ b/code/modules/jobs/job_types/roguetown/viking/vikinggrunt.dm
@@ -9,6 +9,7 @@
 	spawn_positions = 3
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
+	show_in_credits = FALSE		//Stops Scom from announcing their arrival.
 	allowed_patrons = list(/datum/patron/inhumen/graggar)
 	tutorial = "A hardened warrior from the Frost Lands. Follow the leader of your warband, and serve Graggar well. May the black sun darken the sky for all time!"
 	whitelist_req = FALSE
@@ -58,10 +59,10 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/butchering, 3, TRUE)
 
-		H.change_stat("strength", 4)
+		H.change_stat("strength", 3)		//Same as captain.
 		H.change_stat("intelligence", -2)
-		H.change_stat("constitution", 4)
+		H.change_stat("constitution", 3)
 		H.change_stat("endurance", 3)
-		H.change_stat("speed", -2)
+		H.change_stat("speed", -2)			
 
 

--- a/code/modules/jobs/job_types/roguetown/viking/vikinggrunt.dm
+++ b/code/modules/jobs/job_types/roguetown/viking/vikinggrunt.dm
@@ -46,7 +46,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2 , TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3 , TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

So, was asked to do this by both staff and players and Apple said they'd merge if I did a brief re-balance for the Viking roles. Also, fixed an error with Scoms announcing Viking's arrival, easy change. Did it the same way as adventurers, since we don't use end-game credits anyway. 

So, the list:
- Lowered Battleaxe armor pen on Chop from 70 to 40. Cut is 30, and chop already gives 1.2 extra bonus damage modifier. That's still pretty damn good, half the pen of a dagger but over double the damage. Hell, spears have only 50 AP as do crossbows. And the spear has far lower damage, and crossbow has a reload time and delay. You'll live fine with this.
- Lowered Viking base skills from 4 strength and 4 con to 3 in each; streamlines them as equal to Captain's stats. Left the Viking king with their +4 strength and con, I'm iffy on it but whatever it's a solo leadership role and the heavy knight in the royal guard gets +1 strength. It seems OK for now.
- Fixed Scoms, they no longer announce viking role arrivals.

To note: I do think these stats are still strong, but I think it's.. miiiildly better, I think the battle axe nerf does the heavy-lifting required to make the roles less strong.

But keep in mind:
- Strength determines grappling (strength modified by skill) as well as extra damage on top of whatever the weapon's base damage is.
- Constitution impacts your **entire** body's limb health. So, at higher limb health's, you can take a huge beating before the limb breaks or the like. This is still pretty high, even compared to other roles, but I guess it's fine.

Other fixes are being done by W, this just fixes the balancing end of it. I may look at their armor starting stuff in the future; but this works for now fine.

## Why It's Good For The Game

Overall vikings were overly powerful; I still think they're pretty damn powerful with these changes but less-so as now they are basically mini-Captains instead of ultra-chad heavy knights with a the 'i kill everyone equally' weapon. Battle-axe is still great honestly, but it doesn't flat near ignore armor now. Instead it's basically still better than any other axe, and objectively still an amazing weapon if you have axe skill, but it's far more fair now that heavy armors aren't just butter for it.

Also, stats were needed. Statpaks were letting EVERY viking roll up to 19 strength if you min-maxed. This is still gonna be a mild issue but at least regular beserkers can, at best, get 18 now if they powergame min-max. 17 if the cope PR Gets merged.
