### PR TITLE
Quick balancing and fixes for Arcane Magic

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -30,6 +30,7 @@
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/black
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
 	beltr = /obj/item/keyring/mage
 	id = /obj/item/clothing/ring/gold
@@ -40,7 +41,7 @@
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/arcane, pick(6,5), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, pick(1,2), TRUE)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -550,7 +550,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "hierophant"
 	range = 2
-	var/damage = 8
+	var/damage = 10
 
 /obj/effect/proc_holder/spell/invoked/arcyne_storm/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -309,7 +309,8 @@
 	range = 6
 	overlay_state = "ensnare"
 	var/area_of_effect = 1
-	var/duration = 5 SECONDS
+	var/duration = 2.5 SECONDS
+	var/delay = 0.8 SECONDS
 
 /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])
@@ -319,9 +320,10 @@
 			continue
 		new /obj/effect/temp_visual/slowdown_spell_aoe(affected_turf)
 
-	addtimer(CALLBACK(src, PROC_REF(apply_slowdown), T, area_of_effect, 6 SECONDS, user), 0.6 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(apply_slowdown), T, area_of_effect, duration, user), delay)
 	playsound(T,'sound/magic/webspin.ogg', 50, TRUE)
 	return TRUE
+
 /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe/proc/apply_slowdown(turf/T, area_of_effect, duration)
 	for(var/mob/living/simple_animal/hostile/animal in range(area_of_effect, T))
 		animal.Paralyze(duration, updating = TRUE, ignore_canstun = TRUE)	//i think animal movement is coded weird, i cant seem to stun them
@@ -340,7 +342,7 @@
 	duration = 1 SECONDS
 
 /obj/effect/temp_visual/slowdown_spell_aoe/long
-	duration = 3 SECONDS
+	duration = 2.5 SECONDS
 
 /obj/effect/proc_holder/spell/invoked/message
 	name = "Message"
@@ -375,7 +377,10 @@
 	for(var/mob/living/carbon/human/HL in GLOB.human_list)
 		if(HL.real_name == input)
 			var/message = stripped_input(user, "You make a connection. What are you trying to say?")
+			if(!message)
+				return
 			to_chat(HL, "Arcyne whispers fill the back of my head, resolving into a clear, if distant, voice: </span><font color=#7246ff>\"[message]\"</font>")
+			log_game("[key_name(user)] sent a message to [key_name(HL)] with contents [message]")
 			// maybe an option to return a message, here?
 			return TRUE
 	to_chat(user, span_warning("I seek a mental connection, but can't find [input]."))
@@ -544,7 +549,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "hierophant"
-	range = 3
+	range = 2
 	var/damage = 8
 
 /obj/effect/proc_holder/spell/invoked/arcyne_storm/cast(list/targets, mob/user = usr)
@@ -554,7 +559,7 @@
 		if(turfs_in_range.density)
 			continue
 		affected_turfs.Add(turfs_in_range)
-	for(var/i = 1, i < 21, i++)
+	for(var/i = 1, i < 16, i++)
 		addtimer(CALLBACK(src, PROC_REF(apply_damage), affected_turfs), wait = i * 1 SECONDS)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Arcyne storm (damage AOE)  has a lower range and duration, slightly increased damage. Ensare (AOE slowdown) has a drastically lower duration, and a longer delay. Message spell has admin logging (Probably a bad idea to have a direct message function without this). Fixed two small changes i accidentally reverted in magician.dm.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ensnare is WAY overpowered with how long it stuns, I feel the AOE is too long and wide. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
