### PR TITLE
Adventurer Limit

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = -1
-	spawn_positions = -1
+	total_positions = 20
+	spawn_positions = 20
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Hero of nothing, adventurer by trade. Whatever led you to this fate is up to the wind to decide, and you've never fancied yourself for much other than the thrill. Someday your pride is going to catch up to you, and you're going to find out why most men don't end up in the annals of history."
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
@@ -13,7 +13,7 @@
 	bypass_lastclass = TRUE
 	bypass_jobban = FALSE
 
-	advclass_cat_rolls = list(CTAG_PILGRIM = 20, CTAG_ADVENTURER = 5)	//Get some adventurer options sometimes. 
+	advclass_cat_rolls = list(CTAG_PILGRIM = 20, CTAG_ADVENTURER = 3)	//Get some adventurer options sometimes. 
 	PQ_boost_divider = 10
 
 	display_order = JDO_PILGRIM

--- a/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
@@ -13,7 +13,7 @@
 	bypass_lastclass = TRUE
 	bypass_jobban = FALSE
 
-	advclass_cat_rolls = list(CTAG_PILGRIM = 20, CTAG_ADVENTURER = 20)
+	advclass_cat_rolls = list(CTAG_PILGRIM = 20, CTAG_ADVENTURER = 5)	//Get some adventurer options sometimes. 
 	PQ_boost_divider = 10
 
 	display_order = JDO_PILGRIM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Sets limit on adventurer at 20. Got asked by people to set it to old 8 or 10 like OG Roguetown, others 15, etc. I just standardized it to what it was before the limit was removed on Blackstone, which they also reverted to, which is 20.

Staff asked for this, players asked for this, idk why this change was ever done in the first place to remove the cap. Ratwood went back to 20 adventurers, Blackstone went back to 20 adventurers, etc. It was determined near universally that a healthy server for roleplay and jobs needs an adventurer cap. (..Shown that we hit 40 adventurers during a round on only ~60-70 people..)

Pilgrim remains unlimited, which has a very small handful of classes capable of combat, but they are oriented towards trade and skills rather than combat. Hopefully these roles may see a bit more use if adventurer caps out as you can do hunter work, wood cutter work, etc and still easily fit into a similar category. 

**Also, note:** Pilgrims can get adventurer combat classes as rare pick options; your PQ actually does seem to effect this if you have 5+ PQ. I believe it's the PQ divider chance that Blackstone added and was left in code.

## Why It's Good For The Game

Encourages people to play other roles other than adventurer. Late spawn adventurer types can still be spawned over the limit from my knowledge via migration tab, but you'll have to wait and see what roles its offering in migrant waves. So, it's a toss-up if you get adventurer, pilgrim, heartfelt, traveling band, or such.
