### PR TITLE
fixes duplicate recipe names for feldhood and surghood

### DIFF
--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -178,14 +178,14 @@
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/feldhood
-	name = "hood"
+	name = "feldhood"
 	result = list(/obj/item/clothing/head/roguetown/roguehood/feldhood)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/surghood
-	name = "hood"
+	name = "surghood"
 	result = list(/obj/item/clothing/head/roguetown/roguehood/surghood)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Basically, both these recipes were named "hood" and that conflicted with the existing hood recipe. This patch makes both of them craftable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's drip or drown, and baby I'm the Deluge
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
