### PR TITLE
Surgery XP Gain Fix

### DIFF
--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -75,6 +75,8 @@
 		6 = -1,
 	)
 
+	var/experience_multiplier = 0.5 // Multiply int with this for total XP gain
+
 	/// Handles techweb-oriented surgeries
 	var/requires_tech = FALSE
 	/**
@@ -317,6 +319,9 @@
 	LAZYREMOVE(target.surgeries, target_zone)
 	var/success = !try_to_fail && ((iscyborg(user) && !silicons_obey_prob) || prob(success_prob)) && chem_check(target)
 	if(success && success(user, target, target_zone, tool, intent))
+		if(ishuman(user))
+			var/mob/living/carbon/human/doctor = user
+			user.mind.adjust_experience(/datum/skill/misc/medicine, doctor.STAINT * (skill_min * experience_multiplier))
 		play_success_sound(user, target, target_zone, tool)
 		if(repeating && can_do_step(user, target, target_zone, tool, intent, try_to_fail))
 			initiate(user, target, target_zone, tool, intent, try_to_fail)

--- a/code/modules/surgery/surgeries/amputation.dm
+++ b/code/modules/surgery/surgeries/amputation.dm
@@ -36,6 +36,7 @@
 	requires_bodypart_type = NONE
 	skill_min = SKILL_LEVEL_APPRENTICE
 	skill_median = SKILL_LEVEL_JOURNEYMAN
+	experience_multiplier = 3
 	preop_sound = 'sound/surgery/scalpel1.ogg'
 	success_sound = 'sound/surgery/organ2.ogg'
 

--- a/code/modules/surgery/surgeries/amputation.dm
+++ b/code/modules/surgery/surgeries/amputation.dm
@@ -47,12 +47,9 @@
 	return TRUE
 
 /datum/surgery_step/amputate/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I sever [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] severs [target]'s [parse_zone(target_zone)]!"),
 		span_notice("[user] severs [target]'s [parse_zone(target_zone)]!"))
 	var/obj/item/bodypart/target_limb = target.get_bodypart(check_zone(target_zone))
 	target_limb?.drop_limb()
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries/dislocation.dm
+++ b/code/modules/surgery/surgeries/dislocation.dm
@@ -36,6 +36,7 @@
 	ignore_clothes = TRUE
 	skill_min = SKILL_LEVEL_APPRENTICE
 	skill_median = SKILL_LEVEL_JOURNEYMAN
+	experience_multiplier = 3
 
 /datum/surgery_step/relocate_bone/validate_bodypart(mob/user, mob/living/carbon/target, obj/item/bodypart/bodypart, target_zone)
 	. = ..()

--- a/code/modules/surgery/surgeries/dislocation.dm
+++ b/code/modules/surgery/surgeries/dislocation.dm
@@ -51,8 +51,6 @@
 	return TRUE
 
 /datum/surgery_step/relocate_bone/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I successfully relocate the bone in [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] successfully relocate the bone in [target]'s [parse_zone(target_zone)]!"),
 		span_notice("[user] successfully relocate the bone in [target]'s [parse_zone(target_zone)]!"))
@@ -60,5 +58,4 @@
 	if(bodypart)
 		for(var/datum/wound/dislocation/bone in bodypart.wounds)
 			bone.relocate_bone()
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries/fracture.dm
+++ b/code/modules/surgery/surgeries/fracture.dm
@@ -35,6 +35,7 @@
 	surgery_flags = SURGERY_INCISED | SURGERY_RETRACTED | SURGERY_BROKEN
 	skill_min = SKILL_LEVEL_JOURNEYMAN
 	skill_median = SKILL_LEVEL_EXPERT
+	experience_multiplier = 3
 
 /datum/surgery_step/set_bone/validate_bodypart(mob/user, mob/living/carbon/target, obj/item/bodypart/bodypart, target_zone)
 	. = ..()

--- a/code/modules/surgery/surgeries/fracture.dm
+++ b/code/modules/surgery/surgeries/fracture.dm
@@ -50,8 +50,6 @@
 	return TRUE
 
 /datum/surgery_step/set_bone/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I successfully set the bone in [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] successfully sets the bone in [target]'s [parse_zone(target_zone)]!"),
 		span_notice("[user] successfully sets the bone in [target]'s [parse_zone(target_zone)]!"))
@@ -59,5 +57,4 @@
 	if(bodypart)
 		for(var/datum/wound/fracture/bone in bodypart.wounds)
 			bone.set_bone()
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -61,8 +61,6 @@
 	return TRUE
 
 /datum/surgery_step/heal/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	var/umsg = "You succeed in fixing some of [target]'s wounds" //no period, add initial space to "addons"
 	var/tmsg = "[user] fixes some of [target]'s wounds" //see above
 	var/urhealedamt_brute = brutehealing
@@ -80,7 +78,6 @@
 	display_results(user, target, span_notice("[umsg]."),
 		"[tmsg].",
 		"[tmsg].")
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.2)
 	return TRUE
 
 /datum/surgery_step/heal/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -24,6 +24,7 @@
 	surgery_flags = SURGERY_BLOODY | SURGERY_INCISED | SURGERY_CLAMPED
 	skill_min = SKILL_LEVEL_APPRENTICE
 	skill_median = SKILL_LEVEL_APPRENTICE
+	experience_multiplier = 1
 	/// How much brute damage we heal per completion
 	var/brutehealing = 0
 	/// How much burn damage we heal per completion

--- a/code/modules/surgery/surgeries/limb_replacement.dm
+++ b/code/modules/surgery/surgeries/limb_replacement.dm
@@ -42,8 +42,6 @@
 	return TRUE
 
 /datum/surgery_step/replace_limb/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	var/mob/living/M = user
-
 	var/obj/item/bodypart/existing = target.get_bodypart(check_zone(target_zone))
 	if(existing)
 		if(istype(tool, /obj/item/organ_storage))
@@ -61,5 +59,4 @@
 		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent?.name)]")
 	else
 		to_chat(user, span_warning("[target] has no organic [parse_zone(target_zone)] there!"))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries/limb_replacement.dm
+++ b/code/modules/surgery/surgeries/limb_replacement.dm
@@ -19,6 +19,7 @@
 	surgery_flags = SURGERY_INCISED | SURGERY_RETRACTED | SURGERY_BROKEN
 	skill_min = SKILL_LEVEL_JOURNEYMAN
 	skill_median = SKILL_LEVEL_EXPERT
+	experience_multiplier = 3
 
 /datum/surgery_step/replace_limb/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	if(istype(tool, /obj/item/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))

--- a/code/modules/surgery/surgeries/organ_manipulation.dm
+++ b/code/modules/surgery/surgeries/organ_manipulation.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 	surgery_flags = SURGERY_INCISED | SURGERY_RETRACTED
 	skill_min = SKILL_LEVEL_JOURNEYMAN
 	skill_median = SKILL_LEVEL_EXPERT
+	experience_multiplier = 3
 	preop_sound = 'sound/surgery/organ2.ogg'
 	success_sound = 'sound/surgery/organ1.ogg'
 	/// Implements used to extract an organ - This really should be split into two different steps...

--- a/code/modules/surgery/surgeries/organ_manipulation.dm
+++ b/code/modules/surgery/surgeries/organ_manipulation.dm
@@ -129,8 +129,6 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 	return TRUE
 
 /datum/surgery_step/manipulate_organs/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	if(istype(tool, /obj/item/organ_storage))
 		tool.icon_state = initial(tool.icon_state)
 		tool.desc = initial(tool.desc)
@@ -145,7 +143,6 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 		display_results(user, target, span_notice("I insert [tool] into [target]'s [parse_zone(target_zone)]."),
 			span_notice("[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!"),
 			span_notice("[user] inserts something into [target]'s [parse_zone(target_zone)]!"))
-		M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 		return TRUE
 	var/obj/item/organ/selected_organ = target.getorganslot(user.organ_slot_selected)
 	if(QDELETED(selected_organ) || (selected_organ.owner != target))
@@ -160,7 +157,6 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 	selected_organ.Remove(target)
 	selected_organ.forceMove(target.drop_location())
 	user.put_in_hands(selected_organ)
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE
 
 /datum/surgery_step/make_organs
@@ -216,8 +212,6 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 	return TRUE
 
 /datum/surgery_step/make_organs/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	if(!isnull(target.getorganslot(user.organ_slot_selected)))
 		to_chat(user, span_warning("[target] alread has that organ!"))
 		return FALSE
@@ -229,5 +223,4 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 	var/datum/organ_dna/organ_template = carbonized.dna.organ_dna[user.organ_slot_selected]
 	var/obj/item/organ/organ_to_add = organ_template.create_organ(target)
 	organ_to_add.Insert(target)
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries/organic_steps.dm
+++ b/code/modules/surgery/surgeries/organic_steps.dm
@@ -23,11 +23,8 @@
 	return TRUE
 
 /datum/surgery_step/incise/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("Blood pools around the incision in [target]'s [parse_zone(target_zone)]."),
 		span_notice("Blood pools around the incision in [target]'s [parse_zone(target_zone)]."))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.4)
 	var/obj/item/bodypart/gotten_part = target.get_bodypart(check_zone(target_zone))
 	if(gotten_part)
 		gotten_part.add_wound(/datum/wound/slash/incision)
@@ -53,12 +50,9 @@
 	return TRUE
 
 /datum/surgery_step/clamp/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I clamp the bleeders in [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] clamps the bleeders in [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] clamps the bleeders in [target]'s [parse_zone(target_zone)]."))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.4)
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	bodypart?.add_embedded_object(tool, crit_message = FALSE)
 	return TRUE
@@ -84,12 +78,9 @@
 	return TRUE
 
 /datum/surgery_step/retract/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-	
 	display_results(user, target, span_notice("I retract [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] retract [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] retract [target]'s [parse_zone(target_zone)]."))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.4)
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	bodypart?.add_embedded_object(tool, crit_message = FALSE)
 	return TRUE
@@ -122,12 +113,9 @@
 	return TRUE
 
 /datum/surgery_step/cauterize/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I cauterize the wounds on [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] cauterizes the wounds on [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] cauterizes the wounds on [target]'s [parse_zone(target_zone)]."))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.4)
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	if(bodypart)
 		for(var/datum/wound/bleeder in bodypart.wounds)
@@ -174,12 +162,9 @@
 	return TRUE
 
 /datum/surgery_step/saw/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I saw [target]'s [parse_zone(target_zone)] open."),
 		span_notice("[user] saws [target]'s [parse_zone(target_zone)] open!"),
 		span_notice("[user] saws [target]'s [parse_zone(target_zone)] open!"))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.4)
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	if(bodypart)
 		var/fracture_type = /datum/wound/fracture
@@ -217,12 +202,9 @@
 	return TRUE
 
 /datum/surgery_step/drill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	var/mob/living/M = user
-
 	display_results(user, target, span_notice("I drill into [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] drills into [target]'s [parse_zone(target_zone)]!"),
 		span_notice("[user] drills into [target]'s [parse_zone(target_zone)]!"))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*0.4)
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	bodypart?.add_wound(/datum/wound/puncture/drilling)
 	target.emote("scream")

--- a/code/modules/surgery/surgeries/plastic_surgery.dm
+++ b/code/modules/surgery/surgeries/plastic_surgery.dm
@@ -32,8 +32,6 @@
 	return TRUE
 
 /datum/surgery_step/reshape_face/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	if(bodypart?.has_wound(/datum/wound/facial/disfigurement))
 		display_results(user, target, span_notice("I successfully restore [target]'s appearance."),
@@ -66,7 +64,6 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
 		human_target.sec_hud_set_ID()
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE
 
 /datum/surgery_step/reshape_face/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries/plastic_surgery.dm
+++ b/code/modules/surgery/surgeries/plastic_surgery.dm
@@ -22,6 +22,7 @@
 	surgery_flags = SURGERY_BLOODY | SURGERY_INCISED | SURGERY_CLAMPED | SURGERY_RETRACTED
 	skill_min = SKILL_LEVEL_JOURNEYMAN
 	skill_median = SKILL_LEVEL_EXPERT
+	experience_multiplier = 3
 
 /datum/surgery_step/reshape_face/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	user.visible_message(span_notice("[user] begins to alter [target]'s appearance."), span_notice("I begin to alter [target]'s appearance..."))

--- a/code/modules/surgery/surgeries/prosthetic_replacement.dm
+++ b/code/modules/surgery/surgeries/prosthetic_replacement.dm
@@ -65,8 +65,6 @@
 	return TRUE
 
 /datum/surgery_step/add_prosthetic/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	if(istype(tool, /obj/item/organ_storage))
 		tool.icon_state = initial(tool.icon_state)
 		tool.desc = initial(tool.desc)
@@ -81,5 +79,4 @@
 	display_results(user, target, span_notice("I succeed transplanting [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] successfully transplants [target]'s [parse_zone(target_zone)] with [tool]!"),
 		span_notice("[user] successfully transplants [target]'s [parse_zone(target_zone)]!"))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries/prosthetic_replacement.dm
+++ b/code/modules/surgery/surgeries/prosthetic_replacement.dm
@@ -35,6 +35,7 @@
 	requires_bodypart_type = NONE
 	skill_min = SKILL_LEVEL_EXPERT
 	skill_median = SKILL_LEVEL_MASTER
+	experience_multiplier = 3
 
 /datum/surgery_step/add_prosthetic/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	if(istype(tool, /obj/item/organ_storage))

--- a/code/modules/surgery/surgeries/remove_embedded_object.dm
+++ b/code/modules/surgery/surgeries/remove_embedded_object.dm
@@ -42,8 +42,6 @@
 	return TRUE
 
 /datum/surgery_step/remove_object/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))
 	var/objects = 0
 	if(bodypart)
@@ -59,7 +57,6 @@
 		display_results(user, target, span_notice("I successfully remove [objects] object[s] from [target]'s [bodypart]."),
 			span_notice("[user] successfully removes [objects] object[s] from [target]'s [bodypart]!"),
 			span_notice("[user] successfully removes [objects] object[s] from [target]'s [bodypart]!"))
-		M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*1.5)
 	else if(bodypart)
 		to_chat(user, span_warning("I find no objects embedded in [target]'s [bodypart]!"))
 	else

--- a/code/modules/surgery/surgeries/remove_embedded_object.dm
+++ b/code/modules/surgery/surgeries/remove_embedded_object.dm
@@ -17,6 +17,7 @@
 	surgery_flags = SURGERY_INCISED
 	skill_min = SKILL_LEVEL_NOVICE
 	skill_median = SKILL_LEVEL_NOVICE
+	experience_multiplier = 3
 	preop_sound = 'sound/surgery/organ2.ogg'
 	success_sound = 'sound/surgery/organ1.ogg'
 

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -20,6 +20,7 @@
 	time = 8 SECONDS
 	surgery_flags = SURGERY_INCISED
 	skill_min = SKILL_LEVEL_APPRENTICE
+	experience_multiplier = 5
 	preop_sound = 'sound/surgery/cautery1.ogg'
 	success_sound = 'sound/surgery/cautery2.ogg'
 

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -32,8 +32,6 @@
 
 // most of this is copied from the Cure Rot spell
 /datum/surgery_step/burn_rot/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	var/burndam = 20
 	if(user.mind)
 		burndam -= (user.mind.get_skill_level(/datum/skill/misc/medicine) * 3)
@@ -70,5 +68,4 @@
 		"[user] burns the rot within [target].",
 		"[user] takes a [tool] to [target]'s innards.")
 	target.take_bodypart_damage(null, burndam)
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -21,6 +21,7 @@
 	time = 8 SECONDS
 	surgery_flags = SURGERY_BLOODY | SURGERY_INCISED | SURGERY_CLAMPED | SURGERY_RETRACTED | SURGERY_BROKEN
 	skill_min = SKILL_LEVEL_APPRENTICE
+	experience_multiplier = 3
 	preop_sound = 'sound/surgery/organ2.ogg'
 	success_sound = 'sound/surgery/organ1.ogg'
 

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -38,8 +38,6 @@
 	return TRUE
 
 /datum/surgery_step/extract_lux/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	target.emote("painscream")
 	if(target.has_status_effect(/datum/status_effect/debuff/devitalised))
 		display_results(user, target, span_notice("You cannot draw lux from [target]; they have none left to give."),
@@ -52,5 +50,4 @@
 			"[user] extracts lux from [target]'s innards.")
 		new /obj/item/reagent_containers/lux(target.loc)
 		target.apply_status_effect(/datum/status_effect/debuff/devitalised)
-		M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	return TRUE

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -36,8 +36,6 @@
 	return TRUE
 
 /datum/surgery_step/infuse_lux/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	var/mob/living/M = user
-
 	var/revive_pq = PQ_GAIN_REVIVE
 	if(target.mob_biotypes & MOB_UNDEAD)
 		display_results(user, target, span_notice("You cannot infuse life into the undead! The rot must be cured first."),
@@ -63,7 +61,6 @@
 	target.Jitter(100)
 	target.update_body()
 	target.visible_message(span_notice("[target] is dragged back from Necra's hold!"), span_green("I awake from the void."))
-	M.mind.adjust_experience(/datum/skill/misc/medicine, M.STAINT*5)
 	qdel(tool)
 	if(target.mind)
 		if(revive_pq && !HAS_TRAIT(target, TRAIT_IWASREVIVED) && user?.ckey)

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -19,6 +19,7 @@
 	time = 10 SECONDS
 	surgery_flags = SURGERY_BLOODY | SURGERY_INCISED | SURGERY_CLAMPED | SURGERY_RETRACTED | SURGERY_BROKEN
 	skill_min = SKILL_LEVEL_JOURNEYMAN
+	experience_multiplier = 5
 	preop_sound = 'sound/surgery/organ2.ogg'
 	success_sound = 'sound/surgery/organ1.ogg'
 

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
@@ -35,10 +35,11 @@
 	. = 1
 
 /datum/reagent/medicine/soporpot/overdose_process(mob/living/carbon/M)
-	M.drowsiness += 2
+	M.drowsyness += 2
 	M.confused += 2
 	..()
 	. = 1 
+
 /datum/reagent/medicine/fortitudepot
 	name = "Fortitude Potion"
 	description = "Increases one's Strength and Constitution."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Applies a varying xp gain to all surgery steps. 
Also fixes a typo in my soporific reagent, idk how I missed that. 😩 

Applies a check to the success proc that adds a variable xp rate depending on the difficulty of the surgery, scaling with intelligence. Also adds an experience_multiplier variable to surgery steps, which allows for another level of customizable rates. Useful for cases like damage repair, that succeed multiple times until its finished.

Thanks to [EvenInDeathIStillServe](https://github.com/EvenInDeathIStillServe) for showing me a less spaghetti way of accomplishing this!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tired of seeing people cut themselves open and sew themselves shut to train medicine.
Do invasive explorative surgery. The more invasive, the more xp. Cut out organs, learn the body, quit the teen angst attention seeking RP to train medicine.

Doing actual surgery is faster to train with this pr.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
