### PR TITLE
Craftable Dirt Turf

### DIFF
--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -237,6 +237,8 @@
 /datum/crafting_recipe/roguetown/turfs/dirt/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
+	if(istype(T, /turf/open/floor/rogue/grass))
+		return
 	if(!istype(T, /turf/open/floor/rogue))
 		if(!istype(T, /turf/open/transparent/openspace))
 			if(!istype(T, /turf/open/water))

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -224,6 +224,25 @@
 				return
 	return TRUE
 
+/datum/crafting_recipe/roguetown/turfs/dirt
+	name = "dirt floor"
+	result = /turf/open/floor/rogue/dirt/road
+	reqs = list(/obj/item/natural/dirtclod = 4)
+	skillcraft = /datum/skill/craft/crafting
+	verbage_simple = "spread"
+	verbage = "spreads"
+	tools = list(/obj/item/rogueweapon/shovel)
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/turfs/dirt/TurfCheck(mob/user, turf/T)
+	if(isclosedturf(T))
+		return
+	if(!istype(T, /turf/open/floor/rogue))
+		if(!istype(T, /turf/open/transparent/openspace))
+			if(!istype(T, /turf/open/water))
+				return
+	return TRUE
+
 /datum/crafting_recipe/roguetown/turfs/tentwall
 	name = "tent wall"
 	result = /turf/closed/wall/mineral/rogue/tent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a crafting recipe for dirt turfs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets people make their own farmable areas in otherwise unfarmable locations, assuming they go through the tedium of digging up soil.
Can also potentially allow for an early form of removing undesired turfs, like unreasonable floating bridges for example, by means of digging up the resulting dirt until its gone. Can give more limitations to the crafting once a proper means of tearing up existing tiles is added.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
