### PR TITLE
Surgery Buffs p2

### DIFF
--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -55,24 +55,24 @@
 	/// Necessary skill MINIMUM to perform this surgery step, of skill_used
 	var/skill_min = SKILL_LEVEL_NOVICE
 	/// Skill median used to apply success and speed bonuses
-	var/skill_median = SKILL_LEVEL_NOVICE
+	var/skill_median = SKILL_LEVEL_NONE
 	/// Modifiers to success chance when you're above the median
 	var/list/skill_bonuses = list(
-		1 = 0.4,
-		2 = 0.8,
-		3 = 1,
-		4 = 1.2,
-		5 = 1.5,
-		6 = 2,
+		1 = 1.5,
+		2 = 2,
+		3 = 2.5,
+		4 = 3,
+		5 = 3.5,
+		6 = 4,
 	)
 	/// Modifiers to success chance when you're below the median
 	var/list/skill_maluses = list(
-		1 = -0.2,
-		2 = -0.4,
-		3 = -0.6,
-		4 = -0.8,
-		5 = -1,
-		6 = -2,
+		1 = 0,
+		2 = -0.2,
+		3 = -0.4,
+		4 = -0.6,
+		5 = -0.8,
+		6 = -1,
 	)
 
 	/// Handles techweb-oriented surgeries


### PR DESCRIPTION
- Surgery is still complete ass even with my previous buffs.
- Level 1 surgery is a debuff as is since you don't get prompted to what you're doing. Level 2 gives you the first boost in %, getting you to around 50% success rate but you still lack some surgeries, level 3 gets you around 100% in basic surgeries but there are still failure chances in other surgeries.
- Ghetto surgery is like a 1% chance before I ever buffed anything, so now at legendary medicine it becomes around 100%.

Overall, surgery is massively inferior to miracles and takes longer even with 100% success rates. This will make it competitive at level 3+ medicine.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
