### PR TITLE
bog troll and wendigo spawn rate reduction

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -197,10 +197,10 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 				/mob/living/carbon/human/species/skeleton/npc/dungeon/ambush = 30,
 				/mob/living/carbon/human/species/skeleton/npc/ambush = 50,
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 60,
-				/mob/living/simple_animal/hostile/retaliate/rogue/bogtroll = 50,
+				/mob/living/simple_animal/hostile/retaliate/rogue/bogtroll = 30,
 				/mob/living/simple_animal/hostile/retaliate/rogue/spider = 40,
 				/mob/living/carbon/human/species/goblin/npc/ambush/cave = 40,
-				/mob/living/simple_animal/hostile/retaliate/rogue/wendigo = 40)
+				/mob/living/simple_animal/hostile/retaliate/rogue/wendigo = 25)
 	first_time_text = "THE TERRORBOG"
 	converted_type = /area/rogue/indoors/shelter/bog
 

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/wendigo.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/wendigo.dm
@@ -17,8 +17,8 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 13,
 						/obj/item/natural/hide = 15, /obj/item/natural/bundle/bone/full = 3)
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	health = 250
-	maxHealth = 300
+	health = 400
+	maxHealth = 500
 	melee_damage_lower = 35
 	melee_damage_upper = 50
 	vision_range = 6
@@ -31,7 +31,7 @@
 	pooptype = null
 	STACON = 15
 	STASTR = 15
-	STASPD = 3
+	STASPD = 5
 	deaggroprob = 0
 	defprob = 40
 	defdrain = 10

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/wendigo.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/wendigo.dm
@@ -17,10 +17,10 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 13,
 						/obj/item/natural/hide = 15, /obj/item/natural/bundle/bone/full = 3)
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	health = 400
-	maxHealth = 500
-	melee_damage_lower = 45
-	melee_damage_upper = 70
+	health = 250
+	maxHealth = 300
+	melee_damage_lower = 35
+	melee_damage_upper = 50
 	vision_range = 6
 	aggro_vision_range = 5
 	retreat_distance = 0
@@ -29,9 +29,9 @@
 	food_type = list(/obj/item/reagent_containers/food/snacks/rogue/meat, /obj/item/bodypart, /obj/item/organ)
 	footstep_type = FOOTSTEP_MOB_HEAVY
 	pooptype = null
-	STACON = 19
-	STASTR = 16
-	STASPD = 5
+	STACON = 15
+	STASTR = 15
+	STASPD = 3
 	deaggroprob = 0
 	defprob = 40
 	defdrain = 10


### PR DESCRIPTION
damage reduced for wendigo and spawnrate reduction for bogtroll and wendigo's since these are ment to be more elite mobs


wendigo's damaged reduced these things where hitting for over 100+ damage on a crit. had 2x the damage of a wielded battleaxe with a 16str hitting you with it.... twice. because two of them.