### PR TITLE
Fixes Steward Desk Shutter

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -33789,6 +33789,12 @@
 	pixel_y = -6;
 	redstone_id = "stewardshutterout"
 	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "reception desk shutter";
+	pixel_y = 6;
+	redstone_id = "stewardshutter"
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "xXI" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Mentioned this back when Apple did a map change, they broke the steward desk shutter since one of the two levers I added got mapped out.

No one fixed it in over a week. So here, I fixed it. Second time I've had to do this change now..

## Why It's Good For The Game

Now the steward can open his damn reception shutter.