### PR TITLE
points fertility code at another sexcon

### DIFF
--- a/code/datums/sexcon/sexcon_helpers.dm
+++ b/code/datums/sexcon/sexcon_helpers.dm
@@ -71,7 +71,8 @@
 	var/obj/item/organ/vagina/vag = wife.getorganslot(ORGAN_SLOT_VAGINA)
 	if(!vag)
 		return
-	if(prob(25))
+	if(prob(25) && wife.is_fertile() && is_virile())
+	//This is the correct one used by the game. There's another sexcon that's not included in the DME. I'm stupid. - Kyo
 		vag.be_impregnated(src)
 
 /mob/living/carbon/human/proc/get_highest_grab_state_on(mob/living/carbon/human/victim)


### PR DESCRIPTION
Points my fertility adjustments to the correct sexcon helper as per Sigma Predator's direction. I've learned a lot more about Byond's filestructure from this single thing.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Properly points to the correct sexcon used by the game. "Sigma Predator" from the discord caught this while porting it to another server.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Properly does what I planned with my first PR. It's funny how I never failed the roll to see if pregnancy works? The universe is ironic. Sorry Apple.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
