### PR TITLE
fixes extract_lux.dm warning

### DIFF
--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -45,6 +45,6 @@
 		display_results(user, target, span_notice("You extract a single dose of lux from [target]'s heart."),
 			"[user] extracts lux from [target]'s innards.",
 			"[user] extracts lux from [target]'s innards.")
-		var/obj/item/reagent_containers/lux/L = new /obj/item/reagent_containers/lux(target.loc)
+		new /obj/item/reagent_containers/lux(target.loc)
 		target.apply_status_effect(/datum/status_effect/debuff/devitalised)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

changes one line of extract_lux.dm to not use an unnecessary variable, removing the warning caused

## Why It's Good For The Game

clean code is good
