### PR TITLE
Adds Needle Back to Surgery Kit

### DIFF
--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -168,3 +168,4 @@
 	new /obj/item/rogueweapon/surgery/retractor(src)
 	new /obj/item/rogueweapon/surgery/bonesetter(src)
 	new /obj/item/rogueweapon/surgery/cautery(src)
+	new /obj/item/needle/pestra(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Just adds the needle of pestra back into the surgery kit, since it cannot be obtained outside of job spawns otherwise.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Idk, it was like this before but so far seems like it was forgotten in translation. Its useful for doctors to do their job, just like the rest of the tools.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
