### PR TITLE
Another Small Potion Expansion

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -210,14 +210,3 @@
 /atom/movable/screen/alert/status_effect/debuff/devitalised
 	name = "Devitalised"
 	desc = "Something has been taken from me, and it will take time to recover."
-
-/datum/status_effect/debuff/soporific
-	id = "drowsy"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/soporific
-	effectedstats = list("speed" = -10)
-	duration = 5 MINUTES
-
-/atom/movable/screen/alert/status_effect/debuff/soporific
-	name = "Drowsy"
-	desc = "Something is making me weak and sluggish..."
-	icon_state = "sleepy"

--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -221,6 +221,10 @@
 	gender = PLURAL
 	icon = 'icons/roguetown/items/gems.dmi'
 	icon_state = "sublimate"
-	list_reagents = null // Maybe give this mana restorative properties?
-	grind_results = null
-	volume = null
+	volume = 30
+	list_reagents = list(
+		/datum/reagent/gemdust = 5,
+		/datum/reagent/medicine/manapot = 25) // Enough manna pot to give 20% fatigue bar, but gemdust to make it obnoxious compared to manna potion.
+	grind_results = list(
+		/datum/reagent/gemdust = 5,
+		/datum/reagent/medicine/manapot = 25)

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -16,6 +16,12 @@
 	projectile_type = /obj/projectile/bullet/reusable/bolt/poison
 	icon_state = "bolt_poison"
 
+/obj/item/ammo_casing/caseless/rogue/bolt/tranq
+	name = "tranquilizer bolt"
+	desc = "A durable iron bolt. This one has an injection mechanism filled with a clear liquid."
+	projectile_type = /obj/projectile/bullet/reusable/bolt/tranq
+	icon_state = "bolt_poison"
+
 /obj/projectile/bullet/reusable/bolt
 	name = "bolt"
 	damage = 70
@@ -58,6 +64,22 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 7) //not gonna kill anyone, but they will be quite quiet
+
+/obj/projectile/bullet/reusable/bolt/tranq
+	name = "bolt"
+	damage = 15 // Enough damage and penetration to pierce medium, but not heavy.
+	damage_type = BRUTE
+	armor_penetration = 50
+	icon = 'icons/roguetown/weapons/ammo.dmi'
+	icon_state = "bolt_proj"
+	ammo_type = /obj/item/ammo_casing/caseless/rogue/bolt/tranq
+	range = 15
+	embedchance = 0
+	woundclass = BCLASS_BLUNT
+	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
+	poisontype = /datum/reagent/medicine/tranquilizer
+	poisonfeel = "intense numbing" 
+	poisonamount = 10
 
 /obj/item/ammo_casing/caseless/rogue/arrow
 	name = "arrow"
@@ -154,16 +176,19 @@
 
 /obj/projectile/bullet/reusable/arrow/sopor
 	name = "arrow"
-	damage = 10 // Support arrow, effects outweigh the need for damage here
+	damage = 15 // Support arrow, effects outweigh the need for damage here
 	damage_type = BRUTE
+	armor_penetration = 50
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow
 	range = 15
+	embedchance = 0
+	woundclass = BCLASS_BLUNT
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	poisontype = /datum/reagent/medicine/soporpot
-	poisonfeel = "stiffness" 
-	poisonamount = 10
+	poisonfeel = "numbing" 
+	poisonamount = 15
 
 /obj/projectile/bullet/reusable/arrow/poison/stone
 	name = "stone arrow"

--- a/code/modules/cargo/packsrogue/luxury.dm
+++ b/code/modules/cargo/packsrogue/luxury.dm
@@ -16,6 +16,18 @@
 	cost = 5
 	contains = list(/obj/item/reagent_containers/powder/moondust)
 
+/datum/supply_pack/rogue/luxury/sublimate // Far cheaper to make your own.
+	name = "Arcyne Sublimate"
+	cost = 80
+	contains = list(
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+	)
+
 /datum/supply_pack/rogue/luxury/spice
 	name = "Spice"
 	cost = 50

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -379,15 +379,17 @@
 	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/tranq //Coded, but commented out pending balance discussion.
-	name = "tranquilizer bolt (x3)"
+	name = "tranquilizer bolt (x5)"
 	result = list(
+				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
 				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
 				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
 				/obj/item/ammo_casing/caseless/rogue/bolt/tranq
 				)
 	reqs = list(
 		/obj/item/ammo_casing/caseless/rogue/bolt = 3,
-		/datum/reagent/medicine/soporpot = 90
+		/datum/reagent/medicine/soporpot = 150
 		)
 
 	req_table = FALSE

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -323,7 +323,7 @@
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor
 	reqs = list(
 				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 1,
-				/datum/reagent/medicine/soporpot = 10
+				/datum/reagent/medicine/soporpot = 6
 				)
 	req_table = FALSE
 
