### PR TITLE
Lets Kobolds Eat Coins and Rocks

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1441,12 +1441,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"auK" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "auL" = (
 /obj/structure/lever/wall{
 	pixel_x = 32;
@@ -1811,6 +1805,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"aIH" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "aII" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -8794,12 +8792,9 @@
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
 "fKf" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/item/quiver/bolts,
-/obj/structure/closet/crate/roguecloset/inn/chest,
-/obj/item/storage/foodbag/hardtack,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "fKC" = (
 /turf/open/water/river{
 	dir = 1;
@@ -10445,10 +10440,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"gYq" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet/bogcaves)
 "gYC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -12683,6 +12674,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"iyV" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/spider{
+	tame = 1
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet/bogcaves)
 "ize" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -14296,9 +14294,8 @@
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jHc" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -14353,6 +14350,13 @@
 "jJx" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter)
+"jJC" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/item/quiver/bolts,
+/obj/structure/closet/crate/roguecloset/inn/chest,
+/obj/item/storage/foodbag/hardtack,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
@@ -14452,13 +14456,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"jNi" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/spider{
-	tame = 1
-	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet/bogcaves)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -20410,6 +20407,12 @@
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/grass/snow,
 /area/rogue/outdoors/vikingarea)
+"ojc" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "ojp" = (
 /obj/structure/closet/dirthole/grave,
 /turf/closed/wall/mineral/rogue/stone,
@@ -24224,6 +24227,10 @@
 /obj/item/clothing/head/roguetown/helmet/horned,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"qGD" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet/bogcaves)
 "qGP" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
