### PR TITLE
Removes Time Stop because our event makers can't be trusted

### DIFF
--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -163,7 +163,7 @@
 	invocation = "HO HO HO"
 	clothes_req = FALSE
 	say_destination = FALSE // Santa moves in mysterious ways
-
+/*
 /obj/effect/proc_holder/spell/aoe_turf/timestop
 	name = "Stop Time"
 	desc = ""
@@ -195,7 +195,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/timestop_greater/cast(list/targets, mob/user = usr)
 	new /obj/effect/timestop/magic(get_turf(user), timestop_range, timestop_duration, list(user))
-
+*/ 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/Wolf
 	name = "Summon Volf"
 	desc = ""


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/user-attachments/assets/f3df105f-c8e1-493e-b97b-466372bcc69f)
This PR gets rid of the time stop spell so GMs can stop abusing it during their subpar events.

## Why It's Good For The Game

Observe:
 https://www.youtube.com/watch?v=RYVBlJdQcww