### PR TITLE
druid tweaks

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,9 +7,10 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/church/chapel)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -2664,6 +2665,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/rtfield)
+"bqH" = (
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "bqP" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/bath)
@@ -13198,12 +13203,9 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/druid{
-	dir = 8
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -17132,6 +17134,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/town/basement)
+"lLK" = (
+/obj/effect/landmark/start/druid,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
@@ -22543,6 +22549,15 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"pDA" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_y = -7;
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "pDF" = (
 /obj/structure/table/wood{
 	icon_state = "map5"
@@ -23645,9 +23660,6 @@
 /area/rogue/indoors)
 "qoi" = (
 /obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/druid{
-	dir = 8
-	},
 /obj/effect/landmark/start/farmer{
 	dir = 8
 	},
@@ -29896,6 +29908,11 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/snow,
 /area/rogue/outdoors/vikingarea)
+"uPa" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/landmark/start/druid,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uPg" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/ruinedwood,
@@ -304288,7 +304305,7 @@ qvR
 uaL
 qvR
 qvR
-aac
+qvR
 qvR
 qvR
 qvR
@@ -324398,7 +324415,7 @@ qvR
 wSn
 wOD
 dUZ
-iRN
+dUZ
 kRf
 ltT
 ltT
@@ -428056,7 +428073,7 @@ nSr
 teW
 ael
 cLL
-hqI
+iRN
 fUr
 hqI
 wte
@@ -428456,9 +428473,9 @@ teW
 uzT
 fnF
 teW
-htU
-hqI
-htU
+pDA
+bqH
+aac
 hqI
 gdJ
 uGf
@@ -429663,9 +429680,9 @@ rSg
 swm
 teW
 ajj
+lLK
 hqI
-hqI
-fUr
+uPa
 tML
 tML
 ffv

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -2665,10 +2665,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/rtfield)
-"bqH" = (
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "bqP" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/bath)
@@ -13203,7 +13199,13 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/rogueweapon/hoe,
 /obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "iRR" = (
@@ -428474,7 +428476,7 @@ uzT
 fnF
 teW
 pDA
-bqH
+hqI
 aac
 hqI
 gdJ

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -37,7 +37,7 @@
 		/obj/item/seeds/apple = 1,
 		/obj/item/seeds/shroom = 1,
 		/obj/item/seeds/sweetleaf = 1,
-		/obj/item/seeds/pipeweed = 1,
+		/obj/item/roguekey/church = 1,
 	)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -32,7 +32,13 @@
 	head = /obj/item/clothing/head/roguetown/dendormask
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
-	backpack_contents = list(/obj/item/roguekey/farm = 1)		//Should populate pouch with this.
+	backpack_contents = list(
+		/obj/item/seeds/wheat = 1,
+		/obj/item/seeds/apple = 1,
+		/obj/item/seeds/shroom = 1,
+		/obj/item/seeds/sweetleaf = 1,
+		/obj/item/seeds/pipeweed = 1,
+	)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
* Removes farm key from druid loadout. Replaced with church key.
* Moves druid spawn markers to the church courtyard.
* Adds bucket, sack, thresher, hoe (to hoe up the grass), and shovel (to flatten fields) near druid spawn in a locked chest.
* Adds one wheat, apple, eldershroom, and swampweed seed to druid’s satchel on spawn.

![image](https://github.com/user-attachments/assets/83aa8a84-f8df-4341-b7f2-0c60973fea3e)

## Why It's Good For The Game
Druids can farm anywhere they want on the map, so for them to beeline at the one place soilsons have to themselves and take it over, pushes the soilers out and eliminates the need for one to join midround at all. Spawn was moved to encourage interaction, and reinforce alignment with the church. Seeds were chosen to encourage more witchy, utilitarian purposes with farming. Wheat and apple seed was added as safety net for rounds without soilers present to provide food.

This PR doesn’t solve the inherent issue with druids being soiler+ right off the bat, but it’s a start.

