### PR TITLE
PROSPERO - Spellcrafting Machine

### DIFF
--- a/code/controllers/subsystem/rogue/library.dm
+++ b/code/controllers/subsystem/rogue/library.dm
@@ -1,0 +1,79 @@
+
+SUBSYSTEM_DEF(library)
+	name = "library"
+	wait = 1
+	priority = FIRE_PRIORITY_WATER_LEVEL
+	var/library_value = 0
+	var/list/stockpile_datums = list()
+	var/multiple_item_penalty = 0.66
+	var/next_library_check = 0
+
+/datum/controller/subsystem/library/Initialize()
+	library_value = rand(800,1500)
+	for(var/path in subtypesof(/datum/roguestock/bounty))
+		var/datum/D = new path
+		stockpile_datums += D
+	for(var/path in subtypesof(/datum/roguestock/stockpile))
+		var/datum/D = new path
+		stockpile_datums += D
+	for(var/path in subtypesof(/datum/roguestock/import))
+		var/datum/D = new path
+		stockpile_datums += D
+	return ..()
+
+/datum/controller/subsystem/library/fire(resumed = 0)
+	if(world.time > next_library_check)
+		next_library_check = world.time + rand(5 MINUTES, 8 MINUTES)
+		var/list/stockpile_items = list()
+
+		if(SSticker.current_state == GAME_STATE_PLAYING)
+
+		//wtf is this?
+			for(var/datum/roguestock/X in stockpile_datums)
+				if(!X.stable_price && !X.transport_item)
+					if(X.demand < initial(X.demand))
+						X.demand += rand(5,15)
+					if(X.demand > initial(X.demand))
+						X.demand -= rand(5,15)
+
+		var/area/A = GLOB.areas_by_type[/area/rogue/indoors/town/library]
+		var/amt_to_generate = 0
+
+		for(var/obj/item/I in A)
+			if(!isturf(I.loc))
+				continue
+			if(I.get_real_price() <= 0 || !istype(I, /obj/item/book/granter/spell))
+				continue
+			if(!I.submitted_to_stockpile)
+				I.submitted_to_stockpile = TRUE
+			if(I.type in stockpile_items)
+				stockpile_items[I.type] *= multiple_item_penalty
+			else
+				stockpile_items[I.type] = I.get_real_price()
+
+			amt_to_generate += (stockpile_items[I.type])
+
+		amt_to_generate = round(amt_to_generate)
+
+		//increase ink
+		give_ink_library(amt_to_generate, "library")
+
+		//inform the tower staff
+		var/people_told = 0
+		for(var/mob/living/carbon/human/X in GLOB.human_list)
+			switch(X.job)
+				if("Court Magician", "Magicians Apprentice")
+					people_told += 1
+					send_ooc_note("Arcyne ink from library: +[amt_to_generate]", name = X.real_name)
+					if(people_told > 3)
+						return
+
+/datum/controller/subsystem/library/proc/give_ink_library(amt, source)
+	if(!amt)
+		return
+	library_value += amt
+
+/datum/controller/subsystem/library/proc/remove_ink_library(amt, source)
+	if(!amt)
+		return
+	library_value -= amt

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -595,6 +595,13 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 /area/rogue/indoors/town/vault/can_craft_here()
 	return FALSE
 
+/area/rogue/indoors/town/library
+	name = "library"
+	icon_state = "vault"
+
+/area/rogue/indoors/town/library/can_craft_here()
+	return FALSE
+
 /area/rogue/indoors/town/entrance
 	first_time_text = "Roguetown"
 	icon_state = "entrance"

--- a/code/modules/cargo/packsrogue/wizardvend/basics.dm
+++ b/code/modules/cargo/packsrogue/wizardvend/basics.dm
@@ -1,0 +1,12 @@
+
+/datum/supply_pack/rogue/basics
+	group = "Basic Spells"
+	crate_name = "mages guild's crate"
+	crate_type = /obj/structure/closet/crate/chest/merchant
+
+/datum/supply_pack/rogue/basics/fetcg
+	name = "Fetch"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/blackstone/fetch
+				)

