### PR TITLE
Fix for Tabard Colours on Boobed Individuals

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -66,6 +66,7 @@
 	var/block2add
 	var/detail_tag
 	var/detail_color
+	var/boobed_detail = TRUE //Whether details have their own boobed sprite
 
 /obj/item/clothing/New()
 	..()

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -17,7 +17,7 @@
 
 /obj/item/clothing/cloak/tabard
 	name = "tabard"
-	desc = "A hooded vest meant for knights."
+	desc = "A long vest meant for knights."
 	color = null
 	icon_state = "tabard"
 	item_state = "tabard"
@@ -103,6 +103,7 @@
 /obj/item/clothing/cloak/tabard/crusader
 	detail_tag = "_psy"
 	detail_color = CLOTHING_RED
+	boobed_detail = FALSE
 
 /obj/item/clothing/cloak/tabard/crusader/Initialize()
 	..()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1577,7 +1577,7 @@ generate/load female uniform sprites matching all previously decided variables
 		if(get_detail_color())
 			pic.color = get_detail_color()
 		standing.overlays.Add(pic)
-		if(!isinhands && boobed_overlay && boobed)
+		if(!isinhands && boobed_overlay && boobed_detail && boobed)
 			pic = mutable_appearance(icon(file2use, "[t_state]_boob[get_detail_tag()]"), -layer2use)
 			pic.appearance_flags = RESET_COLOR
 			if(get_detail_color())


### PR DESCRIPTION
Port from https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/284

Okay so there was an issue where crusader tabards don't have a boobed sprite for the detail, and it forces the whole tabard to take the colour of the detail when worn by women. This fixes that.

![image](https://github.com/user-attachments/assets/4246dcf5-74ac-4436-999d-9d5ff60ad76e)
![image](https://github.com/user-attachments/assets/1b154ff8-20a3-43fd-a573-71c87941fb93)
