### PR TITLE
[DRAFT] Dragonscale Necklace Removal & Bandit Adjustment

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1067,8 +1067,6 @@
 							I = new /obj/item/clothing/gloves/roguetown/plate(user.loc)
 						if(9)
 							I = new /obj/item/clothing/wrists/roguetown/bracers(user.loc)
-						if(10)
-							I = new /obj/item/clothing/neck/roguetown/blkknight(user.loc)
 					if(I)
 						I.sellprice = 0
 					playsound(loc,'sound/items/carvgood.ogg', 50, TRUE)

--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -120,50 +120,34 @@
 	else
 		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 		armor = /obj/item/clothing/suit/roguetown/armor/leather
-	var/loadoutm = rand(1,16)
+	var/loadoutm = rand(1,14)
 	switch(loadoutm)
-		if(1 to 3) // sword bandit
+		if(1 to 7) // sword bandit
 			beltr = /obj/item/rogueweapon/sword/iron
 			if(prob(40))
 				backl = /obj/item/rogueweapon/shield/wood
 			H.change_stat("endurance", 1)
-		if(4 to 6) // knife bandit - dodge maxing
+		if(8 to 9) // knife bandit - dodge maxing
 			beltr = /obj/item/rogueweapon/huntingknife/cleaver
 			H.change_stat("speed", 3)
 			H.change_stat("strength", -2)
-		if(7 to 9) // flail bandit small chance to two handed flail
+		if(10 to 11) // flail bandit small chance to two handed flail
 			if(prob(80))
 				beltr = /obj/item/rogueweapon/flail
 				backl = /obj/item/rogueweapon/shield/wood
 			else
 				r_hand = /obj/item/rogueweapon/flail/peasantwarflail
 			H.change_stat("strength", 1)
-		if(10 to 12) // ranged bandit
+		if(11 to 12) // ranged bandit
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
 			beltl = /obj/item/quiver/arrows
 			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
 			H.change_stat("perception", 3)
-		if(13 to 15) // spear bandit
+		if(13 to 14) // spear bandit
 			r_hand = /obj/item/rogueweapon/spear
 			if(prob(40))
 				backl = /obj/item/rogueweapon/shield/wood
 			H.change_stat("endurance", 1)
-		if(16) // hedge knight - give challenge to knights/templars ~6% chance 15-20 bandits roundstart average 1 hedge knight - lacks protection to hands or feet
-			r_hand = /obj/item/rogueweapon/greatsword/zwei
-			beltr = /obj/item/rogueweapon/sword
-			beltl = /obj/item/flashlight/flare/torch/lantern
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/full
-			gloves = /obj/item/clothing/gloves/roguetown/leather
-			head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface
-			if(prob(30))
-				neck = /obj/item/clothing/neck/roguetown/bervor
-			else
-				neck = /obj/item/clothing/neck/roguetown/gorget
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, rand(1,2), TRUE) // either expert or master skill - knights start with master and templars expert sword skill
-			H.change_stat("strength", 1)
-			H.change_stat("constitution", 1)
-			H.change_stat("speed", -2)
-			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	H.change_stat("strength", 3)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 1)

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -929,7 +929,7 @@
 	icon = 'icons/roguetown/clothing/special/blkknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/blkknight.dmi'
 	sleeved = 'icons/roguetown/clothing/special/onmob/blkknight.dmi'
-
+/*
 /obj/item/clothing/neck/roguetown/blkknight
 	name = "dragonscale necklace"
 	desc = ""
@@ -979,7 +979,7 @@
 	else
 		to_chat(user, span_notice("Strange, I don't feel that power anymore.."))
 		armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
-
+*/
 /obj/item/clothing/suit/roguetown/armor/plate/blkknight
 	slot_flags = ITEM_SLOT_ARMOR
 	name = "blacksteel plate"


### PR DESCRIPTION
## About The Pull Request

After a request that has been long asked for, I deliver. Bandit at its core is a short lived antagonist role, They are supposed to be a Brotherhood but by making a bandit all about the gear and extremely overpowered gear (that stacks ontop of a statpack) you have the capacity to completely powergame as seen with bandits with a d-ring, dragonscale cloak and so on and so forth. 

## Why It's Good For The Game

To put it simply, bandit being powercrept is not healthy for the server because the townies need to be compensated, in turn causing an arms race. This is not okay and healthy for the server. Along with this, Bandit is supposed to be a thing you play with friends hence the whole Brotherhood aspect of it, they absolutely should not be super soldiers.