### PR TITLE
Apple's Vampire Expansion DLC

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -3964,7 +3964,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "cxW" = (
-/mob/living/simple_animal/hostile/rogue/wraith/wraith3,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
 "cyr" = (
@@ -5350,7 +5350,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "dzx" = (
-/mob/living/simple_animal/hostile/rogue/wraith/wraith2,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith2,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
 "dzz" = (
@@ -6574,7 +6574,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/vikingarea)
 "etS" = (
-/mob/living/simple_animal/hostile/rogue/wraith,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "eug" = (
@@ -6831,7 +6831,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
 "eFg" = (
-/mob/living/simple_animal/hostile/rogue/wraith/wraith2,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith2,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/vikingarea)
 "eFl" = (
@@ -8266,7 +8266,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "fNw" = (
-/mob/living/simple_animal/hostile/rogue/wraith,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
 "fNz" = (
@@ -9491,7 +9491,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "gNc" = (
-/mob/living/simple_animal/hostile/rogue/wraith/wraith3,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "gNg" = (
@@ -10376,7 +10376,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
 "hpO" = (
-/mob/living/simple_animal/hostile/rogue/wraith,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/vikingarea)
 "hpT" = (
@@ -12189,6 +12189,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"iNk" = (
+/obj/structure/bed/rogue/inn/hay,
+/obj/effect/landmark/start/vampthrall,
+/obj/effect/landmark/start/vampthralllate,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors)
 "iNu" = (
 /obj/structure/bars/passage/shutter/open,
 /obj/structure/bars/pipe,
@@ -13801,7 +13807,7 @@
 	},
 /area/rogue/indoors/town/tavern)
 "kaD" = (
-/mob/living/simple_animal/hostile/rogue/wraith,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "kaG" = (
@@ -17455,7 +17461,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "neg" = (
-/mob/living/simple_animal/hostile/rogue/wraith/wraith3,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
 "ner" = (
@@ -20575,7 +20581,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "puq" = (
-/mob/living/simple_animal/hostile/rogue/wraith,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
 "pur" = (
@@ -25265,6 +25271,8 @@
 "sYM" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/stick,
+/obj/effect/landmark/start/vampthrall,
+/obj/effect/landmark/start/vampthralllate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "sYY" = (
@@ -31696,7 +31704,7 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
 "xXd" = (
-/mob/living/simple_animal/hostile/rogue/wraith/wraith3,
+/mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
 "xXq" = (
@@ -325395,9 +325403,9 @@ sYx
 cyr
 xou
 xou
-pbJ
+iNk
 iBJ
-pbJ
+iNk
 iXc
 xkI
 xou
@@ -326603,7 +326611,7 @@ vqq
 tWR
 sYM
 fAB
-pbJ
+iNk
 aFY
 pbJ
 fel

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -201,7 +201,11 @@
 #define VIKINGFARMER	(1<<1)
 #define VIKINGGRUNT	(1<<1)
 
-#define SLOP		(1<<10)
+#define VAMPIRE		(1<<10)
+#define VAMPTHRALL	(1<<0)
+#define VAMPSMITH	(1<<1)
+
+#define SLOP		(1<<11)
 
 #define TESTER		(1<<0)
 #define DEATHKNIGHT (1<<1)
@@ -308,3 +312,6 @@
 #define JDO_HIGHKING 42
 #define JDO_VIKINGFARMER 43
 #define JDO_VIKINGGRUNT 44
+
+#define JDO_VAMPTHRALL 45
+#define JDO_VAMPSMITH 46

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -484,7 +484,28 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 	jobspawn_override = list("Northmen Berserkir")
 	delete_after_roundstart = FALSE
-	
+
+//Vampire Additions
+
+/obj/effect/landmark/start/vampthrall
+	name = "Vampire Thrall"
+	icon_state = "arrow"
+
+/obj/effect/landmark/start/vampthralllate
+	name = "Vampirethralllate"
+	icon_state = "arrow"
+	jobspawn_override = list("Vampire Thrall")
+	delete_after_roundstart = FALSE
+
+/obj/effect/landmark/start/vampsmith
+	name = "Vampire Smith"
+	icon_state = "arrow"
+
+/obj/effect/landmark/start/vampsmithlate
+	name = "vampsmitelate"
+	icon_state = "arrow"
+	jobspawn_override = list("Vampire Smith")
+	delete_after_roundstart = FALSE
 
 // START LANDMARKS FOLLOW. Don't change the names unless
 // you are refactoring shitty landmark code.

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /mob/living/carbon/human/proc/spawn_pick_class()
 	var/list/classoptions = list("Bard", "Fisher", "Hunter", "Miner", "Peasant", "Woodcutter", "Cheesemaker", "Blacksmith", "Carpenter", "Rogue", "Treasure Hunter", "Mage")
-	var/list/visoptions = list()
+	var/list/visoptions = list("Bard", "Fisher", "Hunter", "Miner", "Peasant", "Woodcutter", "Cheesemaker", "Blacksmith", "Carpenter", "Rogue", "Treasure Hunter", "Mage") //enables all choices for vampire spawn
 
 	for(var/T in 1 to 5)
 		var/picked = pick(classoptions)

--- a/code/modules/jobs/job_types/roguetown/vampire/vampsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/vampire/vampsmith.dm
@@ -1,0 +1,60 @@
+/datum/job/roguetown/vampire/vampsmith
+	title = "Vampire Smith"
+	flag = VAMPSMITH
+	department_flag = VAMPIRE
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	show_in_credits = FALSE		//Stops Scom from announcing their arrival.
+	spells = list(/obj/effect/proc_holder/spell/self/convertrole/vampire,
+	/obj/effect/proc_holder/spell/targeted/shapeshift/bat)
+	tutorial = "You studied for many decades under your master with a few other apprentices to become an Armorer, a trade that certainly has seen a boom in revenue in recent times with many a bannerlord seeing the importance in maintaining a well-equipped army."
+	whitelist_req = FALSE
+	outfit = /datum/outfit/job/roguetown/vampsmith
+	display_order = JDO_VAMPSMITH
+	min_pq = 0
+	max_pq = null
+	cmode_music = 'sound/music/combat_vamp.ogg'
+
+/datum/outfit/job/roguetown/vampsmith/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/hatfur
+	if(prob(50))
+		head = /obj/item/clothing/head/roguetown/hatblu
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/blacksmithing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/smelting, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
+		
+	if(H.gender == MALE)
+		pants = /obj/item/clothing/under/roguetown/trou
+		shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
+		backr = /obj/item/storage/backpack/rogue/satchel
+		backpack_contents = list(/obj/item/rogueweapon/hammer = 1, /obj/item/rogueweapon/tongs = 1)
+		belt = /obj/item/storage/belt/rogue/leather
+		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+		beltr = /obj/item/roguekey/blacksmith
+		cloak = /obj/item/clothing/cloak/apron/blacksmith
+	else
+		pants = /obj/item/clothing/under/roguetown/trou
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
+		backr = /obj/item/storage/backpack/rogue/satchel
+		backpack_contents = list(/obj/item/rogueweapon/hammer = 1, /obj/item/rogueweapon/tongs = 1)
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		belt = /obj/item/storage/belt/rogue/leather
+		cloak = /obj/item/clothing/cloak/apron/blacksmith
+		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+		beltr = /obj/item/roguekey/blacksmith
+	H.change_stat("strength", 2)
+	H.change_stat("intelligence", 1)
+	H.change_stat("endurance", 2)
+	H.change_stat("constitution", 2)

--- a/code/modules/jobs/job_types/roguetown/vampire/vampthrall.dm
+++ b/code/modules/jobs/job_types/roguetown/vampire/vampthrall.dm
@@ -1,0 +1,72 @@
+/datum/job/roguetown/vampire/vampthrall
+	title = "Vampire Thrall"
+	flag = VAMPTHRALL
+	department_flag = VAMPIRE
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	show_in_credits = FALSE		//Stops Scom from announcing their arrival.
+	spells = list(/obj/effect/proc_holder/spell/self/convertrole/vampire,
+	/obj/effect/proc_holder/spell/targeted/shapeshift/bat)
+	tutorial = "Outcasted from society and under rule of the Vampire Lord, either as a worshipping fanatic or a victim of circumstance, you are caught in the middle of two Lords. You are a lowly peasant who will choose their path in this world. Do you serve your Lord, or will you try to win over your abusors?"
+	whitelist_req = FALSE
+	outfit = /datum/outfit/job/roguetown/vampthrall
+	/* advclass_cat_rolls = list(CTAG_ADVENTURER = 20)
+	PQ_boost_divider = 10 */ //Tried to give them adventure roles, but this doesn't work.
+
+	display_order = JDO_VAMPTHRALL
+	min_pq = 4
+	max_pq = null
+	cmode_music = 'sound/music/combat_vamp.ogg'
+
+/datum/outfit/job/roguetown/vampthrall/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/labor/farming, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
+	belt = /obj/item/storage/belt/rogue/leather/rope
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
+	pants = /obj/item/clothing/under/roguetown/trou
+	head = /obj/item/clothing/head/roguetown/armingcap
+	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+	backr = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/storage/backpack/rogue/backpack/surgery
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	backl = /obj/item/storage/backpack/rogue/satchel
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	armor = /obj/item/clothing/suit/roguetown/armor/workervest
+	mouth = /obj/item/rogueweapon/huntingknife
+	beltr = /obj/item/flint
+	ADD_TRAIT(H, TRAIT_FAITHLESS, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STRONGBITE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOROGSTAM, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOHUNGER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOBREATH, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_TOXIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_VAMPMANSION, TRAIT_GENERIC)
+	H.change_stat("strength", 1)
+	H.change_stat("speed", 2)
+	H.change_stat("intelligence", 2)
+	/*	if(H.mind)
+		var/datum/antagonist/vampire/new_antag = new /datum/antagonist/vampire/lesser()
+		H.mind.add_antag_datum(new_antag) */ // Only gives vampire tab for abilities but completely unfunctional
+
+	
+/obj/effect/proc_holder/spell/self/convertrole/vampire
+	name = "Recruit Ally"
+	new_role = "Vampyre Sympathizer"
+	recruitment_faction = "Vampire"
+	recruitment_message = "Aid our cause, %RECRUIT!"
+	accept_message = "For what is right."
+	refuse_message = "I refuse."

--- a/code/modules/jobs/job_types/roguetown/vampire/vampthrall.dm
+++ b/code/modules/jobs/job_types/roguetown/vampire/vampthrall.dm
@@ -58,9 +58,9 @@
 	H.change_stat("strength", 1)
 	H.change_stat("speed", 2)
 	H.change_stat("intelligence", 2)
-	/*	if(H.mind)
-		var/datum/antagonist/vampire/new_antag = new /datum/antagonist/vampire/lesser()
-		H.mind.add_antag_datum(new_antag) */ // Only gives vampire tab for abilities but completely unfunctional
+	/*if(H.mind)
+		var/datum/antagonist/vampire/new_antag = new /datum/antagonist/vampirelord/lesser()
+		H.mind.add_antag_datum(new_antag) */ //Functional Vampirism
 
 	
 /obj/effect/proc_holder/spell/self/convertrole/vampire

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -175,6 +175,11 @@ GLOBAL_LIST_INIT(viking_positions, list(
 	"Northmen Berserkir"
 ))
 
+GLOBAL_LIST_INIT(vampire_positions, list(
+	"Vampire Thrall",
+	"Vampire Smith"
+))
+
 
 GLOBAL_LIST_INIT(roguefight_positions, list(
 	"Red Captain",

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -593,6 +593,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	omegalist += list(GLOB.apprentices_positions)
 	omegalist += list(GLOB.goblin_positions)
 	omegalist += list(GLOB.viking_positions)
+	omegalist += list(GLOB.vampire_positions)
 
 	if(istype(SSticker.mode, /datum/game_mode/chaosmode))
 		var/datum/game_mode/chaosmode/C = SSticker.mode
@@ -642,6 +643,8 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 					cat_name = "Tribe"
 				if (VIKING)
 					cat_name = "Viking"
+				if (VAMPIRE)
+					cat_name = "Vampire"
 
 			dat += "<fieldset style='width: 185px; border: 2px solid [cat_color]; display: inline'>"
 			dat += "<legend align='center' style='font-weight: bold; color: [cat_color]'>[cat_name]</legend>"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2303,6 +2303,8 @@
 #include "code\modules\jobs\job_types\roguetown\viking\highking.dm"
 #include "code\modules\jobs\job_types\roguetown\viking\vikingfarmer.dm"
 #include "code\modules\jobs\job_types\roguetown\viking\vikinggrunt.dm"
+#include "code\modules\jobs\job_types\roguetown\vampire\vampthrall.dm"
+#include "code\modules\jobs\job_types\roguetown\vampire\vampsmith.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\alchemist.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\apothecary.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\archivist.dm"


### PR DESCRIPTION
This PR is to set the very basic groundwork for the vampire faction.
- Adding Vampire Thrall and Smith
- Smith is disabled for now
- Thrall has 4 Slots
- Average Stats, Shit Loadout
- Bat Form, Recruit Sympathizer Spell, All the basic vampire traits + FAITHLESS
- Couldn't figure out how to code the actual vampire stuff, so these are work-arounds. The idea of vampires who are caught between zizo and psydon being faithless seems pretty thematic. Either way being Zizo gives no benefit and vampires shouldn't be getting healed.
- As a stark contrast to vikings, this is meant to almost be an entirely RP focused faction. Vampire faction is meant to be non-antag neutral.
UPDATE: I did figure out the vampirism situation, though it may be a bit overpowered and abused if real vampirism is given. We will go with the RP approach over real vampirism to test the waters.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