--- a/code/modules/cargo/packsrogue/wizardvend/cantrips.dm
+++ b/code/modules/cargo/packsrogue/wizardvend/cantrips.dm
@@ -1,0 +1,151 @@
+
+/datum/supply_pack/rogue/cantrips
+	group = "Level 1 Spells"
+	crate_name = "mages guild's crate"
+	crate_type = /obj/structure/closet/crate/chest/merchant
+
+/datum/supply_pack/rogue/cantrips/acidsplash5e
+	name = "Acid Splash"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/acidsplash5e
+				)
+/datum/supply_pack/rogue/cantrips/bladeward5e
+	name = "Blade Ward"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/bladeward5e
+				)
+/datum/supply_pack/rogue/cantrips/boomingblade5e
+	name = "Booming Blade"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/boomingblade5e
+				)
+/datum/supply_pack/rogue/cantrips/createbonfire5e
+	name = "Create Bonfire"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/createbonfire5e
+				)
+/datum/supply_pack/rogue/cantrips/chilltouch5e
+	name = "Chill Touch"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/chilltouch5e
+				)
+/datum/supply_pack/rogue/cantrips/decompose5e
+	name = "Decompose"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/decompose5e
+				)
+/datum/supply_pack/rogue/cantrips/eldritchblast5e
+	name = "Eldtritch Blast"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/eldritchblast5e
+				)
+/datum/supply_pack/rogue/cantrips/encodethoughts5e
+	name = "Encode Thoughts"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/encodethoughts5e
+				)
+/datum/supply_pack/rogue/cantrips/firebolt5e
+	name = "Fire Bolt"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/firebolt5e
+				)
+/datum/supply_pack/rogue/cantrips/frostbite5e
+	name = "Frostbite"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/frostbite5e
+				)
+/datum/supply_pack/rogue/cantrips/greenflameblade5e
+	name = "Green-Flame Blade"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/greenflameblade5e
+				)
+/datum/supply_pack/rogue/cantrips/guidance5e
+	name = "Guidance"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/guidance5e
+				)
+/datum/supply_pack/rogue/cantrips/infestation5e
+	name = "Infestation"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/infestation5e
+				)
+/datum/supply_pack/rogue/cantrips/light5e
+	name = "Light"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/light5e
+				)
+/datum/supply_pack/rogue/cantrips/lightninglure5e
+	name = "Lightning Lure"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/lightninglure5e
+				)
+/datum/supply_pack/rogue/cantrips/magicstone5e
+	name = "Magic Stone"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/magicstone5e
+				)
+/datum/supply_pack/rogue/cantrips/mending5e
+	name = "Mending"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/mending5e
+				)
+/datum/supply_pack/rogue/cantrips/mindsliver5e
+	name = "Mind Sliver"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/mindsliver5e
+				)
+/datum/supply_pack/rogue/cantrips/poisonspray5e
+	name = "Poison Spray"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/poisonspray5e
+				)
+/datum/supply_pack/rogue/cantrips/primalsavagery5e
+	name = "Primal Savagery"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/primalsavagery5e
+				)
+/datum/supply_pack/rogue/cantrips/rayoffrost5e
+	name = "Ray of Frost"
+	cost = 30
+	contains = list(
+					/obj/item/book/granter/spell/spells5e/rayoffrost5e
+				)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/code/modules/cargo/packsrogue/wizardvend/cantrips.dm
+++ b/code/modules/cargo/packsrogue/wizardvend/cantrips.dm
@@ -1,132 +1,132 @@
 
 /datum/supply_pack/rogue/cantrips
