### PR TITLE
Sleeping on beds does not require buckling.

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -37,7 +37,15 @@
 
 		//Healing while sleeping in a bed
 		if(IsSleeping())
-			var/sleepy_mod = buckled?.sleepy || 0.5
+			//Hearthstone change - beds need no buckle.
+			var/sleepy_mod = 0.5
+			if(buckled?.sleepy)
+				sleepy_mod = buckled.sleepy
+			else if(isturf(loc)) //No illegal tech.
+				var/obj/structure/bed/rogue/bed = locate() in loc
+				if(bed)
+					sleepy_mod = bed.sleepy
+			//Hearthstone end.
 			var/yess = HAS_TRAIT(src, TRAIT_NOHUNGER)
 			if(nutrition > 0 || yess)
 				rogstam_add(sleepy_mod * 15)
@@ -59,7 +67,16 @@
 					Sleeping(300)
 		else if(!IsSleeping() && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 			// Resting on a bed or something
+			//Hearthstone change - beds don't need buckles.
+			var/sleepy_mod = 0
 			if(buckled?.sleepy)
+				sleepy_mod = buckled.sleepy
+			else if(isturf(loc) && !(mobility_flags & MOBILITY_STAND))
+				var/obj/structure/bed/rogue/bed = locate() in loc
+				if(bed)
+					sleepy_mod = bed.sleepy
+			if(sleepy_mod > 0)
+			//Hearthstone end.
 				if(eyesclosed)
 					if(!fallingas)
 						to_chat(src, span_warning("I'll fall asleep soon..."))
@@ -67,7 +84,7 @@
 					if(fallingas > 15)
 						Sleeping(300)
 				else
-					rogstam_add(buckled.sleepy * 10)
+					rogstam_add(sleepy_mod * 10)
 			// Resting on the ground (not sleeping or with eyes closed and about to fall asleep)
 			else if(!(mobility_flags & MOBILITY_STAND))
 				if(eyesclosed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Title. Permits beds (and subtypes of beds) to be used without buckling to them (though obviously you have to be prone anyways).
This, by extension, permits multiple people to sleep on the same (normal) bed without only one receiving the benefits.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone wanted this and I don't really see much of an issue with it, given if you can make one bed, making more is fairly trivial.

Worst case if it gets abused (somehow??) I can just implement a rest effectiveness falloff.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
