### PR TITLE
Food QoL Additions and fixes.

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -6166,13 +6166,13 @@
 /area/rogue/indoors)
 "eeD" = (
 /obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/egg/loaded,
-/obj/item/reagent_containers/food/snacks/egg/loaded,
-/obj/item/reagent_containers/food/snacks/egg/loaded,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "eeK" = (
@@ -9261,6 +9261,12 @@
 /area/rogue/indoors/town)
 "gEj" = (
 /obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
 "gEE" = (
@@ -10331,6 +10337,7 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "hnN" = (
@@ -11585,13 +11592,20 @@
 "iqB" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/wallfire/candle/r,
-/obj/item/reagent_containers/food/snacks/egg/loaded,
-/obj/item/reagent_containers/food/snacks/egg/loaded,
-/obj/item/reagent_containers/food/snacks/egg/loaded,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "iqD" = (
@@ -23245,6 +23259,10 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/rogue/potato,
+/obj/item/reagent_containers/food/snacks/grown/rogue/potato,
+/obj/item/reagent_containers/food/snacks/grown/rogue/potato,
+/obj/item/reagent_containers/food/snacks/grown/rogue/potato,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rrg" = (
@@ -23736,6 +23754,7 @@
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_y = 10
 	},
+/obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
 "rNH" = (
@@ -25950,6 +25969,10 @@
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/food/snacks/grown/rogue/potato,
+/obj/item/reagent_containers/food/snacks/grown/rogue/potato,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "tyy" = (

--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -130,6 +130,28 @@
 	export_price = 5
 	importexport_amt = 5
 
+/datum/roguestock/stockpile/potato
+	name = "Potato"
+	desc = "A starchy tuber."
+	item_type = /obj/item/reagent_containers/food/snacks/grown/rogue/potato
+	held_items = list(0, 0)
+	payout_price = 3
+	withdraw_price = 5
+	transport_fee = 1
+	export_price = 5
+	importexport_amt = 5
+
+/datum/roguestock/stockpile/sugarcane
+	name = "Sugarcane"
+	desc = "A sweet stalk."
+	item_type = /obj/item/reagent_containers/food/snacks/grown/sugarcane
+	held_items = list(0, 0)
+	payout_price = 3
+	withdraw_price = 5
+	transport_fee = 1
+	export_price = 5
+	importexport_amt = 5
+
 /datum/roguestock/stockpile/meat
 	name = "Meat"
 	desc = "Edible flesh harvested from animals."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixed invisible Cackleberries. Added cackleberries to the inn. Added sugar to the inn and keep kitchen. Added sugarcane to the lower levels of the inn's storage. Added sugarcane and potatoes to the stockpile.

I also gave the keep kitchen another silver goblet so they can provide drinks for both of the nobility that eat on either side of the king during feasts.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This adds the core ingredients I've added to the stockpile as well as gives a basic sweep of the new ingredients to places where it makes sense, but have otherwise not had access. This should cover the early period of the game where the soilson has not yet prepared the farm for orders, as well as give kitchen staff the ability to engage with all aspects of the current cooking system. Increased options, increased engagement

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
