### PR TITLE
Monster antag headshots, updated flavor text, and eye fix

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -444,6 +444,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(!valid_headshot_link(null, headshot_link, TRUE))
 		headshot_link = null
 
+	S["vampireheadshot_link"]			>> vampireheadshot_link
+	if(!valid_vampireheadshot_link(null, vampireheadshot_link, TRUE))
+		vampireheadshot_link = null
+
+	S["werewolfheadshot_link"]			>> werewolfheadshot_link
+	if(!valid_werewolfheadshot_link(null, werewolfheadshot_link, TRUE))
+		werewolfheadshot_link = null
+
 	S["pronouns"] >> pronouns
 	S["voice_type"] >> voice_type
 	//try to fix any outdated data if necessary
@@ -591,6 +599,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	
 	WRITE_FILE(S["update_mutant_colors"] , update_mutant_colors)
 	WRITE_FILE(S["headshot_link"] , headshot_link)
+	WRITE_FILE(S["vampireheadshot_link"] , vampireheadshot_link)
+	WRITE_FILE(S["werewolfheadshot_link"] , werewolfheadshot_link)
 	WRITE_FILE(S["statpack"] , statpack.type)
 	WRITE_FILE(S["voice_type"] , voice_type)
 	WRITE_FILE(S["pronouns"] , pronouns)


### PR DESCRIPTION
adding in additional headshot options

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds undisguised vampire and werewolf headshot options and your human headshot (default). Adds in fang and pale skin descriptions for vampires. Removes the dead eye color change

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
adds a bit more immersion for the headshots if players have an alternative. Also gives better ways to recognize vampires other than they are "indistinguishable" from a lore perspective. Also removes the eye change with dead eyes and adding pink or red 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