-	group = "Level 1 Spells"
+	group = "Cantrips"
 	crate_name = "mages guild's crate"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 /datum/supply_pack/rogue/cantrips/acidsplash5e
 	name = "Acid Splash"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/acidsplash5e
 				)
 /datum/supply_pack/rogue/cantrips/bladeward5e
 	name = "Blade Ward"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/bladeward5e
 				)
 /datum/supply_pack/rogue/cantrips/boomingblade5e
 	name = "Booming Blade"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/boomingblade5e
 				)
 /datum/supply_pack/rogue/cantrips/createbonfire5e
 	name = "Create Bonfire"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/createbonfire5e
 				)
 /datum/supply_pack/rogue/cantrips/chilltouch5e
 	name = "Chill Touch"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/chilltouch5e
 				)
 /datum/supply_pack/rogue/cantrips/decompose5e
 	name = "Decompose"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/decompose5e
 				)
 /datum/supply_pack/rogue/cantrips/eldritchblast5e
 	name = "Eldtritch Blast"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/eldritchblast5e
 				)
 /datum/supply_pack/rogue/cantrips/encodethoughts5e
 	name = "Encode Thoughts"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/encodethoughts5e
 				)
 /datum/supply_pack/rogue/cantrips/firebolt5e
 	name = "Fire Bolt"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/firebolt5e
 				)
 /datum/supply_pack/rogue/cantrips/frostbite5e
 	name = "Frostbite"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/frostbite5e
 				)
 /datum/supply_pack/rogue/cantrips/greenflameblade5e
 	name = "Green-Flame Blade"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/greenflameblade5e
 				)
 /datum/supply_pack/rogue/cantrips/guidance5e
 	name = "Guidance"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/guidance5e
 				)
 /datum/supply_pack/rogue/cantrips/infestation5e
 	name = "Infestation"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/infestation5e
 				)
 /datum/supply_pack/rogue/cantrips/light5e
 	name = "Light"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/light5e
 				)
 /datum/supply_pack/rogue/cantrips/lightninglure5e
 	name = "Lightning Lure"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/lightninglure5e
 				)
 /datum/supply_pack/rogue/cantrips/magicstone5e
 	name = "Magic Stone"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/magicstone5e
 				)
 /datum/supply_pack/rogue/cantrips/mending5e
 	name = "Mending"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/mending5e
 				)
 /datum/supply_pack/rogue/cantrips/mindsliver5e
 	name = "Mind Sliver"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/mindsliver5e
 				)
 /datum/supply_pack/rogue/cantrips/poisonspray5e
 	name = "Poison Spray"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/poisonspray5e
 				)
 /datum/supply_pack/rogue/cantrips/primalsavagery5e
 	name = "Primal Savagery"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/primalsavagery5e
 				)
 /datum/supply_pack/rogue/cantrips/rayoffrost5e
 	name = "Ray of Frost"
-	cost = 30
+	cost = 75
 	contains = list(
 					/obj/item/book/granter/spell/spells5e/rayoffrost5e
 				)