@@ -28586,10 +28593,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"tPc" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "tPg" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/rtfield)
@@ -32565,12 +32568,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"wLX" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -32829,10 +32826,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"wWM" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "wXf" = (
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -231209,7 +231202,7 @@ gxt
 gxt
 gxt
 gxt
-gYq
+qGD
 qtE
 gxt
 gxt
@@ -231611,10 +231604,10 @@ gxt
 gxt
 gxt
 gxt
-gYq
-jNi
+qGD
+iyV
 qtE
-gYq
+qGD
 gxt
 gxt
 gxt
@@ -232015,9 +232008,9 @@ gxt
 gxt
 qtE
 qtE
-gYq
+qGD
 qtE
-gYq
+qGD
 gxt
 gxt
 gxt
@@ -232416,9 +232409,9 @@ gxt
 gxt
 gxt
 gxt
-gYq
+qGD
 qtE
-jNi
+iyV
 qtE
 gxt
 gxt
@@ -232818,9 +232811,9 @@ gxt
 gxt
 gxt
 gxt
-gYq
+qGD
 qtE
-gYq
+qGD
 gxt
 gxt
 gxt
@@ -332507,7 +332500,7 @@ wlD
 wlD
 wlD
 oQJ
-jGT
+ooq
 cyr
 cyr
 hHF
@@ -332909,7 +332902,7 @@ wlD
 wlD
 wlD
 wOD
-hHF
+shd
 cyr
 hHF
 cyr
@@ -334526,7 +334519,7 @@ wSn
 qvR
 uaL
 qvR
-tPc
+aIH
 qvR
 qvR
 wSn
@@ -334928,7 +334921,7 @@ kVc
 qvR
 wSn
 qvR
-wWM
+fKf
 uaL
 qvR
 hcW
@@ -335329,9 +335322,9 @@ kVc
 kVc
 kVc
 kVc
-wWM
+fKf
 qvR
-wWM
+fKf
 hcW
 hcW
 hcW
@@ -427719,7 +427712,7 @@ tML
 wAm
 wAm
 wAm
-wLX
+jGT
 hqI
 bPz
 enq
@@ -429329,7 +429322,7 @@ hqI
 hqI
 hqI
 hqI
-auK
+ojc
 enq
 ffv
 ffv
@@ -495664,7 +495657,7 @@ erZ
 nEd
 fVQ
 lgN
-fKf
+jJC
 lgN
 fVQ
 nEd

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1627,12 +1627,6 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
-"aBn" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "aCe" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/machinery/light/rogue/firebowl/stump/snow{
@@ -1811,6 +1805,12 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"aIG" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "aII" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -3934,6 +3934,13 @@
 /obj/item/roguekey/nightmaiden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"clX" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/item/quiver/bolts,
+/obj/structure/closet/crate/roguecloset/inn/chest,
+/obj/item/storage/foodbag/hardtack,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "clY" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/poo,
@@ -8794,11 +8801,9 @@
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
 "fKf" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet/bogcaves)
 "fKC" = (
 /turf/open/water/river{
 	dir = 1;
@@ -17195,6 +17200,9 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter)
+"lOw" = (
+/turf/closed,
+/area/rogue/outdoors/rtfield)
 "lOz" = (
 /obj/structure/mineral_door/bars{
 	lockid = "graveyard"
@@ -25847,13 +25855,6 @@
 "rSC" = (
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
-"rSF" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/item/quiver/bolts,
-/obj/structure/closet/crate/roguecloset/inn/chest,
-/obj/item/storage/foodbag/hardtack,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "rSG" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -29038,6 +29039,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/vikingarea)
+"ujK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/spider{
+	tame = 1
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet/bogcaves)
 "ujO" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
@@ -30114,6 +30122,12 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uUA" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uUV" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/dirt,
@@ -231190,8 +231204,8 @@ gxt
 gxt
 gxt
 gxt
-gxt
-gxt
+fKf
+qtE
 gxt
 gxt
 gxt
@@ -231592,10 +231606,10 @@ gxt
 gxt
 gxt
 gxt
-gxt
-gxt
-gxt
-gxt
+fKf
+ujK
+qtE
+fKf
 gxt
 gxt
 gxt
@@ -231994,11 +232008,11 @@ gxt
 gxt
 gxt
 gxt
-gxt
-gxt
-gxt
-gxt
-gxt
+qtE
+qtE
+fKf
+qtE
+fKf
 gxt
 gxt
 gxt
@@ -232397,10 +232411,10 @@ gxt
 gxt
 gxt
 gxt
-gxt
-gxt
-gxt
-gxt
+fKf
+qtE
+ujK
+qtE
 gxt
 gxt
 gxt
@@ -232799,9 +232813,9 @@ gxt
 gxt
 gxt
 gxt
-gxt
-gxt
-gxt
+fKf
+qtE
+fKf
 gxt
 gxt
 gxt
@@ -334104,9 +334118,9 @@ kVc
 wSn
 uaL
 qvR
-qvR
-uaL
-uaL
+lOw
+lOw
+lOw
 wSn
 pwu
 wSn
@@ -334506,9 +334520,9 @@ kVc
 wSn
 qvR
 uaL
-qvR
-uaL
-wSn
+lOw
+lOw
+lOw
 qvR
 wSn
 kVc
@@ -334908,9 +334922,9 @@ kVc
 kVc
 qvR
 wSn
-wSn
-uaL
-wSn
+lOw
+lOw
+lOw
 qvR
 hcW
 hcW
@@ -335310,9 +335324,9 @@ kVc
 kVc
 kVc
 kVc
-qvR
-wSn
-qvR
+lOw
+lOw
+lOw
 hcW
 hcW
 hcW
@@ -427700,7 +427714,7 @@ tML
 wAm
 wAm
 wAm
-aBn
+aIG
 hqI
 bPz
 enq
@@ -429310,7 +429324,7 @@ hqI
 hqI
 hqI
 hqI
-fKf
+uUA
 enq
 ffv
 ffv
@@ -495645,7 +495659,7 @@ erZ
 nEd
 fVQ
 lgN
-rSF
+clX
 lgN
 fVQ
 nEd

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1627,6 +1627,12 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
+"aBn" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "aCe" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/machinery/light/rogue/firebowl/stump/snow{
@@ -8788,8 +8794,11 @@
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
 "fKf" = (
-/turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/basement)
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "fKC" = (
 /turf/open/water/river{
 	dir = 1;
@@ -10199,6 +10208,7 @@
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "gPy" = (
@@ -18306,6 +18316,9 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/pumpkin,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "mMJ" = (
@@ -18770,6 +18783,9 @@
 /obj/item/storage/keyring,
 /obj/item/storage/keyring,
 /obj/item/storage/keyring,
+/obj/item/storage/foodbag/hardtack,
+/obj/item/storage/foodbag/hardtack,
+/obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ndj" = (
@@ -25831,6 +25847,13 @@
 "rSC" = (
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
+"rSF" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/item/quiver/bolts,
+/obj/structure/closet/crate/roguecloset/inn/chest,
+/obj/item/storage/foodbag/hardtack,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "rSG" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -26768,6 +26791,7 @@
 /area/rogue/indoors/town/dwarfin)
 "sxW" = (
 /obj/structure/closet/crate/roguecloset,
+/obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "syh" = (
@@ -29035,6 +29059,7 @@
 /area/rogue/outdoors/vikingarea)
 "ukv" = (
 /obj/item/roguebin/crackers,
+/obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "ukD" = (
@@ -32613,6 +32638,7 @@
 /obj/item/roguekey/walls,
 /obj/item/roguekey/manor,
 /obj/item/storage/backpack/rogue/satchel,
+/obj/item/storage/foodbag/hardtack,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "wPt" = (
@@ -209378,14 +209404,14 @@ txa
 txa
 txa
 txa
-fKf
 txa
 txa
 txa
 txa
 txa
 txa
-spR
+iTw
+iTw
 spR
 aKH
 spR
@@ -209781,13 +209807,13 @@ fPR
 fAs
 txa
 txa
-txa
 gwd
 gEj
 gQl
 hff
 txa
-cEK
+iTw
+iTw
 cEK
 cEK
 cEK
@@ -210187,8 +210213,8 @@ gch
 gch
 gch
 gch
-gch
 txa
+iTw
 iTw
 spR
 cEK
@@ -210585,12 +210611,12 @@ iTw
 cBf
 txa
 fPQ
-gch
 gxc
 gch
 gch
 gch
 txa
+iTw
 iTw
 spR
 cEK
@@ -210989,10 +211015,10 @@ txa
 txa
 txa
 txa
-txa
 gSG
 txa
 txa
+iTw
 iTw
 spR
 cEK
@@ -211393,8 +211419,8 @@ iTw
 rSG
 iTw
 iTw
-iTw
 hCL
+iTw
 iTw
 cEK
 cEK
@@ -211794,9 +211820,9 @@ txa
 txa
 txa
 ppi
-cBf
 hiz
 txa
+iTw
 icI
 ivV
 aoF
@@ -426468,10 +426494,10 @@ nKu
 nSr
 sIE
 teW
-teW
-teW
-teW
-ffv
+hqI
+fUr
+wte
+enq
 ffv
 ffv
 ffv
@@ -426870,10 +426896,10 @@ bEL
 jiv
 jjS
 teW
-teW
-teW
-teW
-ffv
+hqI
+hqI
+uGf
+enq
 ffv
 ffv
 ffv
@@ -427272,10 +427298,10 @@ nKu
 nSr
 vIX
 teW
-teW
-teW
-teW
-ffv
+fUr
+hqI
+wUw
+enq
 ffv
 ffv
 ffv
@@ -427674,10 +427700,10 @@ tML
 wAm
 wAm
 wAm
-wAm
-wAm
-tML
-ffv
+aBn
+hqI
+bPz
+enq
 ffv
 ffv
 ffv
@@ -428078,7 +428104,7 @@ cLL
 iRN
 fUr
 hqI
-wte
+uGf
 enq
 ffv
 ffv
@@ -429284,7 +429310,7 @@ hqI
 hqI
 hqI
 hqI
-bPz
+fKf
 enq
 ffv
 ffv
@@ -495619,7 +495645,7 @@ erZ
 nEd
 fVQ
 lgN
-jMW
+rSF
 lgN
 fVQ
 nEd

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1441,6 +1441,12 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"auK" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "auL" = (
 /obj/structure/lever/wall{
 	pixel_x = 32;
@@ -1805,12 +1811,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"aIG" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "aII" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -3934,13 +3934,6 @@
 /obj/item/roguekey/nightmaiden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"clX" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/item/quiver/bolts,
-/obj/structure/closet/crate/roguecloset/inn/chest,
-/obj/item/storage/foodbag/hardtack,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "clY" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/poo,
@@ -8801,9 +8794,12 @@
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
 "fKf" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet/bogcaves)
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/item/quiver/bolts,
+/obj/structure/closet/crate/roguecloset/inn/chest,
+/obj/item/storage/foodbag/hardtack,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "fKC" = (
 /turf/open/water/river{
 	dir = 1;
@@ -10449,6 +10445,10 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"gYq" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet/bogcaves)
 "gYC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -14452,6 +14452,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jNi" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/spider{
+	tame = 1
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet/bogcaves)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -17200,9 +17207,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter)
-"lOw" = (
-/turf/closed,
-/area/rogue/outdoors/rtfield)
 "lOz" = (
 /obj/structure/mineral_door/bars{
 	lockid = "graveyard"
@@ -28582,6 +28586,10 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"tPc" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "tPg" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/rtfield)
@@ -29039,13 +29047,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/vikingarea)
-"ujK" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/spider{
-	tame = 1
-	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet/bogcaves)
 "ujO" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
@@ -30122,12 +30123,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uUA" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "uUV" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/dirt,
@@ -32570,6 +32565,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"wLX" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -32828,6 +32829,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
+"wWM" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "wXf" = (
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -231204,7 +231209,7 @@ gxt
 gxt
 gxt
 gxt
-fKf
+gYq
 qtE
 gxt
 gxt
@@ -231606,10 +231611,10 @@ gxt
 gxt
 gxt
 gxt
-fKf
-ujK
+gYq
+jNi
 qtE
-fKf
+gYq
 gxt
 gxt
 gxt
@@ -232010,9 +232015,9 @@ gxt
 gxt
 qtE
 qtE
-fKf
+gYq
 qtE
-fKf
+gYq
 gxt
 gxt
 gxt
@@ -232411,9 +232416,9 @@ gxt
 gxt
 gxt
 gxt
-fKf
+gYq
 qtE
-ujK
+jNi
 qtE
 gxt
 gxt
@@ -232813,9 +232818,9 @@ gxt
 gxt
 gxt
 gxt
-fKf
+gYq
 qtE
-fKf
+gYq
 gxt
 gxt
 gxt
@@ -334118,9 +334123,9 @@ kVc
 wSn
 uaL
 qvR
-lOw
-lOw
-lOw
+uaL
+uaL
+qvR
 wSn
 pwu
 wSn
@@ -334520,9 +334525,9 @@ kVc
 wSn
 qvR
 uaL
-lOw
-lOw
-lOw
+qvR
+tPc
+qvR
 qvR
 wSn
 kVc
@@ -334922,9 +334927,9 @@ kVc
 kVc
 qvR
 wSn
-lOw
-lOw
-lOw
+qvR
+wWM
+uaL
 qvR
 hcW
 hcW
@@ -335324,9 +335329,9 @@ kVc
 kVc
 kVc
 kVc
-lOw
-lOw
-lOw
+wWM
+qvR
+wWM
 hcW
 hcW
 hcW
@@ -427714,7 +427719,7 @@ tML
 wAm
 wAm
 wAm
-aIG
+wLX
 hqI
 bPz
 enq
@@ -429324,7 +429329,7 @@ hqI
 hqI
 hqI
 hqI
-uUA
+auK
 enq
 ffv
 ffv
@@ -495659,7 +495664,7 @@ erZ
 nEd
 fVQ
 lgN
-clX
+fKf
 lgN
 fVQ
 nEd

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -99,6 +99,7 @@ GLOBAL_LIST_INIT(our_forest_sex, typecacheof(list(
 #define ishalforc(A) (is_species(A, /datum/species/halforc))
 #define isargonian(A) (is_species(A, /datum/species/lizard/brazil))
 #define isgoblinp(A) (is_species(A, /datum/species/goblinp))
+#define iskobold(A) (is_species(A, /datum/species/kobold))
 
 //more carbon mobs
 #define ismonkey(A) (istype(A, /mob/living/carbon/monkey))

--- a/code/datums/special_traits/traits/traits.dm
+++ b/code/datums/special_traits/traits/traits.dm
@@ -415,7 +415,7 @@
 	greet_text = span_sans("People really hate my voice for some reason.")
 	weight = 100
 
-/datum/special_trait/sillyvoice/on_apply((mob/living/carbon/human/character))
+/datum/special_trait/sillyvoice/on_apply(mob/living/carbon/human/character)
 	ADD_TRAIT(character, TRAIT_COMICSANS, "[type]")
 	character.dna.add_mutation(WACKY)
 

--- a/code/game/objects/items/rogueitems/bait.dm
+++ b/code/game/objects/items/rogueitems/bait.dm
@@ -104,4 +104,5 @@
 	desc = "Imagine if vampires got attracted to those!"
 	icon_state = "baitb"
 	attracted_types = list(/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 20,
-						/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 10)
+						/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 10,
+						/mob/living/simple_animal/hostile/retaliate/rogue/spider = 10)

--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -23,6 +23,7 @@
 	var/base_type //used for compares
 	var/quantity = 1
 	var/plural_name
+	destroy_sound = 'sound/foley/coinphy (1).ogg'
 
 /obj/item/roguecoin/Initialize(mapload, coin_amount)
 	. = ..()
@@ -168,6 +169,49 @@
 		G.merge(src, user)
 		return
 	return ..()
+
+/obj/item/reagent_containers/food/snacks/gold
+	name = "temporary kobold coin snack item for gold"
+	desc = ""
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
+	tastes = list("gold" = 1, "commerce" = 1)
+	foodtype = CLOTH
+
+/obj/item/reagent_containers/food/snacks/silver
+	name = "temporary kobold coin snack item for silver"
+	desc = ""
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
+	tastes = list("silver" = 1, "commerce" = 1)
+	foodtype = CLOTH
+
+/obj/item/reagent_containers/food/snacks/copper
+	name = "temporary kobold coin snack item for copper"
+	desc = ""
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	tastes = list("copper" = 1, "commerce" = 1)
+	foodtype = CLOTH
+
+/obj/item/roguecoin/attack(mob/living/M, mob/living/user, def_zone)
+	if(user.used_intent.type != INTENT_HARM && iskobold(M))
+		var/obj/item/reagent_containers/food/snacks/gold/g = new
+		var/obj/item/reagent_containers/food/snacks/silver/s = new
+		var/obj/item/reagent_containers/food/snacks/copper/c = new
+		var/obj/item/roguecoin/I = user.get_active_held_item()
+		if(istype(I, /obj/item/roguecoin/gold))
+			g.name = name
+			if(g.attack(M, user, def_zone))
+				take_damage(75, sound_effect=FALSE)
+			qdel(g)
+		if(istype(I, /obj/item/roguecoin/silver))
+			s.name = name
+			if(s.attack(M, user, def_zone))
+				take_damage(75, sound_effect=FALSE)
+			qdel(s)
+		if(istype(I, /obj/item/roguecoin/copper))
+			c.name = name
+			if(c.attack(M, user, def_zone))
+				take_damage(75, sound_effect=FALSE)
+			qdel(c)
 
 //GOLD
 /obj/item/roguecoin/gold

--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -215,7 +215,7 @@
 	..()
 	set_light(2, 1, "#ec6510")
 
-/obj/item/reagent_containers/powder/sublimate
+/obj/item/reagent_containers/powder/sublimate // Gotten through alchemy, combine milled gemstone with moondust. Higher value dust, more sublimate.
 	name = "arcyne sublimate"
 	desc = "The stuff of gizaels and magic."
 	gender = PLURAL

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -138,6 +138,7 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	slot_flags = ITEM_SLOT_MOUTH
 	obj_flags = null
 	w_class = WEIGHT_CLASS_TINY
+	destroy_sound = 'sound/foley/hit_rock.ogg'
 	grind_results = list(/datum/reagent/consumable/sodiumchloride = 15)
 
 /obj/item/natural/stone/Initialize()
@@ -254,6 +255,23 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			S.start()
 	else
 		..()
+
+/obj/item/reagent_containers/food/snacks/stone
+	name = "temporary kobold snack item for stone"
+	desc = ""
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	tastes = list("salt" = 1)
+	foodtype = CLOTH
+
+/obj/item/natural/stone/attack(mob/living/M, mob/living/user, def_zone)
+	if(user.used_intent.type != INTENT_HARM && iskobold(M))
+		var/obj/item/reagent_containers/food/snacks/stone/R = new
+		var/obj/item/natural/stone/I = user.get_active_held_item()
+		if(istype(I, /obj/item/natural/stone))
+			R.name = name
+			if(R.attack(M, user, def_zone))
+				take_damage(100, sound_effect=FALSE)
+			qdel(R)
 
 /obj/item/natural/rock
 	name = "rock"

--- a/code/modules/cargo/packsrogue/seeds.dm
+++ b/code/modules/cargo/packsrogue/seeds.dm
@@ -79,6 +79,16 @@
 					/obj/item/seeds/sugarcane,
 				)
 
+/datum/supply_pack/rogue/seeds/pumpkin
+	name = "Pumpkin"
+	cost = 12
+	contains = list(
+					/obj/item/seeds/pumpkin,
+					/obj/item/seeds/pumpkin,
+					/obj/item/seeds/pumpkin,
+					/obj/item/seeds/pumpkin,
+				)
+
 /datum/supply_pack/rogue/seeds/onion
 	name = "Onion"
 	cost = 12

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -283,6 +283,7 @@
 	desc = ""
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "pumpkin"
+	mill_result = /obj/item/reagent_containers/food/snacks/rogue/pumpkinspice
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
 	tastes = list("pumpkin" = 1)
 	dropshrink = 0.75

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -113,7 +113,7 @@ All foods are distributed among various categories. Use common sense.
 /obj/item/reagent_containers/food/snacks/process()
 	..()
 	if(rotprocess)
-		if(!istype(loc, /obj/structure/closet/crate/chest))
+		if(!istype(loc, /obj/structure/closet/crate/chest) && !istype(loc, /obj/structure/roguemachine/vendor))
 			warming -= 20 //ssobj processing has a wait of 20
 			if(warming < (-1*rotprocess))
 				if(become_rotten())

--- a/code/modules/mob/living/simple_animal/rogue/creacher/honeyspider.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/honeyspider.dm
@@ -27,7 +27,7 @@
 	milkies = FALSE
 	food_type = list(/obj/item/bodypart, /obj/item/organ, /obj/item/reagent_containers/food/snacks/rogue/meat)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
-	pooptype = null
+	pooptype = /obj/item/natural/silk
 	STACON = 6
 	STASTR = 9
 	STASPD = 10
@@ -39,6 +39,8 @@
 	attack_sound = list('sound/vo/mobs/spider/attack (1).ogg','sound/vo/mobs/spider/attack (2).ogg','sound/vo/mobs/spider/attack (3).ogg','sound/vo/mobs/spider/attack (4).ogg')
 	aggressive = 1
 	stat_attack = UNCONSCIOUS
+	tame_chance = 25
+	bonus_tame_chance = 15
 
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated
 	icon = 'icons/roguetown/mob/monster/spider.dmi'
@@ -101,7 +103,7 @@
 	..()
 	if(stat == CONSCIOUS)
 		if(!target)
-			if(production >= 100)
+			if(production >= 50)
 				production = 0
 				visible_message(span_alertalien("[src] creates some honey."))
 				var/turf/T = get_turf(src)

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -352,7 +352,7 @@
 
 	req_table = FALSE
 
-/datum/crafting_recipe/roguetown/soporarrow_five // Your symmetry is irrelevant here.
+/datum/crafting_recipe/roguetown/soporarrow_five
 	name = "soporific arrow (x5)"
 	result = list(
 				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
@@ -362,7 +362,7 @@
 				/obj/item/ammo_casing/caseless/rogue/arrow/sopor
 				)
 	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow = 3,
+				/obj/item/ammo_casing/caseless/rogue/arrow = 5,
 				/datum/reagent/medicine/soporpot = 30
 				)
 

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -352,7 +352,7 @@
 
 	req_table = FALSE
 
-/datum/crafting_recipe/roguetown/soporarrow_three // Your symmetry is irrelevant here.
+/datum/crafting_recipe/roguetown/soporarrow_five // Your symmetry is irrelevant here.
 	name = "soporific arrow (x5)"
 	result = list(
 				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
@@ -368,7 +368,7 @@
 
 	req_table = FALSE
 
-/datum/crafting_recipe/roguetown/tranq //Coded, but commented out pending balance discussion.
+/datum/crafting_recipe/roguetown/tranq
 	name = "tranquilizer bolt"
 	result = /obj/item/ammo_casing/caseless/rogue/bolt/tranq
 	reqs = list(
@@ -378,7 +378,7 @@
 
 	req_table = FALSE
 
-/datum/crafting_recipe/roguetown/tranq //Coded, but commented out pending balance discussion.
+/datum/crafting_recipe/roguetown/tranqfive
 	name = "tranquilizer bolt (x5)"
 	result = list(
 				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
@@ -388,7 +388,7 @@
 				/obj/item/ammo_casing/caseless/rogue/bolt/tranq
 				)
 	reqs = list(
-		/obj/item/ammo_casing/caseless/rogue/bolt = 3,
+		/obj/item/ammo_casing/caseless/rogue/bolt = 5,
 		/datum/reagent/medicine/soporpot = 150
 		)
 

--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -174,16 +174,16 @@
 	export_price = 5
 	importexport_amt = 5
 
-// /datum/roguestock/stockpile/pumpkin
-// 	name = "Pumpkin"
-// 	desc = "A large gourd."
-// 	item_type = /obj/item/reagent_containers/food/snacks/grown/pumpkin
-// 	held_items = list(0, 0)
-// 	payout_price = 3
-// 	withdraw_price = 5
-// 	transport_fee = 1
-// 	export_price = 5
-// 	importexport_amt = 5
+/datum/roguestock/stockpile/pumpkin
+	name = "Pumpkin"
+	desc = "A large gourd."
+	item_type = /obj/item/reagent_containers/food/snacks/grown/pumpkin
+	held_items = list(0, 0)
+	payout_price = 3
+	withdraw_price = 5
+	transport_fee = 1
+	export_price = 5
+	importexport_amt = 5
 
 // /datum/roguestock/stockpile/carrot
 // 	name = "Carrot"

--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -229,7 +229,7 @@
 	export_price = 8
 	importexport_amt = 5
 
-/datum/roguestock/stockpile/poultry
+/datum/roguestock/stockpile/egg
 	name = "Egg"
 	desc = "Egg laid by a hen."
 	item_type = /obj/item/reagent_containers/food/snacks/egg

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -255,11 +255,11 @@
 	bookfile = "Neu_cooking.json"
 
 /obj/item/storage/foodbag
-	name = "food pouch"
+	name = "snack pouch"
 	desc = "A small pouch for carrying handfuls of food items."
-	icon_state = "sack_rope"
-	item_state = "sack_rope"
-	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "pouch_e"
+	item_state = "pouch_e"
+	icon = 'icons/roguetown/clothing/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_HIP
 	resistance_flags = NONE
@@ -288,10 +288,10 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	var/list/things = STR.contents()
 	if(things.len)
-		icon_state = "sack_rope"
+		icon_state = "pouch"
 		w_class = WEIGHT_CLASS_NORMAL
 	else
-		icon_state = "sack_rope"
+		icon_state = "pouch_e"
 		w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/foodbag/ComponentInitialize()
@@ -303,8 +303,12 @@
 	STR.set_holdable(list(
 		/obj/item/reagent_containers/food/snacks/rogue/berrycandy,
 		/obj/item/reagent_containers/food/snacks/rogue/applecandy,
+		/obj/item/reagent_containers/food/snacks/rogue/pumpkincandy,
 		/obj/item/reagent_containers/food/snacks/rogue/raisins,
-		/obj/item/reagent_containers/food/snacks/rogue/crackerscooked
+		/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
+		/obj/item/reagent_containers/food/snacks/fat/salo,
+		/obj/item/reagent_containers/food/snacks/fat/salo/slice
 		))
 	STR.click_gather = TRUE
 	STR.attack_hand_interact = FALSE
@@ -316,6 +320,16 @@
 	STR.allow_dump_out = TRUE
 	STR.display_numerical_stacking = TRUE
 
+/obj/item/storage/foodbag/hardtack
+	name = "rations pouch"
+	desc = "A small pouch for carrying handfuls of food items."
+	icon_state = "pouch"
+	item_state = "pouch"
+
+/obj/item/storage/foodbag/hardtack/PopulateContents()
+	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
+	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
+	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
 
 /* * * * * * * * * * * * * * *	*
  *								*

--- a/modular/Neu_Food/code/raw/NeuFood_dough.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_dough.dm
@@ -59,6 +59,17 @@
 				qdel(src)
 		else
 			to_chat(user, "<span class='warning'>You need to put [src] on a table to roll it out!</span>")
+	if(istype(I, /obj/item/reagent_containers/powder/sugar))
+		if(isturf(loc)&& (found_table))
+			playsound(get_turf(user), 'modular/Neu_Food/sound/kneading_alt.ogg', 90, TRUE, -1)
+			to_chat(user, "<span class='notice'>Mixing sugar into the dough...</span>")
+			if(do_after(user,long_cooktime, target = src))
+				user.mind.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
+				new /obj/item/reagent_containers/food/snacks/rogue/sweetdough(loc)
+				qdel(I)
+				qdel(src)
+		else
+			to_chat(user, "<span class='warning'>You need to put [src] on a table to roll it out!</span>")
 	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/raisins))
 		if(isturf(loc)&& (found_table))
 			playsound(get_turf(user), 'modular/Neu_Food/sound/kneading.ogg', 100, TRUE, -1)
@@ -122,7 +133,7 @@
 		return ..()
 
 /*	.................   Butterdough   ................... */
-/obj/item/reagent_containers/food/snacks/rogue/butterdough
+/obj/item/reagent_containers/food/snacks/rogue/butterdough // Moved cake base to sweetdough.
 	name = "butterdough"
 	desc = "What is a triumph, to a legacy?"
 	icon_state = "butterdough"
@@ -132,26 +143,6 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/butterdoughslice
 	w_class = WEIGHT_CLASS_NORMAL
 	slice_sound = TRUE 
-	
-/obj/item/reagent_containers/food/snacks/rogue/butterdough/attackby(obj/item/I, mob/living/user, params)
-	var/found_table = locate(/obj/structure/table) in (loc)
-	if(user.mind)
-		short_cooktime = (60 - ((user.mind.get_skill_level(/datum/skill/craft/cooking))*5))
-		long_cooktime = (100 - ((user.mind.get_skill_level(/datum/skill/craft/cooking))*10))
-	if(istype(I, /obj/item/reagent_containers/food/snacks/egg))
-		if(isturf(loc)&& (found_table))
-			playsound(get_turf(user), 'sound/foley/dropsound/food_drop.ogg', 40, TRUE, -1)
-			to_chat(user, "<span class='notice'>Working cackleberry into the dough, shaping it into a cake...</span>")
-			playsound(get_turf(user), 'modular/Neu_Food/sound/eggbreak.ogg', 100, TRUE, -1)
-			if(do_after(user,long_cooktime, target = src))
-				user.mind.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
-				new /obj/item/reagent_containers/food/snacks/rogue/cake_base(loc)
-				qdel(I)
-				qdel(src)
-		else
-			to_chat(user, "<span class='warning'>You need to put [src] on a table to roll it out!</span>")
-	else
-		return ..()
 
 /*	.................   Butterdough piece   ................... */
 /obj/item/reagent_containers/food/snacks/rogue/butterdoughslice
@@ -502,6 +493,158 @@
 	rotprocess = SHELFLIFE_EXTREME
 	eat_effect = /datum/status_effect/buff/foodbuff
 
+/obj/item/reagent_containers/food/snacks/rogue/sweetdough
+	name = "sweet dough"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "sweetdough"
+	slices_num = 4
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/uncookedfinecake
+	cooked_type = null
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("sweetened dough" = 1)
+	foodtype = SUGAR
+	eat_effect = /datum/status_effect/debuff/uncookedfood
+	rotprocess = SHELFLIFE_SHORT
+
+/obj/item/reagent_containers/food/snacks/rogue/uncookedfinecake
+	name = "uncooked fine cake"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "finecake"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
+	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/finecake
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("dough" = 1,"sugar" = 1)
+	foodtype = GRAIN
+	slice_batch = FALSE
+	rotprocess = SHELFLIFE_SHORT
+	eat_effect = /datum/status_effect/debuff/uncookedfood
+
+/obj/item/reagent_containers/food/snacks/rogue/finecake
+	name = "finecake"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "finecake3"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 10)
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("delicate, melt in your mouth sweetness" = 1)
+	foodtype = GRAIN
+	bitesize = 3
+	rotprocess = SHELFLIFE_EXTREME
+
+/obj/item/reagent_containers/food/snacks/rogue/finecake/On_Consume(mob/living/eater)
+	..()
+	if(bitecount == 1)
+		icon_state = "finecake2"
+	if(bitecount == 2)
+		icon_state = "finecake1"
+
+/obj/item/reagent_containers/food/snacks/rogue/plaincake
+	name = "plain cake"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "plaincake"
+	slices_num = 6
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/plaincakeslice
+	list_reagents = list(/datum/reagent/consumable/nutriment = 40)
+	w_class = WEIGHT_CLASS_BULKY
+	tastes = list("crispy sweetened dough with a sugar glaze and hints of rosewater" = 1)
+	foodtype = SUGAR
+	eat_effect = /datum/status_effect/buff/foodbuff
+	bitesize = 6
+	rotprocess = SHELFLIFE_EXTREME
+	dropshrink = 0.80
+
+/obj/item/reagent_containers/food/snacks/rogue/plaincakeslice
+	name = "plain cake slice"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "plaincakeslice"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 7)
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("crispy sweetened dough with a sugar glaze and hints of rosewater" = 1)
+	foodtype = SUGAR
+	eat_effect = /datum/status_effect/buff/foodbuff
+	bitesize = 3
+	rotprocess = null
+	dropshrink = 0.60
+
+/obj/item/reagent_containers/food/snacks/rogue/sweetdough/attackby(obj/item/I, mob/living/user, params)
+	var/found_table = locate(/obj/structure/table) in (loc)
+	if(user.mind)
+		short_cooktime = (60 - ((user.mind.get_skill_level(/datum/skill/craft/cooking))*5))
+		long_cooktime = (100 - ((user.mind.get_skill_level(/datum/skill/craft/cooking))*10))
+	if(istype(I, /obj/item/reagent_containers/food/snacks/egg))
+		if(isturf(loc)&& (found_table))
+			playsound(get_turf(user), 'sound/foley/dropsound/food_drop.ogg', 40, TRUE, -1)
+			to_chat(user, "<span class='notice'>Working cackleberry into the dough, shaping it into a cake...</span>")
+			playsound(get_turf(user), 'modular/Neu_Food/sound/eggbreak.ogg', 100, TRUE, -1)
+			if(do_after(user,long_cooktime, target = src))
+				user.mind.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
+				new /obj/item/reagent_containers/food/snacks/rogue/cake_base(loc)
+				qdel(I)
+				qdel(src)
+		else
+			to_chat(user, "<span class='warning'>You need to put [src] on a table to work it!</span>")
+	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/pumpkinspice))
+		if(isturf(loc)&& (found_table))
+			playsound(get_turf(user), 'sound/foley/dropsound/food_drop.ogg', 40, TRUE, -1)
+			to_chat(user, "<span class='notice'>Working pumpkin spice into the dough, shaping it into a pie...</span>")
+			playsound(get_turf(user), 'modular/Neu_Food/sound/kneading_alt.ogg', 100, TRUE, -1)
+			if(do_after(user,long_cooktime, target = src))
+				user.mind.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
+				new /obj/item/reagent_containers/food/snacks/rogue/rawpumpkinpie(loc)
+				qdel(I)
+				qdel(src)
+		else
+			to_chat(user, "<span class='warning'>You need to put [src] on a table to work it!</span>")
+	else
+		return ..()
+
+// -------------- PUMPKIN PIE --------------- // Can likely be modified to the pie system, but its annoying to read and its almost october
+/obj/item/reagent_containers/food/snacks/rogue/rawpumpkinpie 
+	name = "raw pumpkin pie"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "rawpumpkinpie"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 10)
+	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pumpkinpie
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("sweet, spiced pumpkin filling in a doughy crust" = 1)
+	foodtype = SUGAR
+	eat_effect = /datum/status_effect/debuff/uncookedfood
+	rotprocess = SHELFLIFE_SHORT
+
+/obj/item/reagent_containers/food/snacks/rogue/pumpkinpie
+	name = "pumpkin pie"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "pumpkinpie"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 48)
+	slices_num = 6
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/pumpkinpieslice
+	dropshrink = 0.80
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("sweet, spiced pumpkin filling in a flaky crust" = 1)
+	foodtype = SUGAR
+	bitesize = 3
+	rotprocess = SHELFLIFE_EXTREME
+
+/obj/item/reagent_containers/food/snacks/rogue/pumpkinpieslice
+	name = "pumpkin pie slice"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "pumpkinpieslice"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("sweet, spiced pumpkin filling in a flaky crust" = 1)
+	foodtype = SUGAR
+	bitesize = 3
+	rotprocess = SHELFLIFE_EXTREME
+	dropshrink = 0.60
+
 /*	.................   Sweetroll   ................... */
 
 /obj/item/reagent_containers/food/snacks/rogue/sweetroll
@@ -660,12 +803,13 @@
 
 /*	.................   Cake   ................... */
 /obj/item/reagent_containers/food/snacks/rogue/cake_base
-	name = "cake base"
+	name = "uncooked plaincake"
 	desc = "With this sweet thing, you shall make them sing."
 	icon_state = "cake"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1)
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtype = GRAIN | DAIRY
+	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/plaincake
 	rotprocess = SHELFLIFE_LONG
 /obj/item/reagent_containers/food/snacks/rogue/cake_base/attackby(obj/item/I, mob/living/user, params)
 	var/found_table = locate(/obj/structure/table) in (loc)

--- a/modular/Neu_Food/code/raw/NeuFood_processed.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_processed.dm
@@ -111,6 +111,18 @@
 			qdel(src)
 	else ..()
 
+/obj/item/reagent_containers/food/snacks/rogue/pumpkinspice
+	name = "pumpkin spice"
+	desc = "A warm, spicy blend of cinnamon, nutmeg, and cloves."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "pumpkinspice"
+	bitesize = 1
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
+	w_class = WEIGHT_CLASS_TINY
+	tastes = list("an overwhelming flavor of pumpkin and other herbs." = 1)
+	eat_effect = /datum/status_effect/debuff/badmeal
+	rotprocess = null
+
 /obj/item/reagent_containers/food/snacks/rogue/candybase
 	name = "candy base"
 	desc = ""
@@ -143,6 +155,15 @@
 			if(do_after(user,short_cooktime, target = src))
 				user.mind.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
 				new /obj/item/reagent_containers/food/snacks/rogue/berrycandy(loc)
+				qdel(I)
+				qdel(src)
+	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/pumpkinspice))
+		if(isturf(loc)&& (found_table))
+			playsound(get_turf(user), 'modular/Neu_Food/sound/kneading.ogg', 100, TRUE, -1)
+			to_chat(user, "<span class='notice'>Mixing the pumpkin spice into the base...</span>")
+			if(do_after(user,short_cooktime, target = src))
+				user.mind.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
+				new /obj/item/reagent_containers/food/snacks/rogue/pumpkincandy(loc)
 				qdel(I)
 				qdel(src)
 	else
@@ -198,6 +219,31 @@
 		icon_state = "berrycandy2"
 	if(bitecount == 5)
 		icon_state = "berrycandy1"
+
+/obj/item/reagent_containers/food/snacks/rogue/pumpkincandy
+	name = "pumpkin candy"
+	desc = ""
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "pumpkincandy6"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 12)
+	w_class = WEIGHT_CLASS_NORMAL
+	tastes = list("sweet, spiced pumpkin candy" = 1)
+	foodtype = SUGAR
+	bitesize = 6
+	rotprocess = null
+
+/obj/item/reagent_containers/food/snacks/rogue/pumpkincandy/On_Consume(mob/living/eater)
+	..()
+	if(bitecount == 1)
+		icon_state = "pumpkincandy5"
+	if(bitecount == 2)
+		icon_state = "pumpkincandy4"
+	if(bitecount == 3)
+		icon_state = "pumpkincandy3"
+	if(bitecount == 4)
+		icon_state = "pumpkincandy2"
+	if(bitecount == 5)
+		icon_state = "pumpkincandy1"
 
 // -------------- SPIDER HONEY -----------------
 /obj/item/reagent_containers/food/snacks/rogue/honey

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
@@ -14,7 +14,7 @@
 	. = 1 
 
 /datum/reagent/medicine/soporpot
-	name = "Soporific Potion"
+	name = "Soporific Poison"
 	description = "Weakens those it enters."
 	reagent_state = LIQUID
 	color = "#fcefa8"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Read title!
Gold, silver, copper coins and stone have 3, 2, 1 and 1 nutriment respectively. Only kobolds can eat them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The value of the materials are discouragingly disproportionate to what you could get for their value in real food. Kobolds can eat rocks and metal in DND, so why not here? 
Also gives mammons another use.
Feed your local kobolds with crunchy coins, today.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
