### PR TITLE
No More Sword RNG for Paladin!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -75,10 +75,7 @@
 					cloak = /obj/item/clothing/cloak/tabard/crusader/pestra
 				if("Noc")
 					cloak = /obj/item/clothing/cloak/tabard/crusader/noc
-			if(prob(70))
-				backr = /obj/item/rogueweapon/sword
-			else
-				backr = /obj/item/rogueweapon/sword/long
+		        backr = /obj/item/rogueweapon/sword/long
 			backl = /obj/item/storage/backpack/rogue/satchel
 		if("Battle Master")
 			H.set_blindness(0)


### PR DESCRIPTION
Changes the RNG so Paladins get a Bastard Sword guaranteed instead of a shitty Steel Sword.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I find it really, really godawful that Paladin literally gets stuck with only a regular Steel Sword 70% of the time, and no shield or anything to go with it. Steel Swords aren't that good even when two-handed. This fixes it so at least they get a guaranteed Bastard Sword when they spawn in. I mean, they're basically diet Templars, they don't even get as good armor or gear as them or the same stats... at least let 'em have a good sword. Sheesh.

## Why It's Good For The Game

As I said, it's horrendous how bad of an equipment setup base Paladin gets... Battle Masters at least get a guaranteed flail. Why the heck not just give Paladin a bastard sword and call it a day if you aren't gonna let 'em have a shield?
