### PR TITLE
Bog Trekking Potion

### DIFF
--- a/modular_hearthstone/code/datums/status_effects/rogue/hearthbuff.dm
+++ b/modular_hearthstone/code/datums/status_effects/rogue/hearthbuff.dm
@@ -149,3 +149,24 @@
 	if(iscarbon(owner))
 		REMOVE_TRAIT(owner, TRAIT_ANTIMAGIC, TRAIT_GENERIC)
 	return ..()
+
+/datum/status_effect/buff/bogtrekkingbuff
+	id = "virilitybuff"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/bogtrekkingbuff
+	duration = 10 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/bogtrekkingbuff
+	name = "Freedom of Movement"
+	desc = ""
+	icon_state = "virility"
+
+/datum/status_effect/buff/bogtrekkingbuff/on_apply()
+	if(iscarbon(owner))
+		ADD_TRAIT(owner, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
+
+	return ..()
+
+/datum/status_effect/buff/bogtrekkingbuff/on_remove()
+	if(iscarbon(owner))
+		REMOVE_TRAIT(owner, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
+	return ..()

--- a/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -103,6 +103,16 @@
 		/obj/item/reagent_containers/food/snacks/fat = 2)
 	craftdiff = 6
 
+/datum/crafting_recipe/roguetown/alchemy/trekkersdelight
+	name = "Trekker's Delight"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1, 
+		/obj/item/reagent_containers/powder/sublimate = 1, 
+		/obj/item/reagent_containers/powder/salt = 1,
+		/obj/item/natural/dirtclod = 1)
+	craftdiff = 2
+
 /datum/crafting_recipe/roguetown/alchemy/intellectpot
 	name = "Intellect Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/intellectpot)

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -32,7 +32,7 @@
 	list_reagents = list(/datum/reagent/medicine/nullmagicpot = 20)
 
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight
-	list_reagents = list(/datum/reagent/medicine/trekkersdelight = 20)
+	list_reagents = list(/datum/reagent/medicine/trekkersdelight = 40)
 
 /obj/item/reagent_containers/glass/bottle/rogue/virilitypot
 	list_reagents = list(/datum/reagent/medicine/virilitypot = 40)

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -31,5 +31,8 @@
 /obj/item/reagent_containers/glass/bottle/rogue/nullmagicpot
 	list_reagents = list(/datum/reagent/medicine/nullmagicpot = 20)
 
+/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight
+	list_reagents = list(/datum/reagent/medicine/trekkersdelight = 20)
+
 /obj/item/reagent_containers/glass/bottle/rogue/virilitypot
 	list_reagents = list(/datum/reagent/medicine/virilitypot = 40)

--- a/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguejobs/alchemist/reagent.dm
@@ -190,6 +190,26 @@
 		holder.remove_reagent(/datum/reagent/medicine/nullmagicpot, 20)
 	..()
 	. = 1 
+/datum/reagent/medicine/trekkersdelight
+	name = "Trekker's Delight"
+	description = "Makes one immune turf slowdown."
+	reagent_state = LIQUID
+	color = "#463612"
+	taste_description = "salt and murk"
+	overdose_threshold = 16
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM 
+	alpha = 225
+
+/datum/reagent/medicine/trekkersdelight/overdose_process(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_BOG_TREKKING))
+		if(holder.has_reagent(/datum/reagent/medicine/trekkersdelight))
+			holder.remove_reagent(/datum/reagent/medicine/trekkersdelight, 20)
+		return
+	M.apply_status_effect(/datum/status_effect/buff/bogtrekkingbuff)
+	if(holder.has_reagent(/datum/reagent/medicine/trekkersdelight))
+		holder.remove_reagent(/datum/reagent/medicine/trekkersdelight, 20)
+	..()
+	. = 1 
 
 /datum/reagent/medicine/intellectpot
 	name = "Intellect Potion"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Lets you drink mud to move faster on it.
**_Trekker's Delight:_**
1 bottle, 1 arcyne sublimate, 1 salt, 1 dirt clod
Drink half, get 10 minutes of the bog trekking trait from https://github.com/Tree445/Hearthstone/pull/532
Has no effect on people who already have the trait.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More potions!
Also making traits accessible through potions and alchemy is a great idea. Helps level the playing field, if you have prep time.
Also Apple suggested this, so I did it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
