### PR TITLE
Hidden doors update

### DIFF
--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -459,7 +459,7 @@
 			qdel(src)
 	if(istype(K, /obj/structure/mineral_door))
 		var/obj/structure/mineral_door/KE = K
-		if(K.can_add_lock)
+		if(KE.can_add_lock)
 			if(KE.keylock == TRUE)
 				to_chat(user, span_warning("[K] already has a lock."))
 			else

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -459,14 +459,17 @@
 			qdel(src)
 	if(istype(K, /obj/structure/mineral_door))
 		var/obj/structure/mineral_door/KE = K
-		if(KE.keylock == TRUE)
-			to_chat(user, span_warning("[K] already has a lock."))
+		if(K.can_add_lock)
+			if(KE.keylock == TRUE)
+				to_chat(user, span_warning("[K] already has a lock."))
+			else
+				KE.keylock = TRUE
+				KE.lockhash = src.lockhash
+				KE.lock_strength = 100
+				if(src.holdname)
+					KE.name = src.holdname
+				to_chat(user, span_notice("You add [src] to [K]."))
+				qdel(src)
 		else
-			KE.keylock = TRUE
-			KE.lockhash = src.lockhash
-			KE.lock_strength = 100
-			if(src.holdname)
-				KE.name = src.holdname
-			to_chat(user, span_notice("You add [src] to [K]."))
-			qdel(src)
+			to_chat(user, span_warning("A lock can't be added to [K]."))
 			

--- a/code/game/objects/structures/hidden_doors.dm
+++ b/code/game/objects/structures/hidden_doors.dm
@@ -17,30 +17,44 @@
 	break_sound = 'sound/combat/hits/onwood/destroywalldoor.ogg'
 	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 	flags_1 = HEAR_1
+
+	can_add_lock = FALSE
+	
 	var/over_state = "woodover"
 
 	var/speaking_distance = 2
 	var/open_phrase = "open sesame"
 	var/close_phrase = "close sesame"
-	var/language = null
+	var/lang = /datum/language/common
 	var/list/vip
+	var/vipmessage
+	var/defenses = FALSE
 
 /obj/structure/mineral_door/secret/vault
 	vip = list("King", "Queen", "Steward", "Hand")
+	vipmessage = "King, Queen, Steward and Hand"
 
 /obj/structure/mineral_door/secret/keep
 	vip = list("King", "Queen", "Royal Heir", "Hand")
+	vipmessage = "King, Queen, Royal Heir and Hand"
 
 /obj/structure/mineral_door/secret/merchant
 	vip = list("Merchant", "Shop Hand")
+	vipmessage = "Merchant and Shop Hand"
 
 /obj/structure/mineral_door/secret/wizard //for wizard tower
 	vip = list("Court Magician", "Magicians Apprentice", "Archivist")
+	vipmessage = "Court Magician, Magicians Apprentice and Archivist"
 	//make me look like an arcane door
+	//icon = 'icons/turf/walls/stonebrick.dmi'
+	//icon_state = "stonebrick" //change me
 
 /obj/structure/mineral_door/secret/rogue //for seedy sewer bar / black market?
 	vip = list("Vagabond", "Thug", "Rogue", "Nightmaster", "Nightmistress", "Beggar")
-	//make me look like a wall
+	vipmessage = "Vagabond, Thug, Rogue, Nightmaster, Nightmistress and Beggar"
+	lang = /datum/language/thievescant
+	icon = 'icons/turf/walls/stonebrick.dmi'
+	icon_state = "stonebrick"
 
 /obj/structure/mineral_door/secret/Initialize()
 	//set password
@@ -61,44 +75,101 @@
 		return
 	
 	var/message2recognize = sanitize_hear_message(original_message)
+	var/isvip = FALSE
+	if (vip.Find(H.job) || vip.Find(H.get_role_title()))
+		isvip = TRUE
+
+	if(findtext(message2recognize, "help"))
+		say("My commands are: 'help', 'say phrases', 'set open', 'set close', 'set language', 'set defenses'. My masters are: [vipmessage]", )
+
+	if(findtext(message2recognize, "say phrases"))
+		if(isvip)
+			say("Open: '[open_phrase]', Close: '[close_phrase]'.", language = lang)
+		else
+			say("I don't know you, "+flavor_name()+".", language = lang)
+			triggerdefenses(H, defenses)
 
 	if(findtext(message2recognize, open_phrase))
 		if(locked)
 			locked = FALSE
 			force_open()
-			say("The way is now open, "+flavor_name()+".")
+			say("The way is now open, "+flavor_name()+".", language = lang)
 
 	if(findtext(message2recognize, close_phrase))
 		if(!locked)
 			force_closed()
 			locked = TRUE
-			say("The way is now closed, "+flavor_name()+".")
-
-	if(findtext(message2recognize, "say phrases"))
-		if(vip.Find(H.job) || vip.Find(H.get_role_title()))
-			say("Open: [open_phrase], Close: [close_phrase].")
-		else
-			say("I don't know you, "+flavor_name()+".")
-
-	if(findtext(message2recognize, "help"))
-		if(!locked)
-			say("My commands are: Set Open, Set Close, Say Phrases")
-		else
-			say("Unlock me for help, "+flavor_name()+".")
+			say("The way is now closed, "+flavor_name()+".", language = lang)
 
 	if(findtext(message2recognize, "set open"))
