### PR TITLE
Fixes Undead Mobs being Faithless + Fixes Compile Errors

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/roguetown/haunt.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/haunt.dm
@@ -46,6 +46,7 @@
 	canparry = TRUE
 	retreat_health = null
 	var/obj/structure/bonepile/slavepile
+	patron = /datum/patron/inhumen/zizo		//So they can be hurt by holy fire/healing
 
 /mob/living/simple_animal/hostile/rogue/haunt/electrocute_act(shock_damage, source, siemens_coeff = 1, flags = NONE)
 	return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -34,6 +34,7 @@
 	deathmessage = "collapses into a pile of bones!"
 	del_on_death = 1
 	loot = list(/obj/effect/decal/remains/human)
+	patron = /datum/patron/inhumen/zizo		//So they can be hurt by holy fire/healing
 
 	footstep_type = FOOTSTEP_MOB_SHOE
 

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -520,14 +520,6 @@
 	verbage_simple = "sew"
 	verbage = "sews"
 	craftdiff = 0
-	/datum/crafting_recipe/roguetown/bonespear
-	name = "bone spear"
-	result = /obj/item/rogueweapon/spear/bonespear
-	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
-				/obj/item/natural/bone = 2,
-				/obj/item/natural/fibers = 1)
-	craftdiff = 3
-
 
 /datum/crafting_recipe/roguetown/boneaxe
 	name = "bone axe"
@@ -536,3 +528,11 @@
 				/obj/item/natural/bone = 2,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/bonespear
+	name = "bone spear"
+	result = /obj/item/rogueweapon/spear/bonespear
+	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
+				/obj/item/natural/bone = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 3

--- a/modular/code/game/objects/pillory.dm
+++ b/modular/code/game/objects/pillory.dm
@@ -213,5 +213,3 @@
 /obj/structure/pillory/tribal/reinforced
 	icon_state = "pillory_reinforced"
 	base_icon = "pillory_reinforced"
-
-#undef PILLORY_HEAD_OFFSET

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/cursed.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/cursed.dm
@@ -51,6 +51,7 @@
 	dodgetime = 10
 	canparry = TRUE
 	retreat_health = null
+	patron = /datum/patron/inhumen/zizo		//So they can be hurt by holy fire/healing
 
 /mob/living/simple_animal/hostile/rogue/ghost/cursed/cursed2
 	icon_state = "cursed2"

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/gravelord.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/gravelord.dm
@@ -37,6 +37,7 @@
 	/obj/item/soul_fragment, /obj/item/skull, /obj/item/skull, /obj/item/skull, /obj/item/skull)
 	dodgetime = 0
 //	stat_attack = UNCONSCIOUS
+	patron = /datum/patron/inhumen/zizo		//So they can be hurt by holy fire/healing
 
 
 /mob/living/simple_animal/hostile/rogue/gravelord/taunted(mob/user)

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
@@ -44,6 +44,7 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 3,
 						/obj/item/natural/hide = 2, /obj/item/natural/bundle/bone/full = 1)
 	aggressive = 1
+	patron = /datum/patron/inhumen/graggar		//Flavor + recognized as hostile if preformed miracles on instead of as faithless.
 
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc2
 	icon_state = "savageorc2"

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/simple_skeleton.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/simple_skeleton.dm
@@ -36,6 +36,7 @@
 	faction = list("undead")
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	del_on_death = TRUE
+	patron = /datum/patron/inhumen/zizo		//So they can be hurt by holy fire/healing
 
 /mob/living/simple_animal/hostile/rogue/skeleton/axe
 	name = "Skeleton"

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/wraith.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/wraith.dm
@@ -51,6 +51,7 @@
 	dodgetime = 10
 	canparry = TRUE
 	retreat_health = null
+	patron = /datum/patron/inhumen/zizo		//So they can be hurt by holy fire/healing
 
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith2
 	icon_state = "wraith2"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Basically sets mobs like skeletons, wraiths, haunts, gravekeepers, etc to be Zizo aligned patron entities instead of faithless, allowing holy spells to properly harm them again.

Also fixed:
- The fucking bonespear and antler hood being broken due to improper tabbing for ????
- Pillory had an unused undefine because it was already prior undefined, causing an error.

## Why It's Good For The Game

Fixes error that was had since the Faithless PR additions, properly now making most hostile mobs that are 'intelligent/undead creatures' have an assigned patron. And also makes it so code stops erroring and making people freak out. And fixes crafting issue.