### PR TITLE
Noc Follower Darkvision

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -38,6 +38,7 @@
 
 //Hearthstone change (Tracking)
 #define TRAIT_PERFECT_TRACKER "Perfect Tracker" //! Will always find any tracks and analyzes them perfectly.
+#define TRAIT_NOCSIGHT "Blessing of Noc" // I can see just a bit more clearly in darkness.
 //Hearthstone end.
 
 // PATRON GOD TRAITS
@@ -118,6 +119,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_WATERBREATHING = span_info("I do not drown in bodies of water."),
 	TRAIT_FAITHLESS = span_warning("I don't hold them in my thoughts or prayers - the Gods won't care for me, if they ever did in the first place."),
 	TRAIT_PERFECT_TRACKER = span_info("I am the perfect tracker. No tracks will deceive my eyes, nor will they hide their secrets from me."),//Hearthstone change.
+	TRAIT_NOCSIGHT = "Noc blesses my eyes to be unburdened by the night." //Hearthstone change.
 ))
 
 // trait accessor defines

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -22,6 +22,7 @@
 	domain = "God of the Moon, Night, and Knowledge"
 	desc = "The Firstborn of Psydon, twin of Astrata, gifted man divine knowledge."
 	worshippers = "Wizards and Scholars"
+	mob_traits = list(TRAIT_NOCSIGHT)
 	t1 = /obj/effect/proc_holder/spell/invoked/blindness
 	t2 = /obj/effect/proc_holder/spell/invoked/invisibility
 	confess_lines = list(

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -762,6 +762,9 @@
 		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = max(see_in_dark, 8)
 
+	if(HAS_TRAIT(src, TRAIT_NOCSIGHT))
+		E.lighting_alpha = LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT
+
 	if(see_override)
 		see_invisible = see_override
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -764,6 +764,7 @@
 
 	if(HAS_TRAIT(src, TRAIT_NOCSIGHT))
 		E.lighting_alpha = LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT
+		E.see_in_dark = 7
 
 	if(see_override)
 		see_invisible = see_override


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Adds in a trait for followers of noc that makes the lighting alpha very, very slightly transparent. From 255 to 243.
This also reduces the range at which you can see objects and turfs by 1, to account for the increased overall visibility.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While Noc isnt by any means the least loved of the gods, this change makes the most sense for them due to the domains of night and knowledge. Its not too powerful, and still requires a bit of a squint, but still isnt effective beyond initial screenspace. At most, I anticipate this being used by people to circumvent the need for torches or lanterns in calm situations. I expect a small decline in lamptern thefts!

For combat, this could potentially be used for player ambushes better, but these situations are only just barely tilted in the ambusher's favor due to not necessarily requiring a light if wanting to escape. Usually people have a light source for fighting in the dark, as its CBT otherwise. Noc followers would be expected to shine their brightest (pun intended) when they are embracing their patron's environment, after all.

Here's a picture of how it looks in game, with additional far-look. This is at night, with most lights extinguished in view.

![image](https://github.com/user-attachments/assets/069705b3-2662-48ca-b0db-3cb0116b7c48)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