-		if(!locked)
+		if(isvip || !locked)
 			var/new_pass = stripped_input(H, "What should the new open phrase be?")
 			open_phrase = new_pass
-			say("Open phrase has been set, "+flavor_name()+".")
+			say("Open phrase has been set, "+flavor_name()+".", language = lang)
+		else
+			say("I don't know you, "+flavor_name()+".", language = lang)
+			triggerdefenses(H, defenses)
 		
 
 	if(findtext(message2recognize, "set close"))
-		if(!locked)
+		if(isvip || !locked)
 			var/new_pass = stripped_input(H, "What should the new close phrase be?")
 			close_phrase = new_pass
-			say("Close phrase has been set, "+flavor_name()+".")
+			say("Close phrase has been set, "+flavor_name()+".", language = lang)
+		else
+			say("I don't know you, "+flavor_name()+".", language = lang)
+			triggerdefenses(H, defenses)
 	
+	if(findtext(message2recognize, "set language"))
+		if(isvip || !locked)
+			var/list/langresult = list()
+			for(var/ld in GLOB.all_languages)
+				if (H.mind.language_holder.has_language(ld))
+					langresult.Add(ld)
+			if(langresult)
+				var/datum/language/language_choice = input("Choose the new language", "Available languagess") as anything in langresult
+				lang = language_choice
+		else
+			say("I don't know you, "+flavor_name()+".", language = lang)
+			triggerdefenses(H, defenses)
+
+	if(findtext(message2recognize, "set defenses"))
+		if(isvip || !locked)
+			defenses = !defenses
+			if(defenses)
+				say("Arcyne defenses activated, "+flavor_name()+".", language = lang)
+			else
+				say("Arcyne defenses deactivated, "+flavor_name()+".", language = lang)
+		else
+			say("I don't know you, "+flavor_name()+".", language = lang)
+			triggerdefenses(H, defenses)
+
+proc/triggerdefenses(var/mob/living/carbon/human/H, var/D)
+	if (D)
+		if (H)
+		/*
+			LATER MAKE IT LIGHTNING LURE 
+			var/range = 3 SECONDS
+			var/delay = 3 SECONDS
+			var/sprite_changes = 10
+			var/datum/beam/current_beam = null
+			playsound(src, 'sound/items/stunmace_gen (2).ogg', 100)
+
+			var/x 
+			for(x=1; x < sprite_changes; x++)
+				current_beam = new(src, H, time=30/sprite_changes, beam_icon_state="lightning[rand(1,12)]", btype=/obj/effect/ebeam, maxdistance=10)
+				INVOKE_ASYNC(current_beam, TYPE_PROC_REF(/datum/beam, Start))
+				sleep(delay/sprite_changes)
+
+			var/dist = get_dist(src, H)
+			if (dist <= range)
+				H.electrocute_act(1, src) //just shock	
+			else
+				playsound(src, 'sound/items/stunmace_toggle (3).ogg', 100)
+		*/
+			H.electrocute_act(30, src) //just shock	
+			playsound(src, 'sound/items/stunmace_toggle (3).ogg', 100)
+
 proc/open_word()
 	var/list/open_word = list(
 		"open", 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -46,6 +46,7 @@
 	var/kickthresh = 15
 	var/swing_closed = TRUE
 	var/lock_strength = 100
+	var/can_add_lock = TRUE
 
 	damage_deflection = 10
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -36,4 +36,4 @@
 	H.change_stat("intelligence", -2)
 	H.change_stat("speed", -1)
 	ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC) //tavern brawler
-
+	H.grant_language(/datum/language/thievescant)

--- a/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
@@ -125,6 +125,7 @@
 	backpack_contents = list(/obj/item/lockpickring/mundane)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NASTY_EATER, TRAIT_GENERIC)
+	H.grant_language(/datum/language/thievescant)
 
 /datum/outfit/job/roguetown/vagrant
 	name = "Beggar"

--- a/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
@@ -40,6 +40,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("intelligence", -1)
+		H.grant_language(/datum/language/thievescant)
 	if(H.gender == MALE)
 		pants = /obj/item/clothing/under/roguetown/trou/leather
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor/nightman

--- a/code/modules/jobs/job_types/roguetown/peasants/vagabond.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/vagabond.dm
@@ -51,3 +51,4 @@
 	H.change_stat("intelligence", round(rand(-4,4)))
 	H.change_stat("constitution", -1)
 	H.change_stat("endurance", -1)
+	H.grant_language(/datum/language/thievescant)


### PR DESCRIPTION
-'help' is now accessible by anyone and is stated in common
-'help' now gives a list of commands and the joblist who can say them
-added 'set language'
-the door now speaks languages
-added 'set defenses' which defaults off but when turned off, anyone attempting to use any of the 'set' commands without credentials will be shocked
-changed most commands to be available if the speaker is on the joblist OR the door is already opened
-gave rogue door joblisters thievescant since that door defaults to thievescant
-removed the ability to cheese the door by adding a custom lock to it and opening it that way