### PR TITLE
Ruediger's Storage Powercreep Annihilation

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -230,6 +230,7 @@
 			/obj/item/natural/bundle/cloth
 			/obj/item/natural/worms/leech
 			/obj/item/natural/worms/leech/cheele
+			/obj/item/reagent_containers/lux
 
 /obj/item/storage/backpack/rogue/skit/PopulateContents()
 	new /obj/item/rogueweapon/surgery/scalpel(src)

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -211,6 +211,25 @@
 		STR.max_combined_w_class = 42
 		STR.max_w_class = WEIGHT_CLASS_NORMAL
 		STR.max_items = 12
+		STR.set_holdable(list(
+			/obj/item/rogueweapon/surgery/scalpel
+			/obj/item/rogueweapon/surgery/saw
+			/obj/item/rogueweapon/surgery/hemostat
+			/obj/item/rogueweapon/surgery/hemostat
+			/obj/item/rogueweapon/surgery/retractor
+			/obj/item/rogueweapon/surgery/bonesetter
+			/obj/item/rogueweapon/surgery/cautery
+			/obj/item/needle
+			/obj/item/needle/thorn
+			/obj/item/needle/pestra
+			/obj/item/reagent_containers/glass/bottle/waterskin
+			/obj/item/reagent_containers/glass/bottle
+			/obj/item/natural/fibers
+			/obj/item/natural/cloth
+			/obj/item/natural/bundle/fibers
+			/obj/item/natural/bundle/cloth
+			/obj/item/natural/worms/leech
+			/obj/item/natural/worms/leech/cheele
 
 /obj/item/storage/backpack/rogue/skit/PopulateContents()
 	new /obj/item/rogueweapon/surgery/scalpel(src)


### PR DESCRIPTION
Restrict Doctor's Bag equipment thingies.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

# #391 was hilarious.

I will print it and glue it to my wall like it's a sanctuary. Go look.

Ditto as last but properly took note of what a doctor may, in fact, need to do it's doctoring needs. It is spared from "take off from back to access" because otherwise it's like, opposite of powercreep. Why use new when old good?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Powercreep can suck my balls.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
