### PR TITLE
Add Combattante Association Cloaks

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1249,3 +1249,24 @@
 	allowed_sex = list(MALE, FEMALE)
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	nodismemsleeves = TRUE
+
+/obj/item/clothing/cloak/combattante
+	name = "combattantecloak"
+	desc = "A cloak designed for members of the Combattante Association."
+	color = null
+	icon_state = "combattantecloak"
+	alternate_worn_layer = CLOAK_BEHIND_LAYER
+	slot_flags = ITEM_SLOT_BACK_R|ITEM_SLOT_CLOAK
+//	body_parts_covered = ARMS|CHEST
+	boobed = TRUE
+	sleeved = 'icons/roguetown/clothing/onmob/cloaks.dmi'
+	sleevetype = "shirt"
+	nodismemsleeves = TRUE
+	inhand_mod = TRUE
+	hoodtype = null
+	toggle_icon_state = FALSE
+	color = CLOTHING_BLACK
+	allowed_sex = list(MALE, FEMALE)
+	allowed_race = NON_DWARVEN_RACE_TYPES
+	flags_inv = null
+


### PR DESCRIPTION
Adds a custom cloak asked for by Qarax for a player-made guild. Basically a reskin of the halfcloak.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

A commission by Qarax to add a cool new cloak for members of the Combattante Association (see Discord).

## Why It's Good For The Game

It's a good way to identify members of that Association, and it's a resprite of the halfcloak so it doesn't grant anything besides style points.