--- a/code/modules/roguetown/roguemachine/wizard.dm
+++ b/code/modules/roguetown/roguemachine/wizard.dm
@@ -1,0 +1,292 @@
+#define UPGRADE_CANTRIPS		(1<<0)
+#define UPGRADE_LEVEL_ONE		(1<<1)
+#define UPGRADE_LEVEL_TWO		(1<<2)
+#define UPGRADE_LEVEL_THREE		(1<<3)
+#define UPGRADE_PASSIVE_INK		(1<<4)
+#define UPGRADE_ARTIFACTS		(1<<5)
+
+/obj/structure/roguemachine/wizardvend
+	name = "PROSPERO"
+	desc = "A mage exiled, his magic gleams, warping mind spirits, weaving dreams."
+	icon = 'icons/roguetown/misc/machines.dmi'
+	icon_state = "streetvendor1"
+	density = TRUE
+	blade_dulling = DULLING_BASH
+	max_integrity = 0
+	anchored = TRUE
+	layer = BELOW_OBJ_LAYER
+	var/list/held_items = list()
+	var/locked = FALSE
+	var/budget = 1000
+	var/upgrade_flags
+	var/current_cat = "1"
+
+/obj/structure/roguemachine/wizardvend/Initialize()
+	. = ..()
+	update_icon()
+
+/obj/structure/roguemachine/wizardvend/update_icon()
+	cut_overlays()
+	if(obj_broken)
+		set_light(0)
+		return
+	set_light(1, 1, "#1b7bf1")
+	add_overlay(mutable_appearance(icon, "vendor-merch"))
+
+
+/obj/structure/roguemachine/wizardvend/attackby(obj/item/P, mob/user, params)
+	if(istype(P, /obj/item/roguekey))
+		var/obj/item/roguekey/K = P
+		if(K.lockid == "mage")
+			locked = !locked
+			playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+			update_icon()
+			return attack_hand(user)
+		else
+			to_chat(user, span_warning("Wrong key."))
+			return
+	if(istype(P, /obj/item/storage/keyring))
+		var/obj/item/storage/keyring/K = P
+		for(var/obj/item/roguekey/KE in K.keys)
+			if(KE.lockid == "mage")
+				locked = !locked
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+				update_icon()
+				return attack_hand(user)
+	if(istype(P, /obj/item/reagent_containers/glass/bottle))
+		var/obj/item/reagent_containers/con = P
+		var/datum/reagents/R = con.reagents
+		var/mana = R.get_reagent_amount(/datum/reagent/medicine/manapot)
+		if(mana > 0)
+			to_chat(user, span_notice("Added [mana] arcyne ink."))
+			budget += mana
+			qdel(P)
+			update_icon()
+			playsound(loc, 'sound/misc/machinevomit.ogg', 100, TRUE, -1)
+			return attack_hand(user)
+		else
+			to_chat(user, span_warning("No mana detected."))
+	..()
+
+/obj/structure/roguemachine/wizardvend/Topic(href, href_list)
+	. = ..()
+	if(!ishuman(usr))
+		return
+	if(!usr.canUseTopic(src, BE_CLOSE) || locked)
+		return
+	if(href_list["buy"])
+		var/mob/M = usr
+		var/path = text2path(href_list["buy"])
+		if(!ispath(path, /datum/supply_pack))
+			message_admins("RETARDED MOTHERFUCKER [usr.key] IS TRYING TO BUY A [path] WITH THE PROSPERO")
+			return
+		var/datum/supply_pack/PA = new path
+		var/cost = PA.cost
+
+		if(budget >= cost)
+			budget -= cost
+		else
+			say("Not enough ink!")
+			return
+
+		var/shoplength = PA.contains.len
+		var/l
+
+		for(l=1,l<=shoplength,l++)
+			var/pathi = pick(PA.contains)
+			var/obj/item/I = new pathi(get_turf(src))
+			M.put_in_hands(I)
+		//qdel(PA)
+		
+	if(href_list["change"])
+		if(budget > 0)
+			budget2change(budget, usr)
+			budget = 0
+	if(href_list["changecat"])
+		current_cat = href_list["changecat"]
+	if(href_list["secrets"])
+		var/list/options = list()
+		if(!(upgrade_flags & UPGRADE_CANTRIPS))
+			options += "Learn Cantrips (50)"
+		if(!(upgrade_flags & UPGRADE_LEVEL_ONE))
+			options += "Learn level 1 Spells (100)"
+		if(!(upgrade_flags & UPGRADE_LEVEL_TWO))
+			options += "Learn level 2 Spells (200)"
+		if(!(upgrade_flags & UPGRADE_LEVEL_THREE))
+			options += "Learn level 3 Spells (400)"	
+		if(!(upgrade_flags & UPGRADE_PASSIVE_INK))
+			options += "Upgrade Passive Ink Supply (800)"
+		if(!(upgrade_flags & UPGRADE_ARTIFACTS))
+			options += "Unlock Artifacts (1200)"
+		var/select = input(usr, "Please select an option.", "", null) as null|anything in options
+		if(!select)
+			return
+		if(!usr.canUseTopic(src, BE_CLOSE) || locked)
+			return
+		switch(select)
+
+			if("Learn Cantrips (50)")
+				if(upgrade_flags & UPGRADE_LEVEL_ONE)
+					return
+				if(budget < 50)
+					say(wizard_vend_negative())
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 50
+				upgrade_flags |= UPGRADE_LEVEL_ONE
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+
+			if("Learn Level 1 Spells (100)")
+				if(upgrade_flags & UPGRADE_LEVEL_ONE)
+					return
+				if(budget < 100)
+					say(wizard_vend_negative())
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 100
+				upgrade_flags |= UPGRADE_LEVEL_ONE
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+
+			if("Learn Level 2 Spells (200)")
+				if(upgrade_flags & UPGRADE_LEVEL_TWO)
+					return
+				if(budget < 200)
+					say(wizard_vend_negative())
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 200
+				upgrade_flags |= UPGRADE_LEVEL_TWO
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+
+			if("Learn Level 3 Spells (400)")
+				if(upgrade_flags & UPGRADE_LEVEL_THREE)
+					return
+				if(budget < 400)
+					say(wizard_vend_negative())
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 400
+				upgrade_flags |= UPGRADE_LEVEL_THREE
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+
+			if("Upgrade Passive Ink Supply (800)")
+				if(upgrade_flags & UPGRADE_PASSIVE_INK)
+					return
+				if(budget < 800)
+					say(wizard_vend_negative())
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 800
+				upgrade_flags |= UPGRADE_PASSIVE_INK
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+
+			if("Unlock Artifacts (1200)")
+				if(upgrade_flags & UPGRADE_ARTIFACTS)
+					return
+				if(budget < 1200)
+					say(wizard_vend_negative())
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 1200
+				upgrade_flags |= UPGRADE_ARTIFACTS
+				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+
+	return attack_hand(usr)
+
+/obj/structure/roguemachine/wizardvend/attack_hand(mob/living/user)
+	. = ..()
+	if(.)
+		return
+	if(!ishuman(user))
+		return
+	if(locked)
+		to_chat(user, span_warning("It's locked. Of course."))
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+	var/canread = user.can_read(src, TRUE)
+	var/contents
+	contents = "<center>PROSPERO - Arcane arts, infinite power.<BR>"
+	contents += "MANA INK: [budget]<BR>"
+
+	var/mob/living/carbon/human/H = user
+	if(H.job == "Court Magician" || "Magicians Apprentice")
+		if(canread)
+			contents += "<a href='?src=[REF(src)];secrets=1'>Secrets</a>"
+		else
+			contents += "<a href='?src=[REF(src)];secrets=1'>[stars("Secrets")]</a>"
+
+	contents += "</center><BR>"
+
+	var/list/unlocked_cats = list("Basic Spells")
+	if(upgrade_flags & UPGRADE_CANTRIPS)
+		unlocked_cats+="Cantrips"
+	if(upgrade_flags & UPGRADE_LEVEL_ONE)
+		unlocked_cats+="Level 1 Spells"
+	if(upgrade_flags & UPGRADE_LEVEL_TWO)
+		unlocked_cats+="Level 2 Spells"
+	if(upgrade_flags & UPGRADE_LEVEL_THREE)
+		unlocked_cats+="Level 3 Spells"
+
+	if(current_cat == "1")
+		contents += "<center>"
+		for(var/X in unlocked_cats)
+			contents += "<a href='?src=[REF(src)];changecat=[X]'>[X]</a><BR>"
+		contents += "</center>"
+	else
+		contents += "<center>[current_cat]<BR></center>"
+		contents += "<center><a href='?src=[REF(src)];changecat=1'>\[RETURN\]</a><BR><BR></center>"
+		var/list/pax = list()
+		for(var/pack in SSshuttle.supply_packs)
+			var/datum/supply_pack/PA = SSshuttle.supply_packs[pack]
+			if(PA.group == current_cat)
+				pax += PA
+		for(var/datum/supply_pack/PA in sortList(pax))
+			var/costy = PA.cost
+			contents += "[PA.name] [PA.contains.len > 1?"x[PA.contains.len]":""] - ([costy])<a href='?src=[REF(src)];buy=[PA.type]'>BUY</a><BR>"
+
+	if(!canread)
+		contents = stars(contents)
+
+	var/datum/browser/popup = new(user, "VENDORTHING", "", 370, 600)
+	popup.set_content(contents)
+	popup.open()
+
+/obj/structure/roguemachine/wizardvend/obj_break(damage_flag)
+	..()
+	budget2change(budget)
+	set_light(0)
+	update_icon()
+	icon_state = "goldvendor0"
+
+/obj/structure/roguemachine/wizardvend/Destroy()
+	set_light(0)
+	return ..()
+
+/obj/structure/roguemachine/wizardvend/Initialize()
+	. = ..()
+	update_icon()
+
+proc/wizard_vend_negative()
+	var/list/wizard_vend_negative = list(
+		//normal
+		"A shortage of inky sustenance has hindered my arcyne endeavors.",
+		"The arcyne forces have conspired against my ink supply, a most unfortunate twist of fate.",
+		"This is a arcyne emergency, and I require a swift replenishment of my ink supply.",
+		"My inkwell seems to be protesting my excessive spell-crafting.",
+		"The arcane currents have dried up my inkwell, a most peculiar occurrence.",
+		"A dearth of inky schmutz has befallen my arcyne pursuits.",
+		"This option is a masterpiece, yet it lacks the vital elixir of arcane ink.",
+		"A peculiar malaise has afflicted my arcyne inkwell, a most vexing affliction.",
+		"A lack of inky schmutz has caused my arcyne well to run dry.",
+		"The inky schmutz that fuels my spells is dwindling.",
+		"Noc says no.",
+
+		//sus
+		"I want inkies~",
+		"I wish to imbibe thy ink first.",
+		"Fill my inkwell with thy inky schmutz!",
+		"Plunge a girthy mana potion deep into my crevice that I may complete thy request.",
+		"Fill me up with thine ink~",
+		"My inkwell is as parched as a desert wanderer. Fill me up.")
+	return pick(wizard_vend_negative)

