### PR TITLE
Noc's Enlightened Part 2: Species Edition

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
@@ -5,9 +5,9 @@
 	name = "Axian"
 	id = "akula"
 	desc = "<b>Axian</b><br>\
-		A race of sharklike people, Axian settlements are dotted along the coastline of the continents. 
-		A society mainly consisting of fishermen, the Axians ply their trade, and are some of the best sailors in all of Grimoria. 
-		Some Axians go so far as to put down the rod and take up the cutlass, roaming the seas as pirates. 
+		A race of sharklike people, Axian settlements are dotted along the coastline of the continents. \
+		A society mainly consisting of fishermen, the Axians ply their trade, and are some of the best sailors in all of Grimoria. \
+		Some Axians go so far as to put down the rod and take up the cutlass, roaming the seas as pirates. \
 		Clever and strong, the Axians can make the most of bad situations, and rarely give up. Abyssor, Malum and Ravox are their preferred gods of worship."
 
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)

--- a/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
@@ -4,7 +4,7 @@
 /datum/species/akula
 	name = "Axian"
 	id = "akula"
-	desc = "An empre, now a diaspora. \
+	desc = "<b>Axian</b><br>\
 		A race of sharklike people, Axian settlements are dotted along the coastline of the continents. 
 		A society mainly consisting of fishermen, the Axians ply their trade, and are some of the best sailors in all of Grimoria. 
 		Some Axians go so far as to put down the rod and take up the cutlass, roaming the seas as pirates. 

--- a/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
@@ -5,9 +5,11 @@
 	name = "Axian"
 	id = "akula"
 	desc = "An empre, now a diaspora. \
-	In old times, the empire of Ei'doan was a mighty mercantile and colonial force that ruled the seas. A century of steady decline saw them cede, lose. or abandon most of our overseas colonies. \
-	Many Akula who had come to these colonies during the empire's height simply stayed, due to marrying into certain families, or to keep their livelihoods. It is not rare to find one of my kind in nobility, or townhood, or as a wanderer. \
-	Though a strong naval tradition has left us sharp-witted and strong, we are poorly-adapted to see well in such a boggy, rocky locale."
+		A race of sharklike people, Axian settlements are dotted along the coastline of the continents. 
+		A society mainly consisting of fishermen, the Axians ply their trade, and are some of the best sailors in all of Grimoria. 
+		Some Axians go so far as to put down the rod and take up the cutlass, roaming the seas as pirates. 
+		Clever and strong, the Axians can make the most of bad situations, and rarely give up. Abyssor, Malum and Ravox are their preferred gods of worship."
+
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_WATERBREATHING)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -5,15 +5,12 @@
 	name = "Wild-Kin"
 	id = "anthromorph"
 	desc = "<b>Wild-Kin</b><br>\
-	The Wild Volk are the errant children of Dendor, to whom they all share an innate connection. \
-	Wild-Kin arise in all the lands of Grimoria and are nearly as widespread as Humens.<br>\
-	Wild-Kin are humanoid animals, sometimes limited to one specific species or a hybrid of multiple. \
-	Of all the races, Wild-Kin has the most variety in appearance.<br>\
-	Despite the Wild Volk’s connection to Dendor, he is not the most favored god of their kind. \
-	Many Wild-Kin believe that remaining civilized is of the utmost importance to keep their humanity and differentiate them from the beasts of the wilderness. \
-	They fear that they will be unable to resist Dendor’s Call when the time comes for him to gather his children.<br>\
-	<br>\
-	We are highly perceptive but slow to learn new skills and ideas."
+		The Wild-Kin, children of Dendor, they live in dense forests and prefer nature to the cities. \
+		But there are those Wild-Kin who have adapted to city life, living there as woodsmen and rangers. \
+		Where there is nature, there are Wild-Kin, and they largely live in peace wherever they are. \
+		The Wild-Kin can appear in many different forms, catlike Wild-Kin which inhabit the deserts of Valoria to the more foxlike Wild-Kin who live in the Great Forests of Dendor itself. \
+		Wild-Kin as a species are so vast and numerous that to catalogue every specific type of Wild-Kin would take ten lifetimes. \
+		Due to their relationship with nature, they favor Dendor of the divine pantheon, but that isn't to say that some Wild-Kin do not worship other gods, such as Abyssor, Malum or even Ravox."
 
 	skin_tone_wording = "Habitat"
 	default_color = "444"

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
@@ -4,8 +4,12 @@
 /datum/species/anthromorphsmall
 	name = "Verminvolk"
 	id = "anthromorphsmall"
