### PR TITLE
Opens up the Court Magician to all the Patrons (for real this time)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -21,7 +21,6 @@
 	max_pq = null
 
 /datum/outfit/job/roguetown/magician
-	allowed_patrons = list(/datum/patron/divine/noc)
 
 /datum/outfit/job/roguetown/magician/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Institutes the First Amendment to Court Magicians, allowing them to pick different patrons. There was an expansion of them a while ago that made it to where they gained different skills and abilities for having different patrons.. but the patron lock of Noc was never removed so it is not able to be utilized, this simply removes the lock.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows Magicians to be things other than Noc Worshipers.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
