### PR TITLE
Revert "trainable up to tier 3 from dumby"

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -931,7 +931,7 @@
 					if(!L.rogfat_add(rand(4,6)))
 						if(ishuman(L))
 							var/mob/living/carbon/human/H = L
-							if(H.tiredness >= 75)
+							if(H.tiredness >= 50)
 								H.apply_status_effect(/datum/status_effect/debuff/trainsleep)
 						probby = 0
 					if(!(L.mobility_flags & MOBILITY_STAND))
@@ -942,7 +942,7 @@
 						user.visible_message(span_info("[user] trains on [src]!"))
 						var/boon = user.mind.get_learning_boon(W.associated_skill)
 						var/amt2raise = L.STAINT/2
-						if(user.mind.get_skill_level(W.associated_skill) >= SKILL_LEVEL_JOURNEYMAN)
+						if(user.mind.get_skill_level(W.associated_skill) >= SKILL_LEVEL_APPRENTICE)
 							to_chat(user, span_warning("I've learned all I can from doing this, it's time for the real thing."))
 							amt2raise = 0
 						if(amt2raise > 0)


### PR DESCRIPTION
Reverts Tree445/Hearthstone#447


**Went through this in Dev-Chat and the Coder-Dev Chat.**

Multiple people asked why this was added despite poor reception. I stated this wasn't a good idea, as did other coders/contributors, staff, and even players. The few arguments in favor given were:
- "But I don't wanna have to talk to people to train." - It's a roleplaying game. Roleplay with people, and play the role given. That or go play the class that is directly designated to have these skills; there's PLENTY to the point of role-bloat.
- "Blackstone did this." - No, that is blatantly false. No they did not; it can be seen in their files PR history. Blackstone did the change we already had, which was you were able to train to **apprentice** instead of **novice**. I get that change, but understand we ALSO already lowered exp requirements across the board to level up. Not only do we have this change, allowing you to level up, but we also _made it easier_ to level up _across the entire board_.
- "But towner needs this." - This has literally not helped towners (besides, funnily, woodcutter - since he gets good combat stats - and maybe thug) at all and is a terrible blanket change for every single role in the game to enable higher training, such as me bashing a dummy with a crossbow now to level 3 as just anyone, to then have equal crossbow training to other classes. It makes specialization near pointless and replaceable by wordless grinding and also just immensely helps already powerful roles.

I was going to hold off reverting this till doing a rework of feinting and feint intent but they should be done separate; thus this revert PR.

Rework the system if needed, evaluate _why_ classes struggle first. Workshop a fix, then do it. This really doesn't accomplish anything regarding actual issues. Please, encourage roleplay instead of mechanical, wordless grinding using the already publicly made dummies right near the gate itself to town..