### PR TITLE
Sublime Ambrosia (Remake)

### DIFF
--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -8,6 +8,9 @@
 /obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot
 	list_reagents = list(/datum/reagent/medicine/majorhealthpot = 45)
 
+/obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia
+	list_reagents = list(/datum/reagent/medicine/sublimeambrosia = 5)
+	
 /obj/item/reagent_containers/glass/bottle/rogue/manapot
 	list_reagents = list(/datum/reagent/medicine/manapot = 45)
 

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -79,6 +79,71 @@
 	M.adjustToxLoss(3, 0)
 	M.blood_volume = min(M.blood_volume+100, BLOOD_VOLUME_MAXIMUM) // Full to bursting.
 
+/datum/chemical_reaction/sublime_ambrosia
+	name = "Sublime Ambrosia"
+	id = /datum/reagent/medicine/sublimeambrosia
+	results = list(/datum/reagent/medicine/sublimeambrosia = 5)
+	required_reagents = list (/datum/reagent/medicine/healthpot = 45, /datum/reagent/medicine/minorhealthpot = 45, /datum/reagent/medicine/majorhealthpot = 45)
+
+/datum/reagent/medicine/sublimeambrosia
+	name = "Sublime Ambrosia"
+	description = "Rapidly regenerates all types of damage, and reverses death."
+	reagent_state = LIQUID
+	color = "#b89c2b"
+	taste_description = "magical apoptosis"
+	overdose_threshold = 6 // Small doses...
+	metabolization_rate = 0.3 * REAGENTS_METABOLISM
+	alpha = 173
+
+/datum/reagent/medicine/sublimeambrosia/on_mob_life(mob/living/carbon/M)
+	var/list/wCount = M.get_wounds()
+	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+		M.blood_volume = min(M.blood_volume+200, BLOOD_VOLUME_MAXIMUM)
+	else
+		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_MAXIMUM)
+	if(wCount.len > 0)	
+		M.heal_wounds(6)
+		M.update_damage_overlays()
+	M.adjustBruteLoss(-4.5*REM, 0)
+	M.adjustFireLoss(-4.5*REM, 0)
+	M.adjustOxyLoss(-9, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -9*REM)
+	M.adjustCloneLoss(-9*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/sublimeambrosia/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(iscarbon(M) && M.stat == DEAD)
+		if(M.mob_biotypes & MOB_UNDEAD)
+			return FALSE
+		if(!M.revive(full_heal = FALSE))
+			M.visible_message(span_notice("[M]'s body does not seem to react to the ambrosia..."))
+			return FALSE
+		if(method == INGEST)
+			var/mob/living/carbon/spirit/underworld_spirit = M.get_spirit()
+			if(underworld_spirit)
+				var/mob/dead/observer/ghost = underworld_spirit.ghostize()
+				qdel(underworld_spirit)
+				ghost.mind.transfer_to(M, TRUE)
+			M.grab_ghost(force = TRUE) // even suicides
+			M.emote("breathgasp")
+			M.Jitter(100)
+			M.update_body()
+			M.visible_message(span_notice("[M]'s body convulses as they're ripped from death's embrace by ambrosia!"), span_green("I awake from the void."))
+			if(M.mind)
+				if(!HAS_TRAIT(M, TRAIT_IWASREVIVED))
+					ADD_TRAIT(M, TRAIT_IWASREVIVED, "[type]")
+		return TRUE
+	..()
+
+/datum/reagent/medicine/sublimeambrosia/overdose_process(mob/living/carbon/M) // This is meant for the dead, or near dead. Imbibe at own risk.
+	M.add_nausea(25)
+	M.adjustBruteLoss(3*REM, 0)
+	M.dizziness += 2
+	M.confused += 2
+	M.adjustToxLoss(15, 0)
+	M.blood_volume = min(M.blood_volume+100, BLOOD_VOLUME_MAXIMUM)
+
 /datum/reagent/medicine/shroomt
 	name = "Shroom Tea"
 	description = "Extremely slowly regenerates all types of damage. long lasting."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Had an issue with my last repo and had to remake it. Apparently doing this closes all open PRs and makes them unable to be opened again.
Same as in https://github.com/Tree445/Hearthstone/pull/529.

Gives alchemy a way of reviving people, called 'sublime ambrosia'
Takes much longer than all other revival methods to set up, but its extremely quick to apply.
Requires all 3 kinds of healing potions, mixed in a barrel. 45oz reduced down to 1.7oz, a single dose.

Can only be used on corpses that arent rotted, and has more potent healing ability than major healing potion, but anything more than a single sip will most certainly result in death.
Intended as a way to prevent potion stacking, as well as a good capstone for alchemists.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Been thinking about a way to make this for a while now.
And after a recent round where I was actually using alchemy for most of it, I discovered I can just mix all 3 tiers of potions together and make a brew that already brought me back from the brink of death, it near instantly cured broken bones in some, and was overall impossible to OD on. This makes that OP potion mix unfeasible, whilst also still rewarding it with a useful method of revival that can be used or sold to those who cant use or access faith healing or surgery healing.

Did some extensive testing with a friend, and Im satisfied this works as desired.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
