### PR TITLE
Makes Silver Sabers Not Smelt Into Steel

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -616,6 +616,7 @@
 	desc = "This finely crafted saber is of elven smithcraft."
 	icon_state = "esaber"
 	item_state = "esaber"
+	smeltresult = /obj/item/ingot/silver
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Silver sabers if smelted down produce steel because silver swords dont have a smelt result, so it inherits steel instead.
This just adds silver bar as their smelt result, which is still half their cost, so its still a net loss if you do this anyway. Just isnt as dumb as turning a limited resource into something it isnt.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its not steel, so it shouldnt put out steel.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
