### PR TITLE
Innkeep / Cook Supply Buff

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -112,7 +112,7 @@
 	name = "Salt"
 	desc = "Rock salt useful for curing and cooking."
 	item_type = /obj/item/reagent_containers/powder/salt
-	held_items = list(2, 0)
+	held_items = list(8, 10)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 2
@@ -123,7 +123,7 @@
 	name = "Grain"
 	desc = "Spelt grain."
 	item_type = /obj/item/reagent_containers/food/snacks/grown/wheat
-	held_items = list(0, 4)
+	held_items = list(8, 10)
 	payout_price = 2
 	withdraw_price = 3
 	transport_fee = 1
@@ -134,7 +134,7 @@
 	name = "Oats"
 	desc = "Oat grain."
 	item_type = /obj/item/reagent_containers/food/snacks/grown/oat
-	held_items = list(0, 4)
+	held_items = list(8, 10)
 	payout_price = 2
 	withdraw_price = 3
 	transport_fee = 1
@@ -145,7 +145,7 @@
 	name = "Apple"
 	desc = "Harvested produce."
 	item_type = /obj/item/reagent_containers/food/snacks/grown/apple
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 2
 	withdraw_price = 4
 	transport_fee = 1
@@ -156,7 +156,7 @@
 	name = "Potato"
 	desc = "A starchy tuber."
 	item_type = /obj/item/reagent_containers/food/snacks/grown/potato/rogue
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 1
@@ -167,7 +167,7 @@
 	name = "Sugarcane"
 	desc = "A sweet stalk."
 	item_type = /obj/item/reagent_containers/food/snacks/grown/sugarcane
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 1
@@ -178,7 +178,7 @@
 	name = "Pumpkin"
 	desc = "A large gourd."
 	item_type = /obj/item/reagent_containers/food/snacks/grown/pumpkin
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 1
@@ -211,7 +211,7 @@
 	name = "Meat"
 	desc = "Edible flesh harvested from animals."
 	item_type = /obj/item/reagent_containers/food/snacks/rogue/meat/steak
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 4
 	withdraw_price = 8
 	transport_fee = 2
@@ -222,7 +222,7 @@
 	name = "Bird Meat"
 	desc = "Edible flesh harvested from birds."
 	item_type = /obj/item/reagent_containers/food/snacks/rogue/meat/poultry
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 4
 	withdraw_price = 8
 	transport_fee = 2
@@ -233,7 +233,7 @@
 	name = "Egg"
 	desc = "Egg laid by a hen."
 	item_type = /obj/item/reagent_containers/food/snacks/egg
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 2
@@ -244,7 +244,7 @@
 	name = "Butter"
 	desc = "The product of milk and salt."
 	item_type = /obj/item/reagent_containers/food/snacks/butter
-	held_items = list(0, 0)
+	held_items = list(1, 2)
 	payout_price = 9
 	withdraw_price = 13
 	transport_fee = 3
@@ -255,7 +255,7 @@
 	name = "Cheese"
 	desc = "The product of milk and salt."
 	item_type = /obj/item/reagent_containers/food/snacks/rogue/cheese
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 6
 	withdraw_price = 10
 	transport_fee = 3
@@ -266,7 +266,7 @@
 	name = "Carp"
 	desc = "A common freshwater fish."
 	item_type = /obj/item/reagent_containers/food/snacks/fish/carp
-	held_items = list(0, 0)
+	held_items = list(8, 10)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 1
@@ -277,7 +277,7 @@
 	name = "Eel"
 	desc = "A sinuous fish."
 	item_type = /obj/item/reagent_containers/food/snacks/fish/eel
-	held_items = list(0, 0)
+	held_items = list(0, 5)
 	payout_price = 3
 	withdraw_price = 5
 	transport_fee = 3
@@ -288,7 +288,7 @@
 	name = "Angler"
 	desc = "A sinuous fish."
 	item_type = /obj/item/reagent_containers/food/snacks/fish/angler
-	held_items = list(0, 0)
+	held_items = list(0, 5)
 	payout_price = 5
 	withdraw_price = 8
 	transport_fee = 3
@@ -299,7 +299,7 @@
 	name = "Clownfish"
 	desc = "A boring fish."
 	item_type = /obj/item/reagent_containers/food/snacks/fish/clownfish
-	held_items = list(0, 0)
+	held_items = list(4, 6)
 	payout_price = 8
 	withdraw_price = 11
 	transport_fee = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds 8 local and 10 remote to stockpile food items, as well as a smaller amount for fish and clownfish

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One of the least fun things about playing innkeep/cook is, when people come to you for food and drink, you are severely dependant on either doing heavy roundstart prep, or hoping to the gods above that a soilson has bothered to stock the things you desire. This makes it possible for them to have some stock to purchase in order to sustain themselves longer than short term, while also accounting for toxic stewards roundstart selling a batch of goods, ensuring less than 10 will always be available for _anyone_ to purchase round start.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->