-	desc = "A race akin to wild-kin, except afflicted with significantly smaller stature. I'm a bit less respected than my kin due to their closer resemblance to vermin, like the dichotomy between Kobold and Sissean. \
-	We're far weaker of constitution and strength than other races, but make up for it in our agility...and oddly uncanny luck."
+	desc = ""<b>Verminvolk</b><br>\
+		A squat, unusual people, they are greatly related to Wild-Kin, in the same way a Kobold might be related to a dragon. 
+		Like Wild-Kin their appearance can vary greatly, and they are largely looked down upon by their more pure brethren due in part to their height. 
+		But in spite of this Verminvolk make the most of their lot in life, a cheery folk, you'll find them working as artisans, bakers, cheesemakers, a few of them even working as watchmen. 
+		They, like Wild-Kin, worship Dendor primarily in the Divine Pantheon, but many also worship Eora, Malum, and Abyssor."
+
 	default_color = "444"
 	species_traits = list(
 		MUTCOLORS,

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
@@ -5,9 +5,9 @@
 	name = "Verminvolk"
 	id = "anthromorphsmall"
 	desc = ""<b>Verminvolk</b><br>\
-		A squat, unusual people, they are greatly related to Wild-Kin, in the same way a Kobold might be related to a dragon. 
-		Like Wild-Kin their appearance can vary greatly, and they are largely looked down upon by their more pure brethren due in part to their height. 
-		But in spite of this Verminvolk make the most of their lot in life, a cheery folk, you'll find them working as artisans, bakers, cheesemakers, a few of them even working as watchmen. 
+		A squat, unusual people, they are greatly related to Wild-Kin, in the same way a Kobold might be related to a dragon. \
+		Like Wild-Kin their appearance can vary greatly, and they are largely looked down upon by their more pure brethren due in part to their height. \
+		But in spite of this Verminvolk make the most of their lot in life, a cheery folk, you'll find them working as artisans, bakers, cheesemakers, a few of them even working as watchmen. \
 		They, like Wild-Kin, worship Dendor primarily in the Divine Pantheon, but many also worship Eora, Malum, and Abyssor."
 
 	default_color = "444"

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -5,15 +5,10 @@
 	name = "Half-Kin"
 	id = "demihuman"
 	desc = "<b>Half-Kin</b><br>\
-	A half-breed that arises in Humens with Wild-Kin in their lineage. \
-	They are children of Dendor by blood, but their Humen heritage makes this connection impotent. \
-	Half-Kin are said to be the only ones of Dendor’s progeny who can resist his Call of the Wild.<br>\
-	They bear animalistic features, most commonly bestial ears and tails modifying their base Humen form. \
-	These features that mark Half-Kin apart can skip generations, and many half-breeds are born to Humen parents with only a distant Wild-Kin ancestor.<br>\
-	As they are typically born to Humens, most Half-Kin worship the Divine Pantheon.<br>\
-	<br>\
-	Our bodies bear the flaws and benefits of both Humens and Wild-Kin, to a lesser degree. \
-	We are skilled with bows and have great endurance. However, we adapt slowly to new ideas."
+		Half-Kin are the resulting offspring of a relation between Wild-Kin and Humens or Elves. \
+		The Half-Kin take on some features of both parents, a Half-Kin with an Elven parent may have sharp ears, as well as whatever features their Wild-Kin parent possessed. \
+		Half-Kin take to the cities much more easily than their purebred counterparts, and integrate rather easily into whatever society they find themselves in. \
+		Their relationship to Dendor, diluted somewhat, is not as strong as pure Wild-Kin, as such they worship any god of the divine pantheon, with many favoring no particular god among them."
 
 	skin_tone_wording = "Ancestry"
 	default_color = "FFFFFF"

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -4,7 +4,7 @@
 /datum/species/dracon
 	name = "Drakian"
 	id = "dracon"
-	desc = "<b>Axian</b><br>\
+	desc = "<b>Drakian</b><br>\
 		Centuries ago, the Drakian people spanned all along what is now the Dwarven Federation, but during what was known as 'The Dark Year', they were forced out of their lifelong homes in the mountain ranges and scattered to the wind, ending up all over the world where it isn't too cold. \
 		Self righteous and prideful, Drakians often point their snouts up at those they consider to be lesser races, a strong people, but not very dextrous. \
 		Mages are rare in Drakian society, and Drakians much prefer to be soldiers of some sort than any other role. They predominantly worship Ravox."

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -4,10 +4,11 @@
 /datum/species/dracon
 	name = "Drakian"
 	id = "dracon"
-	desc = "The most ancient and proud race. We are strong, independent Creachers that follow no masters and accept no compromise. \
-	Our empire, the Muhwing Dynasty, has ruled the great plains east of Rockhill for thousands of years- and for good reason. We are immaculate \
-	warriors, raised from birth to be immaculately powerful and hardy. Mages are rare amongst us, and very little crafts and writing exists in our empire beyond the practical. \
-	Though we are incredibly powerful and sturdy, the rest of our aspects are...lacking. Members of my race are undefeated in strength, but lack in the dexterity for lucky, decisive blows."
+	desc = "<b>Axian</b><br>\
+		Centuries ago, the Drakian people spanned all along what is now the Dwarven Federation, but during what was known as 'The Dark Year', they were forced out of their lifelong homes in the mountain ranges and scattered to the wind, ending up all over the world where it isn't too cold. \
+		Self righteous and prideful, Drakians often point their snouts up at those they consider to be lesser races, a strong people, but not very dextrous. \
+		Mages are rare in Drakian society, and Drakians much prefer to be soldiers of some sort than any other role. They predominantly worship Ravox."
+
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
@@ -5,7 +5,12 @@
 	name = "Kobold"
 	id = "kobold"
 	desc = "<b>Kobold</b><br>\
-	In time you will learn the history of this race."
+		Thought by some scholars to be cousins to the Verminvolk, Kobolds are a small, lizardlike race which prefers to live underground. \
+		Like Dwarves their primary occupation is as miners, but some of them also dabble in smithing and crafting, a few still even entering into military service. \
+		The color of a Kobold's scales is largely determined by their parents, if a blue Kobold and a red Kobold were to have offspring then the resulting children would be purple for instance. \
+		Kobold mother's lay eggs, and guard them with their lives, although with few natural predators in their underground homes there isnt the fear of losing ones children as there once was. \
+		Kobold's worship the Divine Pantheon, mainly focused on Malum, but some Kobolds who feel an attraction to the sea prefer the worship of Abyssor instead."
+
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
@@ -5,10 +5,12 @@
 	name = "Sissean"
 	id = "lizardfolk"
 	desc = "<b>Sissean</b><br>\
-	Sisseans are semi-aquatic reptilian humanoids that have lived in the low bogs surrounding Rockhill for centuries. \
-	Though not as inclined to industry as the dwarves, and not as crafty as the other Humen and Wild-Kin natives, our strength is enormous, eclipsed only perhaps by the Draken.\
-	Though we are less perceptive and slower than other races, our constitution and strength are impressive. \
-	We also have sharp claws and teeth."
+		Similar to both the Drakians and Kobolds, Sisseans are a lizardlike people, with sharp claws and teeth. \
+		They prefer bogland to reside in, and many Sisseans live on the Island of Enigma, in some of its many bogs, a brave few even settling in the Terrorbog. \
+		Not as crafty or artistic as Humens, Elves or Dwarves, the Sisseans, like their Drakian cousins, much prefer martial roles to those of artisans or smiths. \
+		The Drakians look down on the Sisseans as being lesser, bog dwelling simpletons, but the Sisseans are largely content with their lot in life, and are a generally friendly people. \
+		They prefer to worship Abyssor in the Divine Pantheon, but others are known to worship Astrata, Ravox and Dendor."
+
 	skin_tone_wording = "Skin Colors"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)

