### PR TITLE
trainable up to tier 3 from dumby

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -939,7 +939,7 @@
 						user.visible_message(span_info("[user] trains on [src]!"))
 						var/boon = user.mind.get_learning_boon(W.associated_skill)
 						var/amt2raise = L.STAINT/2
-						if(user.mind.get_skill_level(W.associated_skill) >= SKILL_LEVEL_APPRENTICE)
+						if(user.mind.get_skill_level(W.associated_skill) >= SKILL_LEVEL_JOURNEYMAN)
 							to_chat(user, span_warning("I've learned all I can from doing this, it's time for the real thing."))
 							amt2raise = 0
 						if(amt2raise > 0)

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -928,7 +928,7 @@
 					if(!L.rogfat_add(rand(4,6)))
 						if(ishuman(L))
 							var/mob/living/carbon/human/H = L
-							if(H.tiredness >= 70)
+							if(H.tiredness >= 75)
 								H.apply_status_effect(/datum/status_effect/debuff/trainsleep)
 						probby = 0
 					if(!(L.mobility_flags & MOBILITY_STAND))

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -928,7 +928,7 @@
 					if(!L.rogfat_add(rand(4,6)))
 						if(ishuman(L))
 							var/mob/living/carbon/human/H = L
-							if(H.tiredness >= 50)
+							if(H.tiredness >= 70)
 								H.apply_status_effect(/datum/status_effect/debuff/trainsleep)
 						probby = 0
 					if(!(L.mobility_flags & MOBILITY_STAND))


### PR DESCRIPTION
did a few tests and fpund out basically any combat skill is utterly not worth using untill journeyman level. to get to that level if you ever want to just use a different weapon you will have to find a genuine expert to train you, hope they will give you the time to do it or know how to do it. this change simply raises training dummies learn cap to an actual usable journeyman level. experts will still have and advantage, masters are masters. this just makes a person able to actually rely on there weapon they like to use ocne leveled.