### PR TITLE
Keyring tweaks

### DIFF
--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -32,6 +32,7 @@
 		STR.max_combined_w_class = 20
 		STR.max_w_class = WEIGHT_CLASS_SMALL
 		STR.max_items = 9
+		STR.attack_hand_interact = FALSE
 		STR.click_gather = TRUE
 		STR.allow_dump_out = TRUE
 		STR.rustle_sound = FALSE

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -12,6 +12,7 @@
 	var/lockhash = 0
 	var/lockid = null
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH|ITEM_SLOT_NECK
+	drop_sound = 'sound/items/gems (1).ogg'
 	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/roguekey/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

* Keyring changed to LMB to take it in-hand and RMB to open its inventory.
* Adds a more appropriately metallic drop noise to keys.

## Why It's Good For The Game
It was brought to my attention that LMB + drag to open every single door wasn’t actually that QoL, and I agreed. I couldn’t figure out how to key LMB and RMB to separate functions on the last PR without breaking the entire thing, but now I do.
