### PR TITLE
Gives Mage Spitfire and Fetch to start off.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -44,3 +44,5 @@
 		H.mind.adjust_spellpoints(1)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/learnspell)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/spitfire)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Don't see why Mage Apprentice gets these when Adventurer Mage, which is supposed to be a seasoned mage, doesn't. Remedying this.

## Why It's Good For The Game

Saves two spell points for otherwise semi-useless spells that they should know anyways?
