### PR TITLE
Windows? Yes We Can!

### DIFF
--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -32,6 +32,11 @@
 		return
 	icon_state = "[base_state]"
 
+/obj/structure/roguewindow/openclose/OnCrafted(dirin)
+	dirin = turn(dirin, 180)
+	lockdir = dirin
+	. = ..(dirin)
+
 /obj/structure/roguewindow/MouseDrop_T(atom/movable/O, mob/user)
 	. = ..()
 	if(!wallpress)

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -133,6 +133,7 @@
 	result = /turf/closed/wall/mineral/rogue/craftstone/window
 	reqs = list(/obj/item/natural/stone = 3)
 	skillcraft = /datum/skill/craft/masonry
+	craftsound = 'sound/foley/Building-01.ogg'
 	verbage_simple = "build"
 	verbage = "builds"
 	craftdiff = 4
@@ -156,16 +157,52 @@
 	result = /turf/closed/wall/mineral/rogue/stone/window
 	reqs = list(/obj/item/natural/stone = 2)
 	skillcraft = /datum/skill/craft/masonry
+	craftsound = 'sound/foley/Building-01.ogg'
 	verbage_simple = "build"
 	verbage = "builds"
 	craftdiff = 2
 
-/datum/crafting_recipe/roguetown/turfs/stonewindow/TurfCheck(mob/user, turf/T)
-	if(isclosedturf(T))
-		return
-	if(!istype(T, /turf/open/floor/rogue))
-		return
-	return TRUE
+/// WINDOWS
+
+/datum/crafting_recipe/roguetown/turfs/roguewindow
+	name = "wooden window"
+	result = /obj/structure/roguewindow
+	reqs = list(/obj/item/grown/log/tree/small = 2)
+	skillcraft = /datum/skill/craft/carpentry
+	craftsound = 'sound/foley/Building-01.ogg'
+	verbage_simple = "build"
+	verbage = "builds"
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/turfs/fancywindow/openclose
+	name = "fancy window"
+	result = /obj/structure/roguewindow/openclose
+	reqs = list(
+	  /obj/item/grown/log/tree/small = 2,
+	  /obj/item/natural/stone = 1,
+	  /obj/item/ash = 1,
+	  /obj/item/natural/dirtclod = 1,
+	)
+	skillcraft = /datum/skill/craft/carpentry
+	craftsound = 'sound/foley/Building-01.ogg'
+	verbage_simple = "build"
+	verbage = "builds"
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/turfs/reinforcedwindow/openclose
+	name = "reinforced window"
+	result = /obj/structure/roguewindow/openclose/reinforced
+	reqs = list(
+	  /obj/item/grown/log/tree/small = 2,
+	  /obj/item/ingot/iron = 1,
+	  /obj/item/ash = 1,
+	  /obj/item/natural/dirtclod = 1,
+	)
+	skillcraft = /datum/skill/craft/blacksmithing
+	craftsound = 'sound/items/bsmith1.ogg'
+	verbage_simple = "build"
+	verbage = "builds"
+	craftdiff = 2
 
 /// TWIG AND TENT
 


### PR DESCRIPTION
## About The Pull Request
* Adds wooden window under carpentry, can see through and is impassable nor open-able. Requires two small logs.
* Adds fancy window under carpentry, can see through and passable if opened. Requires two small logs, one stone, one ash and one dirt.
* Adds reinforced window under blacksmithing, a stronger version of fancy window. It’s not impervious, but can withstand quite a lot of hits before it breaks. Requires same recipe as fancy window only with an iron ingot ontop.
* Building windows makes noise.
* Windows are built in the direction you’re facing.


![image](https://github.com/user-attachments/assets/0914ee22-791d-4f79-a659-f1caaefb7ad2)

## Why It's Good For The Game
More building options for homesteaders. Glass currently doesn’t exist, so until glassblowing is PR’d in, I’m substituting the recipe with ash and dirt. 

Huge thanks to @EvenInDeathIStillServe for helping me figure out directionals.
