### PR TITLE
Actually Fixes Cloistered Devout, Electric Boogaloo

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -175,6 +175,25 @@
 	update_devotion(300, CLERIC_REQ_4, silent = TRUE)
 	START_PROCESSING(SSobj, src)
 
+/datum/devotion/proc/grant_spells_devout(mob/living/carbon/human/H)
+	if(!H || !H.mind || !patron)
+		return
+
+	granted_spells = list()
+	var/list/spelllist = list(patron.t0, patron.t1)
+	for(var/spell_type in spelllist)
+		if(!spell_type || H.mind.has_spell(spell_type))
+			continue
+		var/newspell = new spell_type
+		H.mind.AddSpell(newspell)
+		LAZYADD(granted_spells, newspell)
+	level = CLERIC_T1
+	max_progression = CLERIC_REQ_3
+	passive_devotion_gain = 1
+	passive_progression_gain = 1
+	update_devotion(100, CLERIC_REQ_4, silent = TRUE)
+	START_PROCESSING(SSobj, src)
+
 // Debug verb
 /mob/living/carbon/human/proc/devotionchange()
 	set name = "(DEBUG)Change Devotion"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -177,12 +177,7 @@
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	// HEARTHSTONE ADDITION: cloistered devout devo regen & tier buff
 	if (classchoice == "Cloistered Devout")
-		// start with passive devo gain and ability to gain up to T3 spells
-		C.passive_devotion_gain += 0.5 //REQUIRES passive_progression_gain to function.
-		C.passive_progression_gain += 0.5 //People need to check how this works in future.
-		C.max_progression = CLERIC_REQ_3
-		C.max_devotion = CLERIC_REQ_4 //They have the same CAPACITY as priest, but will never be able to reach cure rot/T4 spells
-		C.grant_spells(H) // don't give churn as an extra spell to cloistered since they get their patron's full spell list (up to t3)
+		C.grant_spells_devout(H)
 	else
 		C.grant_spells_cleric(H)
 	// HEARTHSTONE ADDITION END


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
I went and did several test runs of the code and came to the conclusion that the reason devout doesnt get regen is because passive_devotion_gain can only work with whole numbers. 
I also went and created a grant_spells_devout proc to make the devout section of the job role prettier, and for possible future use in other jobs without slopping the job file further.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its been 'fixed' three times now, I think, but I've identified what the problem was successfully. I actually tested this, and it is working as desired.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