@@ -353,8 +353,10 @@
 	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/soporarrow_three // Your symmetry is irrelevant here.
-	name = "soporific arrow (x3)"
+	name = "soporific arrow (x5)"
 	result = list(
+				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
+				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
 				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
 				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
 				/obj/item/ammo_casing/caseless/rogue/arrow/sopor

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -366,6 +366,30 @@
 
 	req_table = FALSE
 
+/datum/crafting_recipe/roguetown/tranq //Coded, but commented out pending balance discussion.
+	name = "tranquilizer bolt"
+	result = /obj/item/ammo_casing/caseless/rogue/bolt/tranq
+	reqs = list(
+		/obj/item/ammo_casing/caseless/rogue/bolt = 1,
+		/datum/reagent/medicine/soporpot = 30
+		)
+
+	req_table = FALSE
+
+/datum/crafting_recipe/roguetown/tranq //Coded, but commented out pending balance discussion.
+	name = "tranquilizer bolt (x3)"
+	result = list(
+				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+				/obj/item/ammo_casing/caseless/rogue/bolt/tranq
+				)
+	reqs = list(
+		/obj/item/ammo_casing/caseless/rogue/bolt = 3,
+		/datum/reagent/medicine/soporpot = 90
+		)
+
+	req_table = FALSE
+
 /*
 /datum/crafting_recipe/roguetown/poisonbolt_five //Coded, but commented out pending balance discussion.
 	name = "poisoned bolts (x5)"

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -92,6 +92,25 @@
 		else if(slice(W, user))
 			return 1
 	..()
+/*	........   Spicing and Poisoning   ................ */
+
+// Used for adding reagents from bottles into food items.
+
+/obj/item/reagent_containers/food/snacks/rogue/MiddleClick(mob/living/user, params) 
+	. = ..()
+	
+	var/obj/item/held_item = user.get_active_held_item()
+	
+	if(held_item)
+		if(istype(held_item, /obj/item/reagent_containers/glass/bottle))
+			if(!held_item.reagents.total_volume)
+				to_chat(user, span_warning("[held_item] is empty!"))
+				return
+			if(src.reagents.total_volume >= src.reagents.maximum_volume)
+				to_chat(user, span_warning("You can't add anymore to [src]!"))
+				return
+			held_item.reagents.trans_to(src, 3, transfered_by = user)
+			user.visible_message(span_warning("[user] slips something into the [src]"), span_notice("I transfer some of the reagents to [src]."), vision_distance = 2)
 
 /*	........   Kitchen tools / items   ................ */
 /obj/item/kitchen/spoon

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -111,7 +111,7 @@
 				return
 			held_item.reagents.trans_to(src, 3, transfered_by = user)
 			var/stealth = user.mind.get_skill_level(/datum/skill/misc/sneaking)
-			var/soh = (6 - (stealth + rand(0,4))) // master level sneaking means a 80% chance of not being noticed at all, and expert being a 20% chance.
+			var/soh = (6 - (stealth + rand(0,4))) // master level sneaking means a 80% chance of not being noticed at all, decreasing in increments of 20% per level under.
 			if(soh >= 1)
 				user.visible_message(span_warning("[user] slips something into the [src]"), span_warning("I hastily transfer some of the reagents to [src]."), vision_distance = soh)
 			else

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -110,7 +110,12 @@
 				to_chat(user, span_warning("You can't add anymore to [src]!"))
 				return
 			held_item.reagents.trans_to(src, 3, transfered_by = user)
-			user.visible_message(span_warning("[user] slips something into the [src]"), span_notice("I transfer some of the reagents to [src]."), vision_distance = 2)
+			var/stealth = user.mind.get_skill_level(/datum/skill/misc/sneaking)
+			var/soh = (6 - (stealth + rand(0,4))) // master level sneaking means a 80% chance of not being noticed at all, and expert being a 20% chance.
+			if(soh >= 1)
+				user.visible_message(span_warning("[user] slips something into the [src]"), span_warning("I hastily transfer some of the reagents to [src]."), vision_distance = soh)
+			else
+				user.visible_message(span_warning("[user] slips something into the [src]"), span_notice("I carefully transfer some of the reagents to [src]."), vision_distance = soh)
 
 /*	........   Kitchen tools / items   ................ */
 /obj/item/kitchen/spoon

--- a/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -3,9 +3,9 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/paralysispot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 2, 
+		/obj/item/reagent_containers/powder/sublimate = 3, 
 		/obj/item/hearthnatural/beespider_fang = 1 )