--- a/code/modules/spells/roguetown/spells5e/spellscrolls.dm
+++ b/code/modules/spells/roguetown/spells5e/spellscrolls.dm
@@ -5,6 +5,7 @@
 	drop_sound = 'sound/foley/dropsound/paper_drop.ogg'
 	pickup_sound =  'sound/blank.ogg'
 	remarks = list("Fascinating!", "Is that so...", "Like this?", "Really now...", "There's a little schmutz on this section...")
+	sellprice = 30
 
 /obj/item/book/granter/spell/spells5e/onlearned(mob/living/carbon/user)
 	..()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -8,7 +8,6 @@
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\roguetest.dm"
 #include "_maps\templates\bog_shack_small.dm"
 #include "_maps\templates\sewers.dm"
 #include "_maps\templates\smalldungeons.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -8,6 +8,7 @@
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "_maps\roguetest.dm"
 #include "_maps\templates\bog_shack_small.dm"
 #include "_maps\templates\sewers.dm"
 #include "_maps\templates\smalldungeons.dm"
@@ -356,6 +357,7 @@
 #include "code\controllers\subsystem\rogue\damoverlays.dm"
 #include "code\controllers\subsystem\rogue\devotion.dm"
 #include "code\controllers\subsystem\rogue\humannpc.dm"
