### PR TITLE
Fix stone soporific arrows dupe on craft

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -427,7 +427,7 @@
 				/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor
 				)
 	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
+				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 3,
 				/datum/reagent/medicine/soporpot = 30
 				)
 


### PR DESCRIPTION
## About The Pull Request

tldr: you don't get 2 extra arrows for some reason when you craft poisoned soporific arrows with the stone ones.

## Why It's Good For The Game

bugs are bad :(