--- a/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
@@ -5,12 +5,11 @@
 	name = "Lupian"
 	id = "lupian"
 	desc = "<b>Lupian</b><br>\
-	Lupians are the sons and daughters of Noc. They are a volf-like people hailing from the Northern Regions of the world. \
-	They are resilient, cunning and fight ready creachures capable of surviving the north thanks to their rugged pelts, \
-	sharp teeth and deep-rooted spirit of community. They are very dutiful individuals and make fantastic and fearsome \
-	warriors to those who earn their loyalty. Thanks to their pack minded nature they are slow to trust the other races \
-	but form deep connections with those they do. In recent years they have been driven from the forests by unrest and pressed \
-	into cohabitation with races they'd deem lesser."
+		Originating from the north, the Lupians are a race of wolflike peoples, living in tight knight packs. \
+		With thick pelts and sharp teeth, for centuries they have managed to survive in places other races would not. \
+		Due to their packlike mentality, they are slow to trust outsiders, but when they do a deep connection is formed which will last until death. \
+		The sons and daughters of Noc, they prefer her over the other gods in the Divine Pantheon, and howl at the moon whenever they see it as a form of prayer."
+
 	skin_tone_wording = "Pack"
 	species_traits = list(
 		MUTCOLORS,

--- a/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
@@ -4,9 +4,13 @@
 /datum/species/moth
 	name = "Fluvian"
 	id = "moth"
-	desc = "A race that hails from the far-away land of Deine-Coad, a grassy, forested land. We are an astute, proud people, albeit slightly weak of constitution. \
-	The creation myth of the Fluvian is that Eora, to emulate even a shred of her grace, plucked a palmful of moon-dust from Noc's mane and salted it upon Humens and other Creachers to create something which mimicked a fraction of her beauty. \
-	We are delicate of constiution and strength, but intelligent and agile. Due to our unique biology, the males and females of our race are equal in strength."
+	desc = "<b>Fluvian</b><br>\
+		Natives to the Great Forests of Dendor, the Fluvians are a mothlike race, astute and proud, though not very strong. \
+		It is said that Eora, somewhat jealous of Noc's own accomplishment with the Aasimar, plucked a palmful of moon-dust from Noc's mane, and salted it upon Humens and other creatures to create something which mimicks a fraction of her beauty. \
+		Intelligent and agile, Fluvians are usually found in managerial positions such as archivists and stewards. \
+		The strength of Fluvian males and females are equal, a unique trait for this strange race. \
+		The Fluvians venerate Eora, though a few of them worship other gods such as Noc, Dendor, Xylix and Pestra."
+
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS,HAIR)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
@@ -7,9 +7,12 @@
 
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	desc = "<b>Tabaxi</b><br>\
-		Tabaxi are lithe felenid humanoids that hail from the far-western Desert-Lands. Our bodies are slender, covered in a layer of fur with many possible patterns. \
-		The desert-lands, though unconquered, also lack a central strong government; as such, our people are adept at fighting our enemies, whoever they may be. \
-		Though we are rather quick, we lack strength and constitution."
+		Hailing from the south and southwest, the Tabaxi are most at home in the deserts of Valoria and Zybantine. \
+		Their bodies tending to be slender, with a layer of fur of many different patterns. \
+		Quick as a whip, the Tabaxi make up in speed what they lack in pure strength. \
+		Tabaxi are considered smooth talkers, and many of them take up positions as gamblers and minstrels. \
+		Astrata, the Firstborn of Psydon and Sun Goddess is their preferred god of worship."
+
 	skin_tone_wording = "Fur Colors"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE, MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -6,19 +6,12 @@
 	id = "dwarfm"
 	clothes_id = "dwarf"
 	desc = "<b>Dwarf</b><br>\
-	A proud and robust race of short mountain folk, \
-	the dwarves are known for their pride in martial strength \
-	and their tenacity towards their ancient traditions.\
-	A Dwarf, much like the rock that they carve their fortress out of \
-	is stubborn and ancient, with their race being the longest lived of all \
-	of the weeping gods creation. They, like stone: also rarely change \
-	and tend to shun the modernization of the world around them. \
-	Instead, a Dwarf looks to his ancestorial heritage for guidance on \
-	the various challenges they face. Even if, in some irony: this behaviour \
-	leads the race towards technological advacement as they continue \
-	to improve their craft through powerful mechanization and forging \
-	Dwarves are hearty, but are not known for their speed or eyesight... \
-	Each dwarf hails from a ancient fortress named after the most plentiful mineral."
+		Dwarves are a stout, short people, they are strong, and favor mining and smithing above any other occupation. \
+		A generally friendly people, they get along well with most races save Elves, who they at worst inflict with their stinging banter. \
+		The dwraves prefer to live in mountains and caves, the comfort of stone walls far more appealing than that of wood. \
+		The skin of dwarves is usually dictated by the city in which they're born, and named after a valuable ore. \
+		Dwarven males are defined by their large beards, wheras female dwarves usually lack such facial hair. \
+		Dwarves worship the divine pantheon much like the Humens, but prefer the God of smiths and miners, Malum."
 
 	skin_tone_wording = "Dwarf Fortress"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -5,13 +5,12 @@
 	name = "Dark Elf"
 	id = "elfd"
 	desc = "<b>Dark Elf</b><br>\
-	Elves, are a generic term for tall, pointy-eared humanoids\
-    Of whom trace their original heritage to the ancient mysterious Snow Elves. \
-	These ones are of a dark complexion and originate mostly from the underdark. \
-    Their culture and entire lives normally involve serving the evil gods of the inhumen pantheon. \
-    Previously rare but in recent times, more and more dark elfs can be seen on the surface. \
-    The ones who aren't overtly cruel and bloodthirsty, tend to flee to the surface lest they get culled by their own society, \
-    while some more sinister ones abandon their cities in search of new and greater power."
+		Dark Elves, the product of Zizo's forceful obtaining of Godhood which cursed the Snow Elves to embody the aspects of Zizo. \
+		They live deep underground, deeper than even many Dwarves within the city-states of their Shadowcities. \ 
+		Even though without sunlight, Dark Elves' often have dark hued skin made up of dark blues, purples and shades of black, usually with black or white hair. \
+		Mistrusted by most other races, the Dark Elves had, for centuries, enslaved other races, ascending from their deep cities to capture and enslave whomever they find before dragging them back down. \
+		Some Dark Elves, either disagreeing with the act of slavery, or simply wanting a change of scenery, leave the Shadowcities behind, hoping to find something better on the surface. \
+		Largely hedonistic and cruel, the Dark Elves worship the Inhumen Pantheon, their main worship going towards Baotha, The Spider With Many Legs, Desire Made Form, Pleasure Unending."
 
 /*
 	Former RT Desc: These guys were undead which doesn't really fit considering now you have a ton of them walking around.

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -5,14 +5,11 @@
 	name = "Elf"
 	id = "elfw"
 	desc = "<b>Elf</b><br>\
-	The Elves are marked apart from other races by their ethereal grace and long lives. \
-	Like Humens, they live throughout the lands of Grimoria. \
-	Yet, unlike other races, they prefer to dwell in lands untouched by civilization.<br>\
-	Elves can be difficult to distinguish from Humens at a glance until one is better acquainted with them. \
-	They are lighter and often more slender than men and bear fairy-like features upon their faces and ears.<br>\
-	The Elves commonly worship the Divine Pantheon in much the same way that Humens do, though they tend towards older practices and beliefs about the Ten.<br>\
-	<br>\
-	Magic comes easily to us, and we are swifter than other races. However, our bodies are weak and fragile."
+		Elves are a lithe, graceful race, many of them spread out across the world not unlike Humens. \
+		They largely prefer to live in nature, and make for some of the best rangers in all of Grimoria. \
+		The most obvious feature of an elf is their sharp ears, and generally slim form. \
+		Like Humens and Dwarves, Elf skin tones are determined by the place of their birth. \
+		The elves worship the divine pantheon, though their preferred god is largely dictated by where they're born."
 
 	skin_tone_wording = "Tribal Identity"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
@@ -5,7 +5,11 @@
 	name = "Goblin"
 	id = "goblinp"
 	desc = "<b>Goblin</b><br>\
-	A vile, cursed race of green skinned fiends with brains as small as their hearts. Be not fooled by their appearance - What they lack in stature, they possess in sheer malice."
+		Spawn of Graggar, these small, green creatures are usually found where Orcs are found. \
+		Cruel and unfriendly, most Goblins stick to their own tribes, and are rarely kind to outsiders. \
+		Runts of the Goblin litter are more often than not shunned and kicked out of their tribe, forced to roam the world alone. \
+		These Goblins can find themselves in the cities of Man, some of them finding work via crime, while others make use of their skills to assist the watchmen. \
+		Born of Graggar's will, Goblins worship him over any other god in the Inhumen Pantheon, but some Goblins will worship any god from the pantheon, especially Baotha or even Matthios, the King of Thieves."
 	species_traits = list(EYECOLOR,LIPS,STUBBLE)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	possible_ages = ALL_AGES_LIST

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -5,12 +5,11 @@
 	name = "Humen"
 	id = "humen"
 	desc = "<b>Humen</b><br>\
-	The most widespread race in Grimoria, Humens are found in nearly every civilized place on land. \
-	This extensive distribution of their kind has led to variations between Humens in custom and appearance. \
-	However, despite differences in appearance and geographical origin, all Humens have the same capabilities.<br>\
-	Humens hold dear the belief that they are the firstborn children of Psydon, \
-	Knowledge of good and evil is his divine gift bestowed upon them. \
-	The Divine Pantheon is the predominant religion of their kind."
+		Humens are one of the most predominant races in Grimoria, every continent, every island, and every city has at least some humens. \
+		It is largely recognized that they are the children of Psydon, formed in his image. Humens appear in all shapes and sizes, and no two humen is the same, so it is said. \
+		Those humens from Grenzelhoft are light in skintone, and predominantly have blue eyes, while a humen born in Zybantine may have a darker complexion. \
+		Despite any geographical difference between these humens, they are largely the same, the only difference being any potential accent they may have developed as they were raised in different cultures. \
+		Humens predominantly worship the divine pantheon, and some fanatical humens even go so far as to worship Psydon himself.
 
 	skin_tone_wording = "Ancestry"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -9,7 +9,7 @@
 		It is largely recognized that they are the children of Psydon, formed in his image. Humens appear in all shapes and sizes, and no two humen is the same, so it is said. \
 		Those humens from Grenzelhoft are light in skintone, and predominantly have blue eyes, while a humen born in Zybantine may have a darker complexion. \
 		Despite any geographical difference between these humens, they are largely the same, the only difference being any potential accent they may have developed as they were raised in different cultures. \
-		Humens predominantly worship the divine pantheon, and some fanatical humens even go so far as to worship Psydon himself.
+		Humens predominantly worship the divine pantheon, and some fanatical humens even go so far as to worship Psydon himself."
 
 	skin_tone_wording = "Ancestry"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -5,14 +5,11 @@
 	name = "Aasimar"
 	id = "aasimar"
 	desc = "<b>Aasimar</b><br>\
-	Aasimar are born of a rare union between Humans and Angels. \
-	They bear the mark of their celestial touch through many varying physical features. \
-	Their looks resemble the traditional characteristics of whichever of the Gods the Angel parent was associated with. \
-	Most commonly, Aasimar are similar to Humans, albeit taller, and possess uncanny beauty. \
-	They have strangely colored skin and are more physically frail than the average Human. \
-	Because of their upbringing, they make for natural conduits for godly powers. \
-	Rockhills populace holds them with a mixture of uneasy fear or, and respect. \
-	It is also widely believed that an Aasimars death is a bad omen..."
+		Children of Noc, it is said that once, when the night was long and her twin slept, Noc created the Aasimar, using the stars themselves in their creation. \
+		When Astrata woke and saw what Noc had done she was outraged, slapping her creations out of her hand, causing them to come crashing down to Grimoria. \
+		Some Aasimar were dormant for decades, centuries before finally waking up, a burning desire in their chest to make the most of this life crafted for them by Noc. \
+		Aasimar can appear all over the world, but they have no set group, no set city to call their own. Aasimars rarely gather together in groups of more than ten, such is how uncommon they truly are. \
+		Aasimar perform well in both scholarly and martial roles, with Noc being their preferred god of worship above all others, but there are those Aasimar who neglect Noc in favor of other gods, such as Ravox or even Astrata."
 
 	skin_tone_wording = "Craft"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -5,15 +5,9 @@
 	name = "Half-Elf"
 	id = "helf"
 	desc = "<b>Half Elf</b><br>\
-	Any Humen with a portion of elven blood is considered a Half-Elf. \
-	They inherit the grace and fairy features of elven-kind yet often bear a taller and thicker body more akin to a Humen.<br>\
-	Whether a Half-Elf resides with Humens or Elves affects how they age. \
-	Half-Elves living in the home of the Elves are said to be nearly indistinguishable from their Elven kin and enjoy the eternal youth of a full-blooded Elf. \
-	Yet most Half-Elves reside in Humen cities and age as Men do.<br>\
-	Half-Elves follow the Divine Pantheon by either Humen or Elven tradition.<br>\
-	<br>\
-	Our bodies bear the flaws and benefits of both Humens and Elves, to a lesser degree. \
-	We quickly learn new skills and run for long distances, but our bodies are frail."
+		Half-Elves are the offspring of both Humens and Elves. Half-Elves take on aspects of both their parents, the gracefulness of the Elves with the ambition of Humens. \
+		Half-Elves have much to prove to the world, looked down upon by many Elves, although Humans seem to get on fine with them. \
+		Half-Elves appear all over the world where both Humens and Elves intermingle, and predominantly worship the divine pantheon."
 
 	skin_tone_wording = "Identity"
 	default_color = "FFFFFF"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -5,14 +5,10 @@
 	name = "Half Orc"
 	id = "halforc"
 	desc = "<b>Half Orcs</b><br>\
-	With the Ironmask clan on a centuries-long warpath to consolidate all orcs within their banner, \
-	crushed orc tribes have lost their menfolk and war-widows have been scattered to the hinterlands. \
-	Between human civilization and orc savagery, orc-women opting for exile over dishonor have become \
-	more common visitors to fur trading posts and prospecting camps, eventually leading to half-orcs \
-	being born in these rough places otherwise devoid of a fairer sex. Your mother-clan is in thrall \
-	to the Ironmask, true orcs would kill you as a mongrel dog and your father’s people cannot decide \
-	between mere distrust and disgust. Yet somehow your wandering feet came to Rockhill, where \
-	half-orcs ply muscle and their hardiness in the rough underbelly or outer reaches of society."
+		The result of communion between an Orc and a Humen, these outcasts of Orcish society find themselves struggling to find purpose in the lands of other races. \
+		Looked down upon by most for their birth, Half-Orcs are not as strong as pure Orcs, but sadly still retain much of their ignorance and stupidity. \
+		Some Half-Orcs find a way to rise above their Orcish heritage, usually through martial prowess. \
+		It is for this reason that Half-Orcs predominantly worship Ravox over other gods in the divine pantheon." 
 
 	skin_tone_wording = "Clan"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -5,17 +5,13 @@
 	name = "Tiefling"
 	id = "tiefling"
 	desc = "<b>Tiefling</b><br>\
-	Tieflings, also known as Infernal-Spawn by the Dwarves, are a relatively new species in Grimmoria\
-	Having shown up sometime within the past two centuries, very little is known about their culture \
-	as many seem to simply intergrate within whatever society they find themselves in. \
-	Tieflings usually cause strong disturbances with their presence, as their fiendish looks \
-	Many have claimed that they are the spawn of a succubus (Or incubus) laying with a mortal. \
-	In this, their species has suffered vast tragedy throughout their short history, \
-	Facing scrutiny, judgement and even genocide in the past. Wounding many tiefling psyche \
-	and leading to most seeking a solitary life outside the watchful eyes of others. \
-	Tiefling cannot reproduce with mortals, and so no half-breed exists. \
-	Tiefling tend to be extremely perceptive and paranoid, as luck is rarely on their side \
-	and their unique biology makes them extremely susceptible to injury."
+		The offspring of demons with mortal Humens, a millenia ago, demons walked up from the steps of hell, spilling out onto Grimoria. \
+		Thousands of years later they were driven back, but in that time they had spawned a number of offspring with their Humen slaves. \
+		These came to be known as 'Tieflings', largely despised by most people for centuries, it was only recently that they became more tolerated, even if the Church still watches them with a weary eye. \
+		When a Tiefling had offspring, no matter the race of their partner, the child would always be a pureblooded Tiefling. \
+		The taint of their very being going back generations and generations, and no amount of cleansing can be rid of it. Some Tieflings embrace their demonic origin, while other shun it. \
+		Those that embrace it worship the Inhumen Pantheon and those which shun it worship the Divine Pantheon. \
+		The former taking up positions in crime, and spreading heresy, while the latter become soldiers, craftsmen, and do anything they can to distance themselves from their cruel brothers and sisters who would consider the curse a blessing."
 
 	skin_tone_wording = "Progenitor"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This is the second PR out of multiple that will begin to update the lore on the server from Blackstone/Ratwood lore to the server's own created lore. Secondly moving onto the different species. If you wish to read the lore yourself then refer to the #w-lore channel on the discord, in which in the lore discussion channel both W and Apple has confirmed that this lore is canon though I have made a few small edits.

All playable species aside from Vulpkian have been updated. Vulpkian does not have any lore written about them, and truthfully shouldn't be a species since there is already other species that do the exact same thing as them.

When it comes to what's actually being changed in the lore, honestly not overly much and you will see for yourself that is quite simplistic and to the point, but leaving much open room for people to have plenty of wiggle room when creating their characters.

Humens: Humens are one of the most predominant races in Grimoria, every continent, every island, and every city has at least some humens. It is largely recognized that they are the children of Psydon, formed in his image. Humens appear in all shapes and sizes, and no two humen is the same, so it is said. Those humens from Grenzelhoft are light in skintone, and predominantly have blue eyes, while a humen born in Zybantine may have a darker complexion. Despite any geographical difference between these humens, they are largely the same, the only difference being any potential accent they may have developed as they were raised in different cultures. Humens predominantly worship the divine pantheon, and some fanatical humens even go so far as to worship Psydon himself.

Dwarves: Dwarves are a stout, short people, they are strong, and favor mining and smithing above any other occupation. A generally friendly people, they get along well with most races save Elves, who they at worst inflict with their stinging banter. The dwraves prefer to live in mountains and caves, the comfort of stone walls far more appealing than that of wood. The skin of dwarves is usually dictated by the city in which they're born, and named after a valuable ore. Dwarven males are defined by their large beards, wheras female dwarves usually lack such facial hair. Dwarves worship the divine pantheon much like the Humens, but prefer the god of smiths and miners, Malum.

Elves: Elves are a lithe, graceful race, many of them spread out across the world not unlike Humens. They largely prefer to live in nature, and make for some of the best rangers in all of Grimoria. The most obvious feature of an elf is their sharp ears, and generally slim form. Like Humens and Dwarves, Elf skin tones are determined by the place of their birth. The elves worship the divine pantheon, though their preferred god is largely dictated by where they're born.

Half-Elves: Half-Elves are the offspring of both Humens and Elves. Half-Elves take on aspects of both their parents, the gracefulness of the Elves with the ambition of Humens. Half-Elves have much to prove to the world, looked down upon by many Elves, although Humans seem to get on fine with them. Half-Elves appear all over the world where both Humens and Elves intermingle, and predominantly worship the divine pantheon.

Wild-Kin: The Wild-Kin, children of Dendor, they live in dense forests and prefer nature to the cities. But there are those Wild-Kin who have adapted to city life, living there as woodsmen and rangers. Where there is nature, there are Wild-Kin, and they largely live in peace wherever they are. The Wild-Kin can appear in many different forms, catlike Wild-Kin which inhabit the deserts of Valoria to the more foxlike Wild-Kin who live in the Great Forests of Dendor itself. Wild-Kin as a species are so vast and numerous that to catalogue every specific type of Wild-Kin would take ten lifetimes. Due to their relationship with nature, they favor Dendor of the divine pantheon, but that isn't to say that some Wild-Kin do not worship other gods, such as Abyssor, Malum or even Ravox.

Half-Kin: Half-Kin are the resulting offspring of a relation between Wild-Kin and Humens or Elves. The Half-Kin take on some features of both parents, a Half-Kin with an Elven parent may have sharp ears, as well as whatever features their Wild-Kin parent possessed. Half-Kin take to the cities much more easily than their purebred counterparts, and integrate rather easily into whatever society they find themselves in. Their relationship to Dendor, diluted somewhat, is not as strong as pure Wild-Kin, as such they worship any god of the divine pantheon, with many favoring no particular god among them.

Dark Elves: Dark Elves live deep underground, deeper than even many Dwarves. Without sunlight, the Dark Elves are a largely pale and lightskinned people, usually with black or white hair. Mistrusted by most other races, the Dark Elves had, for centuries, enslaved other races, ascending from their deep cities to capture and enslave whomever they find before dragging them back down. Some Dark Elves, either disagreeing with the act of slavery, or simply wanting a change of scenery, leave the Shadowcities behind, hoping to find something better on the surface. Largely hedonistic and cruel, the Dark Elves worship the Inhumen Pantheon, their main worship going towards Baotha, The Spider With Many Legs, Desire Made Form, Pleasure Unending.

Half-Orcs: The result of communion between an Orc and a Humen, these outcasts of Orcish society find themselves struggling to find purpose in the lands of other races. Looked down upon by most for their birth, Half-Orcs are not as strong as pure Orcs, but sadly still retain much of their ignorance and stupidity. Some Half-Orcs find a way to rise above their Orcish heritage, usually through martial prowess. It is for this reason that Half-Orcs predominantly worship Ravox over other gods in the divine pantheon.

Goblins: Spawn of Graggar, these small, green creatures are usually found where Orcs are found. Cruel and unfriendly, most Goblins stick to their own tribes, and are rarely kind to outsiders. Runts of the Goblin litter are more often than not shunned and kicked out of their tribe, forced to roam the world alone. These Goblins can find themselves in the cities of Man, some of them finding work via crime, while others make use of their skills to assist the watchmen. Born of Graggar's will, Goblins worship him over any other god in the Inhumen Pantheon, but some Goblins will worship any god from the pantheon, especially Baotha or even Matthios, The King of Thieves.

Aasimar: Children of Noc, it is said that once, when the night was long and her twin slept, Noc created the Aasimar, using the stars themselves in their creation. When Astrata woke and saw what Noc had done she was outraged, slapping her creations out of her hand, causing them to come crashing down to Grimoria. Some Aasimar were dormant for decades, centuries before finally waking up, a burning desire in their chest to make the most of this life crafted for them by Noc. Aasimar can appear all over the world, but they have no set group, no set city to call their own. Aasimars rarely gather together in groups of more than ten, such is how uncommon they truly are. Aasimar perform well in both scholarly and martial roles, with Noc being their preferred god of worship above all others, but there are those Aasimar who neglect Noc in favor of other gods, such as Ravox or even Astrata.

Tiefings: The offspring of demons with mortal Humens, a millenia ago, demons walked up from the steps of hell, spilling out onto Grimoria. Thousands of years later they were driven back, but in that time they had spawned a number of offspring with their Humen slaves. These came to be known as 'Tieflings', largely despised by most people for centuries, it was only recently that they became more tolerated, even if the Church still watches them with a weary eye. When a Tiefling had offspring, no matter the race of their partner, the child would always be a pureblooded Tiefling. The taint of their very being going back generations and generations, and no amount of cleansing can be rid of it. Some Tieflings embrace their demonic origin, while other shun it. Those that embrace it worship the Inhumen Pantheon and those which sun it worship the Divine Pantheon, the former taking up positions in crime, and spreading heresy, while the latter become soldiers, craftsmen, and do anything they can to distance themselves from their cruel brothers and sisters who would consider the curse a blessing.

Verminvolk: A squat, unusual people, they are greatly related to Wild-Kin, in the same way a Kobold might be related to a dragon. Like Wild-Kin their appearance can vary greatly, and they are largely looked down upon by their more pure brethren due in part to their height. But in spite of this Verminvolk make the most of their lot in life, a cheery folk, you'll find them working as artisans, bakers, cheesemakers, a few of them even working as watchmen. They, like Wild-Kin, worship Dendor primarily in the Divine Pantheon, but many also worship Eora, Malum, and Abyssor.

Kobolds: Thought by some scholars to be cousins to the Verminvolk, Kobolds are a small, lizardlike race which prefers to live underground. Like Dwarves their primary occupation is as miners, but some of them also dabble in smithing and crafting, a few still even entering into military service. The color of a Kobold's scales is largely determined by their parents, if a blue Kobold and a red Kobold were to have offspring then the resulting children would be purple for instance. Kobold mother's lay eggs, and guard them with their lives, although with few natural predators in their underground homes there isnt the fear of losing ones children as there once was. Kobold's worship the Divine Pantheon, mainly focused on Malum, but some Kobolds who feel an attraction to the sea prefer the worship of Abyssor instead.

Lupians: Originating from the north, the Lupians are a race of wolflike peoples, living in tight knight packs. With thick pelts and sharp teeth, for centuries they have managed to survive in places other races would not. Due to their packlike mentality, they are slow to trust outsiders, but when they do a deep connection is formed which will last until death. The sons and daughters of Noc, they prefer her over the other gods in the Divine Pantheon, and howl at the moon whenever they see it as a form of prayer.

Tabaxi: Hailing from the south and southwest, the Tabaxi are most at home in the deserts of Valoria and Zybantine, their bodies tending to be slender, with a layer of fur of many different patterns. Quick as a whip, the Tabaxi make up in speed what they lack in pure strength. Tabaxi are considered smooth talkers, and many of them take up positions as gamblers and minstrels. Astrata, the Firstborn of Psydon and Sun Goddess is their preferred god of worship.

Drakian: Centuries ago, the Drakian people spanned all along what is now the Dwarven Federation, but during what was known as 'The Dark Year', they were forced out of their lifelong homes in the mountain ranges and scattered to the wind, ending up all over the world where it isn't too cold. Self righteous and prideful, Drakians often point their snouts up at those they consider to be lesser races, a strong people, but not very dextrous. Mages are rare in Drakian society, and Drakians much prefer to be soldiers of some sort than any other role. They predominantly worship Ravox.

Sissean: Similar to both the Drakians and Kobolds, Sisseans are a lizardlike people, with sharp claws and teeth. They prefer bogland to reside in, and many Sisseans live on the Island of Enigma, in some of its many bogs, a brave few even settling in the Terrorbog. Not as crafty or artistic as Humens, Elves or Dwarves, the Sisseans, like their Drakian cousins, much prefer martial roles to those of artisans or smiths. The Drakians look down on the Sisseans as being lesser, bog dwelling simpletons, but the Sisseans are largely content with their lot in life, and are a generally friendly people. They prefer to worship Abyssor in the Divine Pantheon, but others are known to worship Astrata, Ravox and Dendor.

Fluvians: Natives to the Great Forests of Dendor, the Fluvians are a mothlike race, astute and proud, though not very strong. It is said that Eora, somewhat jealous of Noc's own accomplishment with the Aasimar, plucked a palmful of moon-dust from Noc's mane, and salted it upon Humens and other creatures to create something which mimicks a fraction of her beauty. Intelligent and agile, Fluvians are usually found in managerial positions such as archivists and stewards. The strength of Fluvian males and females are equal, a unique trait for this strange race. The Fluvians venerate Eora, though a few of them worship other gods such as Noc, Dendor, Xylix and Pestra.

Axian: A race of sharklike people, Axian settlements are dotted along the coastline of the continents. A society mainly consisting of fishermen, the Axians ply their trade, and are some of the best sailors in all of Grimoria. Some Axians go so far as to put down the rod and take up the cutlass, roaming the seas as pirates. Clever and strong, the Axians can make the most of bad situations, and rarely give up. Abyssor, Malum and Ravox are their preferred gods of worship.



## Why It's Good For The Game

This is good for the game as this is the first step in getting the server's official lore off the ground onto the server itself instead of using outdated lore from other servers which does not fit our current setting or themes of the server.
