### PR TITLE
Removes Greater Fireball from the learnable list.

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -190,7 +190,6 @@
 	//TODO: make GLOB list of spells, give them a true/false tag for learning, run through that list to generate choices
 	var/list/choices = list()
 	var/list/spell_choices = list(/obj/effect/proc_holder/spell/invoked/projectile/fireball,
-		/obj/effect/proc_holder/spell/invoked/projectile/fireball/greater,
 		/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt,
 		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
 		/obj/effect/proc_holder/spell/invoked/projectile/spitfire,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes Greater Fireball from being learnable. Even if it is a 5 point spell, it should be Court Mage unique, and it will be.

## Why It's Good For The Game

Literally giving the Court Mage's main gimmick spell to everyone is kinda dumb, and there's a spell scroll that teaches it anyways.
