### PR TITLE
Sackening 2024: Ports Allows Using Sacks on Barrels and Composters

### DIFF
--- a/code/game/objects/items/rogueitems/bags.dm
+++ b/code/game/objects/items/rogueitems/bags.dm
@@ -11,6 +11,11 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	max_integrity = 300
 
+/obj/item/storage/roguebag/examine(mob/user)
+	. = ..()
+	if(contents.len)
+		. += span_notice("[contents.len] thing[contents.len > 1 ? "s" : ""] in the sack.")
+
 /obj/item/storage/roguebag/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot == SLOT_HEAD)
@@ -68,6 +73,7 @@
 	STR.allow_quick_gather = TRUE
 	STR.allow_quick_empty = TRUE
 	STR.allow_look_inside = FALSE
+	STR.allow_dump_out = TRUE
 	STR.display_numerical_stacking = TRUE
 
 

--- a/code/modules/farming/composter.dm
+++ b/code/modules/farming/composter.dm
@@ -185,7 +185,7 @@
 	color = "#ffac38"
 	w_class = WEIGHT_CLASS_SMALL
 
-	/obj/item/fertilizer
+/obj/item/fertilizer
 	name = "fertilizer"
 	desc = "A mix of compost and bone meal."
 	icon = 'icons/roguetown/items/misc.dmi'

--- a/code/modules/farming/composter.dm
+++ b/code/modules/farming/composter.dm
@@ -74,70 +74,75 @@
 	flipped_compost += flip_amount
 	update_icon()
 
-/obj/structure/composter/proc/try_handle_adding_compost(obj/item/attacking_item, mob/user, params)
+/obj/structure/composter/proc/try_handle_adding_compost(obj/item/attacking_item, mob/user, batch_process)
 	var/compost_value = 0
-	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks/grown))
+	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks))
 		compost_value = 150
-	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks/meat))
-		compost_value = 250
 	if(istype(attacking_item, /obj/item/natural/chaff))
 		compost_value = 150
 	if(istype(attacking_item, /obj/item/trash/applecore))
 		compost_value = 50
 	if(compost_value > 0)
-		if(compost_value + get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
-			to_chat(user, span_warning("There's too much compost!"))
-			return TRUE
-		unflipped_compost += compost_value
-		to_chat(user, span_notice("I add \the [attacking_item] to \the [src]"))
+		if(get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
+			if(!batch_process)
+				to_chat(user, span_warning("There's too much compost!"))
+			return FALSE
+		unflipped_compost += min(compost_value, MAXIMUM_TOTAL_COMPOST - get_total_compost())
+		if(!batch_process)
+			to_chat(user, span_notice("I add \the [attacking_item] to \the [src]"))
 		qdel(attacking_item)
 		update_icon()
 		return TRUE
 	return FALSE
 
-/obj/structure/composter/proc/try_handle_removing_compost(obj/item/attacking_item, mob/user, params, allows_hand)
-	var/using_tool = FALSE
-	if(attacking_item)
-		if(istype(attacking_item, /obj/item/rogueweapon/pitchfork) || istype(attacking_item, /obj/item/rogueweapon/shovel))
-			using_tool = TRUE
-	if(!allows_hand && !using_tool)
-		return FALSE
+/obj/structure/composter/proc/try_handle_removing_compost(obj/item/attacking_item, mob/living/user)
 	if(ready_compost < COMPOST_PER_PRODUCED_ITEM)
 		to_chat(user, span_warning("There's not enough processed compost!"))
 		return TRUE
-	var/do_time = using_tool ? 1 SECONDS : 2 SECONDS
-	var/fatigue = using_tool ? 0 : 5
-	if(do_after(user, get_farming_do_time(user, do_time), target = src))
-		apply_farming_fatigue(user, fatigue)
-		to_chat(user, span_notice("I take out some ready compost."))
-		if(using_tool)
-			playsound(src,'sound/items/dig_shovel.ogg', 100, TRUE)
-		take_out_compost()
+	apply_farming_fatigue(user, 5)
+	to_chat(user, span_notice("I take out some ready compost."))
+	var/obj/item/compost/compost = take_out_compost()
+	if(compost)
+		user.put_in_active_hand(compost)
 	return TRUE
 
 /obj/structure/composter/proc/take_out_compost()
 	if(ready_compost < COMPOST_PER_PRODUCED_ITEM)
 		return
 	ready_compost -= COMPOST_PER_PRODUCED_ITEM
-	new /obj/item/compost(get_turf(src))
+	. = new /obj/item/compost(get_turf(src))
 	update_icon()
 
 /obj/structure/composter/attackby(obj/item/attacking_item, mob/user, params)
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_FAST)
+	if(istype(attacking_item,/obj/item/storage/roguebag) && attacking_item.contents.len)
+		if(get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
+			to_chat(user, span_warning("There's too much compost!"))
+			return
+		var/success
+		for(var/obj/item/bagged_item in attacking_item.contents)
+			if(try_handle_adding_compost(bagged_item, user, params))
+				success = TRUE
+				if(get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
+					break
+		if(success)
+			to_chat(user, span_info("I dump all the compostables inside [attacking_item] into [src]."))
+			attacking_item.update_icon()
+		else
+			to_chat(user, span_warning("There's nothing in [attacking_item] that can be composted."))
+		return TRUE
 	if(try_handle_adding_compost(attacking_item, user, params))
-		return
-	if(try_handle_removing_compost(attacking_item, user, params, FALSE))
 		return
 	. = ..()
 
 /obj/structure/composter/attack_hand(mob/user)
-	user.changeNext_move(CLICK_CD_MELEE)
-	if(try_handle_removing_compost(null, user, null, TRUE))
+	user.changeNext_move(CLICK_CD_FAST)
+	if(try_handle_removing_compost(null, user, null))
 		return
 	. = ..()
 
 /obj/structure/composter/attack_right(mob/user)
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_FAST)
 	var/obj/item = user.get_active_held_item()
 	if(try_handle_flipping_compost(item, user, null))
 		return
@@ -158,13 +163,13 @@
 	else if (total_unprocessed >= COMPOST_PER_PRODUCED_ITEM)
 		unprocesed_dry_overlay_name = "pre_compost_low_dry"
 		. += "pre_compost_low"
-	
+
 	if(show_dry && unprocesed_dry_overlay_name)
 		var/mutable_appearance/dry_ma = mutable_appearance(icon, unprocesed_dry_overlay_name)
 		dry_ma.color = "#ffbb6d"
 		dry_ma.alpha = 40
 		. += dry_ma
-	
+
 	if(total_processed >= MAXIMUM_TOTAL_COMPOST * 0.60)
 		. += "post_compost_heavy"
 	else if(total_processed >= MAXIMUM_TOTAL_COMPOST * 0.30)
@@ -180,7 +185,7 @@
 	color = "#ffac38"
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/fertilizer
+	/obj/item/fertilizer
 	name = "fertilizer"
 	desc = "A mix of compost and bone meal."
 	icon = 'icons/roguetown/items/misc.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Ports https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/53 by @EvenInDeathIStillServe

"Allows using sack bags on barrels and composters so you don't have to process things one at a time.

Also lets you examine the sack to see how many things are inside, along with letting you mousedrop it on the floor to dump it out on a different tile."

## Why It's Good For The Game
QoL for soilmains, and carpal tunnel preventative measures otherwise. 
