### PR TITLE
Fixes Surgery

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -320,7 +320,7 @@
 		)
 		for(var/bleed_zone in bleed_zones)
 			var/obj/item/bodypart/bleeder = get_bodypart(bleed_zone)
-			if(!bleeder?.get_bleed_rate() || (!observer_privilege && !get_location_accessible(src, bleeder.body_zone, skip_undies = TRUE)))
+			if(!bleeder?.get_bleed_rate() || (!observer_privilege && !get_location_accessible(src, bleeder.body_zone, skipundies = TRUE)))
 				continue
 			bleeding_limbs += parse_zone(bleeder.body_zone)
 		if(length(bleeding_limbs))

--- a/code/modules/roguetown/roguejobs/fisher/leeches.dm
+++ b/code/modules/roguetown/roguejobs/fisher/leeches.dm
@@ -99,7 +99,7 @@
 		var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 		if(!affecting)
 			return
-		if(!get_location_accessible(H, check_zone(user.zone_selected), skip_undies = TRUE))
+		if(!get_location_accessible(H, check_zone(user.zone_selected), skipundies = TRUE))
 			to_chat(user, span_warning("Something in the way."))
 			return
 		var/used_time = (70 - (H.mind.get_skill_level(/datum/skill/misc/medicine) * 10))/2

--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -231,7 +231,7 @@
 				return FALSE
 	*/
 
-	if(!ignore_clothes && !get_location_accessible(target, target_zone || bodypart.body_zone, skip_undies = TRUE))
+	if(!ignore_clothes && !get_location_accessible(target, target_zone || bodypart.body_zone, skipundies = TRUE))
 		return FALSE
 
 	return TRUE

--- a/code/modules/surgery/bodyparts/bodypart_examine.dm
+++ b/code/modules/surgery/bodyparts/bodypart_examine.dm
@@ -57,7 +57,7 @@
 		bodypart_status += "[src] is dislocated."
 	var/location_accessible = TRUE
 	if(owner)
-		location_accessible = get_location_accessible(owner, body_zone, skip_undies = TRUE)
+		location_accessible = get_location_accessible(owner, body_zone, skipundies = TRUE)
 		if(!observer_privilege && !location_accessible)
 			bodypart_status += "Obscured by clothing."
 	var/owner_ref = owner ? REF(owner) : REF(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Surgery was being prevented due to a variable mismatch. I tested it after changing all instances of skip_undies to skipundies in line with everything else that uses the same variable. Tested it, I was able to do surgery on myself as well as apply leeches.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pestra demands it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
