### PR TITLE
Royal guard, shoe correction

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/royalguard.dm
@@ -107,7 +107,7 @@
 	pants = /obj/item/clothing/under/roguetown/heavyroyalplatelegs	//Gets better pants than chain ones.
 	cloak = /obj/item/clothing/cloak/cape/guard
 	gloves = /obj/item/clothing/gloves/roguetown/plate
-	shoes = /obj/item/clothing/shoes/plate
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/signal_horn = 1)
 
 /datum/advclass/royalguard/knight
@@ -177,7 +177,7 @@
 
 /datum/outfit/job/roguetown/royalguard/archer/pre_equip(mob/living/carbon/human/H)
 	..()
-	//This class doesn't use the normal shared skill section; totally different!! 
+	//This class doesn't use the normal shared skill section; totally different!!
 	H.mind.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)	//Good as hell knife skill; makes them standout more compared to other guards.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Swaps out the royal guard (heavy)'s shoes from the OLD TG steel plate boots to the proper current steel plate boots that contain correct sprites for the races, along with proper stats.

Tested and spawning seems to be correct for the new steel plate boots.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently they spawn with shoes that only show up for human males, and are the old TG ones. which dont fit into the current code, cant be smelted down and im not even sure how well they stack up stat wise.

example image of the current ones, from user "ChaosSnek"

 
![Capture](https://github.com/user-attachments/assets/f715408c-846b-4f2f-8de2-0e0b5ebbc862)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
