### PR TITLE
Chainmail fits in Shirt slot again

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -55,7 +55,7 @@
 		return
 
 /obj/item/clothing/suit/roguetown/armor/chainmail
-	slot_flags = ITEM_SLOT_ARMOR
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	name = "haubergeon"
 	desc = "A steel maille shirt."
 	body_parts_covered = CHEST|GROIN|VITALS|ARMS
@@ -78,8 +78,8 @@
 													'sound/foley/footsteps/armor/chain (3).ogg'), 100)
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-	slot_flags = ITEM_SLOT_ARMOR
-	name = "chainmaille"
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
+	name = "iron chainmail"
 	desc = "A chain vest made of heavy iron rings."
 	body_parts_covered = CHEST|GROIN|VITALS
 	icon_state = "ichainmail"
@@ -89,7 +89,7 @@
 	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
-	slot_flags = ITEM_SLOT_ARMOR
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	name = "hauberk"
 	desc = "A longer steel maille that protects the legs."
 	body_parts_covered = CHEST|GROIN|VITALS|ARMS|LEGS
@@ -100,10 +100,10 @@
 	smeltresult = /obj/item/ingot/steel
 	do_sound = TRUE
 	max_integrity = 350
-	armor_class = ARMOR_CLASS_MEDIUM
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/bikini
-	slot_flags = ITEM_SLOT_ARMOR
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	name = "chainmail bikini"
 	desc = "Not very comfortable against the skin."
 	body_parts_covered = CHEST|GROIN|VITALS


### PR DESCRIPTION
Reverted change so that the chainmail items fit in the shirt slot again. Also made hauberk light armor instead of medium.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Reverts chainmail items back to fitting in both armor and shirt slots.
Also makes hauberk light armor, and renames "chainmaille" to "iron chainmail".

## Why It's Good For The Game

People liked wearing chainmail under their robes and other items for non-visible defense. Might make a different item explicitly for that purpose later but for now, this is more of a hotfix.