### PR TITLE
What if you could close a lobby screen?

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -114,7 +114,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 			else
 				dat += "<B>[job.title]</B> ([readiedas])<br>"
 	var/datum/browser/popup = new(src, "lobby_window", "<div align='center'>LOBBY</div>", 330, 430)
-	popup.set_window_options("can_close=0;can_minimize=0;can_maximize=0;can_resize=1;")
+	popup.set_window_options("can_close=1;can_minimize=0;can_maximize=0;can_resize=1;")
 	popup.set_content(dat.Join())
 	if(!client)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Admittedly maybe there is some big, loadbearing reason for this, but it checked out on my end; just... let's you be able to close the lobby screen window.

It will still "refresh" and pop up during the lobby part of the game, but afterwards it has no more procs so it'll stay dead.

... I'm... not sure why nobody has done this before.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

slay the spectre that is this fucking lobby screen bug (while not actually fixing the bug (not my problem))

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof of testing
![image](https://github.com/user-attachments/assets/ce79ca73-7523-4002-8232-9c0381467c18)
