### PR TITLE
Churn Undead Nerf + lots of small changes + More Migrant Waves

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -22586,8 +22586,8 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/item/storage/roguebag{
-	pixel_y = -7;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = -7
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -72039,7 +72039,7 @@ aci
 aci
 abg
 abg
-abe
+abg
 abg
 abg
 abg

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1098,6 +1098,10 @@
 /obj/effect/landmark/start/templar,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"aex" = (
+/obj/structure/flora/wildplant/wild_herbs,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/tribalfort)
 "aeI" = (
 /obj/structure/ladder,
 /obj/structure/roguemachine/scomm,
@@ -1755,6 +1759,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"aGZ" = (
+/obj/structure/fluff/littlebanners,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "aHc" = (
 /obj/effect/landmark/map_load_mark/sewers_bottom,
 /turf/closed/mineral/rogue,
@@ -2271,6 +2279,10 @@
 "baS" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
+"bbm" = (
+/obj/structure/flora/wildplant/wild_poppy,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/tribalfort)
 "bbt" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 10
@@ -3097,6 +3109,7 @@
 /obj/structure/stairs{
 	dir = 4
 	},
+/obj/structure/fluff/littlebanners,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "bFC" = (
@@ -3276,11 +3289,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
 "bNz" = (
-/obj/effect/landmark/start/adventurer{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/bog)
+/obj/structure/fluff/canopy/booth/booth02,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bNF" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3442,14 +3453,16 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "bSE" = (
-/obj/effect/landmark/start/adventurerlate{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/obj/effect/landmark/start/adventurer{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bSW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -3766,6 +3779,10 @@
 /obj/item/rogueweapon/tongs,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"cgG" = (
+/obj/structure/fluff/canopy,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "cgP" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -5239,6 +5256,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bog)
+"dej" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "det" = (
 /obj/effect/landmark/start/nightman,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -6163,6 +6184,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"dRa" = (
+/obj/structure/flora/wildplant/wild_herbs,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dRb" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -12534,6 +12559,10 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/shelter/mountains)
+"iuj" = (
+/obj/structure/fluff/littlebanners/bluewhite,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "iuo" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
@@ -14535,6 +14564,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"jPp" = (
+/obj/structure/flora/wildplant/wild_poppy,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/bog)
 "jPu" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /obj/structure/fluff/railing/border{
@@ -17361,6 +17394,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves)
+"lWv" = (
+/obj/structure/flora/wildplant/wild_poppy,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
@@ -17663,6 +17700,10 @@
 /obj/item/rogueweapon/sickle,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
+"mhC" = (
+/obj/structure/flora/wildplant/wild_herbs,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/bog)
 "mhJ" = (
 /obj/item/chair/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19781,6 +19822,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nOC" = (
+/obj/structure/fluff/littlebanners/bluewhite,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "nOX" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21575,6 +21620,7 @@
 /obj/structure/fluff/walldeco/bsmith{
 	dir = 1
 	},
+/obj/structure/fluff/littlebanners,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "oXq" = (
@@ -23299,6 +23345,16 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qcm" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/walldeco/masonflag,
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town/dwarfin)
 "qct" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -25042,6 +25098,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"rmK" = (
+/obj/structure/flora/wildplant/wild_herbs,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/tribalfort)
 "rmT" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -25526,6 +25586,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"rEL" = (
+/obj/structure/flora/wildplant/wild_herbs,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/bog)
 "rET" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -28579,6 +28643,10 @@
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"tOj" = (
+/obj/structure/fluff/littlebanners/greenwhite,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
@@ -28683,6 +28751,10 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"tUw" = (
+/obj/structure/fluff/littlebanners/greenwhite,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "tUO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
@@ -31336,6 +31408,10 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"vPf" = (
+/obj/structure/flora/wildplant/wild_herbs,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/tribalfort)
 "vPt" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -72039,7 +72115,7 @@ aci
 aci
 abg
 abg
-abg
+abe
 abg
 abg
 abg
@@ -181078,7 +181154,7 @@ whb
 whb
 dpP
 ozm
-bSE
+dVO
 dVO
 dVO
 whb
@@ -273129,7 +273205,7 @@ wLx
 wLx
 wLx
 odi
-odi
+jPp
 sYx
 wGD
 wGD
@@ -280759,7 +280835,7 @@ odi
 sYx
 sYx
 sYx
-odi
+jPp
 wGD
 wGD
 sYx
@@ -285967,7 +286043,7 @@ gxt
 gxt
 odi
 odi
-odi
+jPp
 odi
 kWT
 odi
@@ -289992,7 +290068,7 @@ uRH
 sYx
 wLx
 odi
-odi
+mhC
 odi
 sYx
 sYx
@@ -290142,7 +290218,7 @@ kXN
 kXN
 kXN
 lPu
-lPu
+bbm
 lPu
 lPu
 lPu
@@ -292157,7 +292233,7 @@ kXN
 kXN
 kXN
 kXN
-lPu
+aex
 kXN
 kXN
 lPu
@@ -293759,7 +293835,7 @@ kXN
 kXN
 kXN
 kXN
-kXN
+vPf
 kXN
 kXN
 kXN
@@ -294575,7 +294651,7 @@ kXN
 kXN
 kXN
 kXN
-lPu
+bbm
 kXN
 kXN
 kXN
@@ -294837,7 +294913,7 @@ sYx
 wLx
 sYx
 odi
-odi
+mhC
 odi
 kWT
 kWT
@@ -295249,7 +295325,7 @@ sYx
 sYx
 wLx
 sYx
-odi
+jPp
 odi
 odi
 odi
@@ -295975,7 +296051,7 @@ odi
 odi
 odi
 odi
-odi
+mhC
 odi
 lOV
 lOV
@@ -296409,7 +296485,7 @@ odi
 odi
 wLx
 odi
-odi
+mhC
 odi
 odi
 odi
@@ -297623,7 +297699,7 @@ odi
 odi
 odi
 odi
-odi
+mhC
 odi
 odi
 uRH
@@ -298985,7 +299061,7 @@ kXN
 kXN
 kXN
 kXN
-fPm
+rmK
 fPm
 mDK
 kXN
@@ -299582,7 +299658,7 @@ odi
 odi
 odi
 odi
-odi
+jPp
 wGD
 lOV
 lOV
@@ -300994,7 +301070,7 @@ kXN
 kXN
 kXN
 kXN
-lPu
+bbm
 kXN
 kXN
 kXN
@@ -301002,7 +301078,7 @@ kXN
 lPu
 lPu
 lPu
-lPu
+aex
 lPu
 lPu
 kXN
@@ -301290,7 +301366,7 @@ wGD
 wGD
 wGD
 sYx
-sYx
+rEL
 wGD
 wGD
 htA
@@ -302609,7 +302685,7 @@ mDK
 kXN
 lPu
 lPu
-lPu
+bbm
 lPu
 lPu
 lPu
@@ -303207,7 +303283,7 @@ lOV
 lOV
 wGD
 odi
-odi
+mhC
 odi
 wGD
 odi
@@ -304055,7 +304131,7 @@ khC
 wLx
 wLx
 sYx
-odi
+jPp
 odi
 sYx
 sYx
@@ -304702,11 +304778,11 @@ wbg
 wbg
 wbg
 wbg
+aGZ
 wbg
 wbg
 wbg
-wbg
-wbg
+aGZ
 wbg
 wbg
 wbg
@@ -304724,13 +304800,13 @@ wVI
 nHz
 wVI
 wVI
-wVI
+tUw
 wVI
 wVI
 wVI
 qPD
 wVI
-wVI
+nOC
 wbg
 wbg
 dAy
@@ -305104,6 +305180,11 @@ wbg
 wbg
 wbg
 wbg
+aGZ
+wbg
+wbg
+wbg
+aGZ
 wbg
 wbg
 wbg
@@ -305121,18 +305202,13 @@ wbg
 wbg
 wbg
 wbg
+tOj
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+iuj
 wbg
 wbg
 lia
@@ -305506,6 +305582,11 @@ wbg
 wbg
 wbg
 wbg
+aGZ
+wbg
+wbg
+wbg
+aGZ
 wbg
 wbg
 wbg
@@ -305523,18 +305604,13 @@ wbg
 wbg
 wbg
 wbg
+tOj
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+iuj
 wbg
 wbg
 lia
@@ -305562,7 +305638,7 @@ fxx
 fxx
 fxx
 fxx
-uaL
+cgG
 aar
 aar
 qvR
@@ -305893,8 +305969,8 @@ bZB
 pku
 xAt
 xAt
-xAt
 eoy
+bNz
 wbg
 wbg
 wbg
@@ -305930,13 +306006,13 @@ wbg
 wbg
 wbg
 wbg
+tOj
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
+iuj
 wbg
 wbg
 lia
@@ -306295,8 +306371,8 @@ gPy
 gPy
 xAt
 xAt
-pQo
-hJq
+eoy
+bSE
 wbg
 wbg
 wbg
@@ -306310,7 +306386,7 @@ wbg
 wbg
 wbg
 wVI
-ufu
+qcm
 cZg
 fRa
 jDB
@@ -306332,13 +306408,13 @@ wbg
 wbg
 wbg
 wbg
-wVI
+tUw
 wVI
 wVI
 wVI
 knW
 wVI
-wVI
+nOC
 wVI
 wbg
 gKK
@@ -306698,7 +306774,7 @@ xAt
 xAt
 xAt
 eoy
-wbg
+dej
 wbg
 ksI
 lCv
@@ -307938,7 +308014,7 @@ wSl
 bQf
 mwE
 pKQ
-mwE
+lWv
 adK
 xMr
 yho
@@ -308507,7 +308583,7 @@ odi
 uRH
 odi
 odi
-odi
+jPp
 sYx
 sYx
 odi
@@ -309142,7 +309218,7 @@ fRN
 pkK
 mwE
 jEB
-mwE
+dRa
 mwE
 mKR
 oUn
@@ -310915,7 +310991,7 @@ odi
 sYx
 odi
 odi
-odi
+mhC
 sYx
 odi
 odi
@@ -312095,7 +312171,7 @@ odi
 odi
 odi
 odi
-odi
+mhC
 sYx
 sYx
 odi
@@ -314911,7 +314987,7 @@ sYx
 odi
 sYx
 sYx
-odi
+jPp
 odi
 uRH
 uRH
@@ -315352,7 +315428,7 @@ sYx
 odi
 odi
 odi
-odi
+mhC
 sYx
 sYx
 sYx
@@ -316484,7 +316560,7 @@ whb
 sYx
 sYx
 sYx
-odi
+mhC
 kWT
 sYx
 sYx
@@ -318170,7 +318246,7 @@ kWT
 kWT
 odi
 odi
-odi
+jPp
 sYx
 odi
 odi
@@ -318500,7 +318576,7 @@ odi
 odi
 uRH
 odi
-odi
+jPp
 odi
 odi
 sYx
@@ -319751,7 +319827,7 @@ quT
 quT
 sYx
 odi
-sYx
+rEL
 sYx
 sYx
 odi
@@ -323370,7 +323446,7 @@ odi
 kWT
 sYx
 sYx
-odi
+jPp
 odi
 odi
 sYx
@@ -324186,7 +324262,7 @@ sYx
 sYx
 sYx
 sYx
-odi
+mhC
 odi
 kWT
 odi
@@ -327938,7 +328014,7 @@ wLx
 sYx
 odi
 odi
-bNz
+sYx
 odi
 wLx
 wLx
@@ -328340,7 +328416,7 @@ kWT
 sYx
 odi
 sYx
-bNz
+sYx
 odi
 sYx
 odi
@@ -336368,7 +336444,7 @@ odi
 odi
 sYx
 sYx
-bNz
+sYx
 sYx
 sYx
 sYx
@@ -336770,7 +336846,7 @@ sYx
 sYx
 sYx
 sYx
-bNz
+sYx
 odi
 odi
 sYx

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -144,8 +144,8 @@
 				number_of_alphanumeric++
 				last_char_group = 3
 
-			// '  -  .
-			if(39,45,46)			//Common name punctuation
+			// '  ,   -  .
+			if(39,44,45,46)			//Common name punctuation
 				if(!last_char_group)
 					continue
 				t_out += ascii2text(ascii_char)

--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -7,9 +7,9 @@ SUBSYSTEM_DEF(migrants)
 	var/time_until_next_wave = 2 MINUTES
 	var/wave_timer = 0
 
-	var/time_between_waves = 3 MINUTES
-	var/time_between_fail_wave = 90 SECONDS
-	var/wave_wait_time = 30 SECONDS
+	var/time_between_waves = 1 MINUTES
+	var/time_between_fail_wave = 20 SECONDS
+	var/wave_wait_time = 10 SECONDS
 
 	var/list/spawned_waves = list()
 

--- a/code/controllers/subsystem/rogue/humannpc.dm
+++ b/code/controllers/subsystem/rogue/humannpc.dm
@@ -1,7 +1,7 @@
 
 SUBSYSTEM_DEF(humannpc)
 	name = "humannpc"
-	wait = 5
+	wait = 0
 	flags = SS_KEEP_TIMING
 	priority = 50
 	var/list/processing = list()

--- a/code/datums/migrants/migrant_waves/fablefield wave.dm
+++ b/code/datums/migrants/migrant_waves/fablefield wave.dm
@@ -24,8 +24,18 @@
 	name = "The Fablefield Troupe"
 	shared_wave_type = /datum/migrant_wave/fablefield
 	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/fablefield_down_three
 	roles = list(
 		/datum/migrant_role/fablefield/goliard = 1,
 		/datum/migrant_role/fablefield/troubadour = 1,
+	)
+	greet_text = "A troupe of troubadours from fair Fablefield, you travel to Rockhill seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
+
+/datum/migrant_wave/fablefield_down_three
+	name = "The Fablefield Troupe"
+	shared_wave_type = /datum/migrant_wave/fablefield
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/fablefield/goliard = 1,
 	)
 	greet_text = "A troupe of troubadours from fair Fablefield, you travel to Rockhill seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"

--- a/code/datums/migrants/migrant_waves/heartfelt wave.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt wave.dm
@@ -46,9 +46,51 @@
 	name = "The Court of Heartfelt"
 	shared_wave_type = /datum/migrant_wave/heartfelt
 	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_four
 	roles = list(
 		/datum/migrant_role/heartfelt/lord = 1,
 		/datum/migrant_role/heartfelt/lady = 1,
 		/datum/migrant_role/heartfelt/hand = 1,
+	)
+	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+
+/datum/migrant_wave/heartfelt_down_four
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_five
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+		/datum/migrant_role/heartfelt/lady = 1,
+	)
+	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+
+/datum/migrant_wave/heartfelt_down_five
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_six
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+	)
+	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+
+/datum/migrant_wave/heartfelt_down_six
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_seven
+	roles = list(
+		/datum/migrant_role/heartfelt/lady = 1,
+	)
+	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+
+/datum/migrant_wave/heartfelt_down_seven
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/heartfelt/knight = 1,
+		/datum/migrant_role/heartfelt/magos = 1,
 	)
 	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -331,7 +331,7 @@
 	light_color = "#da8c45"
 	on_damage = 10
 	flags_1 = null
-	possible_item_intents = list(/datum/intent/hit, /datum/intent/use)
+	possible_item_intents = list(/datum/intent/use, /datum/intent/hit)
 	slot_flags = ITEM_SLOT_HIP
 	var/datum/looping_sound/torchloop/soundloop
 	max_integrity = 200

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -222,7 +222,7 @@
 		negate_slowdown = TRUE
 
 	if(negate_slowdown)
-		returned = max(returned-2, 0)
+		returned = max(returned-2.5, 0)
 
 	return returned
 

--- a/code/modules/antagonists/roguetown/villain/choosename.dm
+++ b/code/modules/antagonists/roguetown/villain/choosename.dm
@@ -21,7 +21,7 @@
 			else
 				real_name = new_name
 		else
-			to_chat(src, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
+			to_chat(src, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ', . and ,.</font>")
 			return
 	GLOB.chosen_names += real_name
 	if(mind.special_role == "Vampire Lord")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1481,8 +1481,7 @@ Slots: [job.spawn_positions]</span>
 						if(new_name)
 							real_name = new_name
 						else
-							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
-
+							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ', . and ,.</font>")
 //				if("age")
 //					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Years Dead") as num|null
 //					if(new_age)

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -38,13 +38,7 @@
 	heldz_items = 3
 	sewrepair = TRUE
 
-/obj/item/storage/belt/rogue/leather/dropped(mob/living/carbon/human/user)
-	..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	if(STR)
-		var/list/things = STR.contents()
-		for(var/obj/item/I in things)
-			STR.remove_from_storage(I, get_turf(src))
+
 
 /obj/item/storage/belt/rogue/leather/plaquegold
 	name = "plaque belt"

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -38,7 +38,13 @@
 	heldz_items = 3
 	sewrepair = TRUE
 
-
+/*/obj/item/storage/belt/rogue/leather/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src)) */ //this should stop belts from dropping stuff but isnt
 
 /obj/item/storage/belt/rogue/leather/plaquegold
 	name = "plaque belt"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -4,7 +4,6 @@
 	tutorial = "Mages are usually grown-up apprentices of wizards. They are seeking adventure, using their arcyne knowledge to aid or ward off other adventurers."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	maximum_possible_slots = 4
 	outfit = /datum/outfit/job/roguetown/adventurer/mage
 	category_tags = list(CTAG_ADVENTURER)
 

--- a/code/modules/mapping/space_management/multiz_helpers.dm
+++ b/code/modules/mapping/space_management/multiz_helpers.dm
@@ -13,7 +13,7 @@
 	if(my_z == compare_z)
 		return TRUE
 	if(my_z > compare_z)
-		for(var/i in compare_z to my_z)
+		for(var/i in my_z to compare_z)
 			if(!i || i<0)
 				return FALSE
 			if(i == compare_z)

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -200,7 +200,13 @@
 				to_chat(src, span_warning("The enemy defeated my parry!"))
 				return FALSE
 
-			drained = max(drained, 5)		
+			drained = max(drained, 5)
+			var/exp_multi = 1
+
+			if(!U.mind)
+				exp_multi = exp_multi/2
+			if(istype(user.rmb_intent, /datum/rmb_intent/weak))
+				exp_multi = exp_multi/2
 			
 			if(weapon_parry == TRUE)
 				if(do_parry(used_weapon, drained, user)) //show message

--- a/code/modules/power/lanternpost.dm
+++ b/code/modules/power/lanternpost.dm
@@ -41,7 +41,7 @@
 		else
 			return PROCESS_KILL
 
-/obj/machinery/light/rogue/lanternpost/attack_hand(mob/user)
+/*/obj/machinery/light/rogue/lanternpost/attack_hand(mob/user)
 	. = ..()
 	if(.)
 		return
@@ -52,7 +52,7 @@
 		on = FALSE
 		set_light(0)
 		update_icon()
-		playsound(src.loc, 'sound/foley/torchfixturetake.ogg', 100)
+		playsound(src.loc, 'sound/foley/torchfixturetake.ogg', 100) */
 
 /obj/machinery/light/rogue/lanternpost/update_icon()
 	if(torchy)

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -54,12 +54,14 @@
 		reagents.flags = reagent_flags
 		desc = "A bottle with a cork."
 		spillable = FALSE
+		to_chat(usr, span_notice("You put a cork the bottle."))
 	else
 		reagent_flags = OPENCONTAINER
 		reagents.flags = reagent_flags
 		playsound(user.loc,'sound/items/uncork.ogg', 100, TRUE)
 		desc = "An open bottle, hopefully a cork is close by."
 		spillable = TRUE
+		to_chat(usr, span_notice("You've uncorked the bottle."))
 	update_icon()
 
 /obj/item/reagent_containers/glass/bottle/Initialize()

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -439,17 +439,14 @@
 	name = "stone mortar"
 	result = /obj/item/reagent_containers/glass/mortar
 	reqs = list(/obj/item/natural/stone = 1)
-	tools = list(/obj/item/rogueweapon/huntingknife) // Intended to be either stone knife or steel hunting knife
 	craftdiff = 1
-	subtype_reqs = TRUE //Unsure if needed for stone knife to work, feel free to remove this if not.
 
 /datum/crafting_recipe/roguetown/pestle
 	name = "stone pestle"
 	result = /obj/item/pestle
 	reqs = list(/obj/item/natural/stone = 1)
-	tools = list(/obj/item/rogueweapon/huntingknife) // Intended to be either stone knife or steel hunting knife
 	craftdiff = 1
-	subtype_reqs = TRUE //Unsure if needed for stone knife to work, feel free to remove this if not.
+
 
 /datum/crafting_recipe/roguetown/bag
 	name = "bag"

--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -12,7 +12,7 @@
 	var/berry_charges = 0
 	var/atom/movable/inserted
 	var/activecolor = "#FFFFFF"
-	var/list/allowed_types = list(
+	/*var/list/allowed_types = list(
 			/obj/item/clothing/suit/roguetown/shirt/robe,
 			/obj/item/clothing/suit/roguetown/shirt/dress,
 			/obj/item/clothing/suit/roguetown/shirt/undershirt,
@@ -30,6 +30,12 @@
 			/obj/item/clothing/shoes/roguetown/simpleshoes,
 			/obj/item/clothing/suit/roguetown/armor/gambeson
 			)
+*/
+	var/list/allowed_types = list(
+			/obj/item/clothing,
+			/obj/item/storage
+			)
+
 	var/static/list/selectable_colors = list(
   		"White" = "#ffffff",
 		"Black" = "#414143",

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -32,10 +32,10 @@
 
 /obj/effect/proc_holder/spell/targeted/churn
 	name = "Churn Undead"
-	range = 8
+	range = 2
 	overlay_state = "necra"
-	releasedrain = 30
-	charge_max = 30 SECONDS
+	releasedrain = 15
+	charge_max = 15 SECONDS
 	max_targets = 0
 	cast_without_targets = TRUE
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
@@ -44,7 +44,7 @@
 	invocation = "The Undermaiden rebukes!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	miracle = TRUE
-	devotion_cost = 20
+	devotion_cost = 10
 
 /obj/effect/proc_holder/spell/targeted/churn/cast(list/targets,mob/living/user = usr)
 	var/prob2explode = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Nerfed Churn undead range to 2 tiles from person in all directions (previously effected the entire line of sight), reduced cooldown by half and devotion cost by half (15s from 30, 10 devotion from 20.) This encourages vampires to not get close to churchfolk, but isn't a massive aoe. If you're this close to someone who can do this to you, you deserve it.
- Heartfelt Lord can spawn solo, Lady can spawn solo, and Magios/Knight can spawn together, in that order, after the the migration dwindles down. 
- Fablefield can spawn solo
- Reduced Migration Wave timers significantly.
- Added a message for uncorking/corking bottles.
- Disabled removing lanterns from lanternpost.
- Can dye all clothes now. Sigmaport
- Pestle and Mortar do not require knife to craft. Sigmaport
- Half XP from parrying mobs. Sigmaport
- Removed cap on Adventurer Mages for now
- Attempted to remove belts dropping items on take-off/longsleeping but it doesnt work for some reason. Sigma Port
- Torch/Lantern/Etc 's primary action is Use instead of Strike now. Sigma Port
- Fixed Acid City walled off area
- You can now use commas in your name. Example: "Dwayne Johnson, The Rock". Sigma Port
- Removed the delay in movement/attacks from mobs entirely. They're kinda relentless now. Goblins are a little bit more of a considerable threat. Human mobs are almost on par with actual players.

-Added wildplants, canopy, and banners to the map.
-Added 0.5 movement boost to bog_trekking

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