-	craftdiff = 4
+	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/alchemy/soporpot
 	name = "Soporific Poison"

--- a/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -8,12 +8,23 @@
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/soporpot
-	name = "Soporific Potion"
+	name = "Soporific Poison"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/soporpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/ash = 2, 
-		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 2 )
+		/obj/item/ash = 1, 
+		/obj/item/natural/worms/leech = 1,
+		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 5 )
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/alchemy/soporpotx3
+	name = "Soporific Poison (x3)"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/soporpot, /obj/item/reagent_containers/glass/bottle/rogue/soporpot, /obj/item/reagent_containers/glass/bottle/rogue/soporpot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3, 
+		/obj/item/ash = 3, 
+		/obj/item/natural/worms/leech = 3,
+		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 15 )
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/fortitudepot

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
@@ -9,7 +9,7 @@
 	alpha = 225
 
 /datum/reagent/medicine/paralysispot/overdose_process(mob/living/L)
-	L.Paralyze(200)
+	L.Paralyze(500)
 	..()
 	. = 1 
 

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
@@ -19,26 +19,41 @@
 	reagent_state = LIQUID
 	color = "#fcefa8"
 	taste_description = "drowsyness"
-	overdose_threshold = 31
+	overdose_threshold = 0
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	alpha = 225
 
 /datum/reagent/medicine/soporpot/on_mob_life(mob/living/carbon/M)
 	M.confused += 1
 	M.dizziness += 1
-	M.rogstam_add(-5)
-	if(M.rogfat > 80)
-		M.apply_status_effect(/datum/status_effect/debuff/soporific)
+	M.rogstam_add(-25)
+	if(M.rogfat > 75)
+		M.drowsyness += 2
 	else
 		M.rogfat_add(15)
 	..()
 	. = 1
 
-/datum/reagent/medicine/soporpot/overdose_process(mob/living/carbon/M)
-	M.drowsyness += 2
+/datum/reagent/medicine/tranquilizer // Unique to bolt soporific application. More intense effect for 5x cost.
+	name = "Tranquilizer"
+	description = "Weakens those it enters."
+	reagent_state = LIQUID
+	color = "#fcefa8"
+	taste_description = "drowsyness"
+	overdose_threshold = 0
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	alpha = 225
+
+/datum/reagent/medicine/tranquilizer/on_mob_life(mob/living/carbon/M)
 	M.confused += 2
+	M.dizziness += 2
+	M.rogstam_add(-50)
+	if(M.rogfat > 75)
+		M.drowsyness += 4
+	else
+		M.rogfat_add(20)
 	..()
-	. = 1 
+	. = 1
 
 /datum/reagent/medicine/fortitudepot
 	name = "Strength Potion"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds Arcyne Sublimate to the goldface at a considerable upcharge to the base cost of components.
Adjusts soporific potion to be labeled poison.
Adjusts soporific poison recipe.

Adds pouring reagents from bottles onto food items, increments of 1oz, by middle clicking the food with a bottle of reagents. The action's visibility scales with your stealth. At legendary (impossible to gain currently), it is 100% obscured. Each level below this, it increases in increments of 20% on if someone adjacent to you will see the dosing. The action can be visible up to 6 tiles away with no stealth skill at all.

Buffs soporific arrows by replacing the -10 debuff requirements with late stage drowsyness. Gives time to make distance, but is on level with poison arrows. These just knock you out for a very short period instead of killing you like poison. Knockout is very brief (about 5-15 seconds in testing), so if you escape, you'll have a fighting chance again.
Adds tranquilizer bolts recipe. Higher penetration, more potent effects. 5x the cost of arrows.
Buffs soporific arrows' damage so they can pierce light armor.

Adjusts soporific arrows to have proper low lethality. Cant embed, does bludgeoning. If you kill someone with these youre overdoing it.

Adds reagents to arcyne sublimate, mana potion and gem dust. Still blurs and damages you, but provides a substantially weaker fatigue restore than an actual manna potion.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tranquilizer bolts encourages less fragging from guards by making it easier to capture criminals alive. Youll still have time to fight back like the arrows, and heavy armor still blocks the damage from these. Soporific arrows cannot pierce medium armor either.
Sublimate in the goldface will also allow merchants to supply apothecaries more reliably than hoping and praying a miner is around to sell gemstones or ore to you. Its cheaper to make your own even still, even if you buy the ore for transmutes from the stockpile.
the sopor arrows were intended to be non lethal, but being guaranteed to embed kinda subverted that intention.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
