### PR TITLE
Eoran Forced-Coom Spell Redone + Love Potion Reworking

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -73,7 +73,7 @@ Slimecrossing Potions
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "lovebottle"
 
-/obj/item/slimepotion/lovepotion/attack(mob/living/M, mob/user)
+/obj/item/slimepotion/lovepotion/attack(list/targets, mob/living/M, mob/user)
 	if(!isliving(M) || M.stat == DEAD)
 		to_chat(user, span_warning("The love potion only works on living things, sicko!"))
 		return ..()
@@ -92,12 +92,28 @@ Slimecrossing Potions
 
 	if(!do_after(user, 50, target = M))
 		return
-	to_chat(user, span_notice("I feed [M] the love potion!"))
-	to_chat(M, span_notice("I develop feelings for [user], and anyone [user.p_they()] like."))
-	if(M.mind)
-		M.mind.store_memory("You are in love with [user].")
-	M.faction |= "[REF(user)]"
-	M.apply_status_effect(STATUS_EFFECT_INLOVE, user)
+
+	var/mob/living/target = targets[1]
+	if(target.client.prefs.sexable == TRUE)		//For enthrallment
+		var/choice = alert(target, "Do you wish to give into the potion?", "", "Yes", "No")
+		switch(choice)
+			//IF YOU CHOOSE YES - YOU ARE ENTHRALLED BY LOVE
+			if("Yes")
+				to_chat(user, span_notice("I feed [M] the love potion!"))
+				to_chat(M, span_notice("I develop feelings for [user], and anyone [user.p_they()] like."))
+				if(M.mind)
+					M.mind.store_memory("You are in love with [user].")
+				M.faction |= "[REF(user)]"
+				M.apply_status_effect(STATUS_EFFECT_INLOVE, user)
+				return TRUE
+			//IF YOU CHOOSE NO - YOU REJECT EFFECTS
+			if("No")
+				to_chat(user, span_notice("[M] rejects the love potion!"))
+				to_chat(M, span_notice("I reject [user] and their desires!"))
+				return TRUE
+	if(target.client.prefs.sexable == FALSE)	//We reject this; non-coomers may not love.....
+		to_chat(user, span_notice("I feed [M] the love potion - but it has no effect!"))
+		to_chat(M, span_notice("[user] fed me the love potion but.. it doesn't appear to have an effect!"))
 	qdel(src)
 
 //Pressure potion - Charged Dark Blue

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -71,17 +71,18 @@
 	miracle = TRUE
 	devotion_cost = 30
 
+//Sex-pest spell; if you have ERP verbs on it lets you treat it as sexual stuff if opt in, otherwise spell of serenity/peace. 
 /obj/effect/proc_holder/spell/invoked/enrapture/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
-		var/enrapture_to_public = pick("[target] shivers uncontrollably!", "[target] struggles to stay standing!", "[target] clutches their chest!", "[target]' eyes glaze over!")
-		var/enrapture_to_target = pick("A thrill runs down your spine!", "Your knees go weak!", "Your heart thrills in euphoria!", "Your imagination runs wild!")
+		var/enrapture_to_public = pick("[target] muscle's visibly slacken!", "[target] appears weak!", "[target] freezes in place!", "[target]' eyes glaze over!")
+		var/enrapture_to_target = pick("You feel a wave of serenity gloss over you!", "You feel.. at ease, why fight?", "You feel relaxed, your muscles soothed.. you can't move!")
 		target.visible_message(span_warning("[enrapture_to_public]"), span_warning("[enrapture_to_target]"))
 		target.Stun(rand(20))
 		target.Jitter(20)
 		target.add_stress(/datum/stressevent/enrapture)
 		if(prob(33))
-			target.emote(pick("twitch","drool","moan"))
+			target.emote(pick("twitch","shiver"))
 		//LEWD PART WORKS ON NYMPOMANIACS ONLY
 		if(user.has_flaw(/datum/charflaw/addiction/lovefiend))
 			target.sate_addiction()
@@ -105,4 +106,4 @@
 /datum/stressevent/enrapture
 	timer = 5 MINUTES
 	stressadd = -5
-	desc = "<span class='green'>I felt Eora's love.</span>"
+	desc = "<span class='green'>I felt Eora's serentity.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Redoes Eoran forced orgasm spell to not just look like it's giving a user an orgasm regardless of their choice, instead it's serenity and relaxation; that you can merely choose to accept if you want. So it's not SA at a range.

And redid the love potion to span a message to accept or deny, because as-of current you could force people to drink it and become enthralled given this is literally a base TG xeno-bio potion and not a Roguetown unique one. 

If you have ERP panel, you get accept/decline choice, if you don't, it auto-declines.

## Why It's Good For The Game

The Eoran spell is relatively creepy that you can just make people forcefully orgasm; given if anyone sees you hit by it it's relatively clear you are literally twitching, moaning, or the like - along with the message it spans. Instead now it's a wave of serenity, implying a wave of peaceful relaxation - which is far less creepy.

Also, love potion would easily be abused if it was more readily available without this change.