+#include "code\controllers\subsystem\rogue\library.dm"
 #include "code\controllers\subsystem\rogue\pollutants.dm"
 #include "code\controllers\subsystem\rogue\roguemachine.dm"
 #include "code\controllers\subsystem\rogue\roguerot.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -8,6 +8,7 @@
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "_maps\roguetest.dm"
 #include "_maps\templates\bog_shack_small.dm"
 #include "_maps\templates\sewers.dm"
 #include "_maps\templates\smalldungeons.dm"
@@ -1865,6 +1866,8 @@
 #include "code\modules\cargo\packsrogue\tools.dm"
 #include "code\modules\cargo\packsrogue\wardrobe.dm"
 #include "code\modules\cargo\packsrogue\weapons.dm"
+#include "code\modules\cargo\packsrogue\wizardvend\basics.dm"
+#include "code\modules\cargo\packsrogue\wizardvend\cantrips.dm"
 #include "code\modules\chatter\chatter.dm"
 #include "code\modules\client\asset_cache.dm"
 #include "code\modules\client\assets_rogue.dm"
@@ -3318,6 +3321,7 @@
 #include "code\modules\roguetown\roguemachine\titan.dm"
 #include "code\modules\roguetown\roguemachine\vendor.dm"
 #include "code\modules\roguetown\roguemachine\withdraw.dm"
+#include "code\modules\roguetown\roguemachine\wizard.dm"
 #include "code\modules\roguetown\roguestock\_roguestock.dm"
 #include "code\modules\roguetown\roguestock\bounties.dm"
 #include "code\modules\roguetown\roguestock\import.dm"


### PR DESCRIPTION
## About The Pull Request
**MERCHANT STALL SPELL SCROLLS BEGONE!**
Adds a machine that takes mana potions and uses it to print scrolls and unlock new levels of spells.
Adds a library subsystem similar to the vault where the more scrolls you have in the tower library, the more ink you gain passively over time to make more magic crap. This means, don't immediately give out fucking spells to each person who asks for them and power game.

## Why It's Good For The Game
Stop the merchant from being the magic supplier in town
Court mages responsible for giving magical scrolls and protecting their library plus increasing the library supply.

## To Do
-Remove level 1, 2 and 3 from the machine until there are level 1 2 and 3 spells or just make more spells...