### PR TITLE
 Tzula's super duper cool map update & Dungeon

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,9 +7,8 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -496,13 +495,16 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -980,11 +982,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "adK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "adL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -1138,23 +1137,35 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+	dir = 6;
+	icon_state = "largetable"
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town)
 "aev" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"aew" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1225,14 +1236,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"agj" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "agq" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "sheriff"
@@ -1247,6 +1250,12 @@
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"aha" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "ahH" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -1281,20 +1290,6 @@
 /obj/structure/statue/saints/father,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"ajl" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"ajm" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "ajo" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -1341,6 +1336,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"akO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "alk" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -1349,6 +1351,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"alw" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "alL" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -1402,12 +1410,16 @@
 /obj/structure/statue/saints/knight_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"aok" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+"anR" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
+"aok" = (
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1419,10 +1431,6 @@
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
-/area/rogue/indoors/town/church/chapel)
-"aoB" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aoD" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1475,12 +1483,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"arv" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1508,6 +1510,13 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"asR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "atx" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/church,
@@ -1558,12 +1567,11 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1662,6 +1670,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"axV" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "axW" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
@@ -1673,9 +1688,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
@@ -1761,17 +1776,23 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
-"aBA" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+"aBG" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"aBY" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
+"aCa" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1861,16 +1882,17 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"aFc" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"aFP" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "aFS" = (
 /obj/structure/chair/wood/rogue,
 /obj/item/rogueweapon/whip,
@@ -1885,6 +1907,14 @@
 "aGb" = (
 /obj/structure/bars,
 /turf/closed/wall/mineral/rogue/stone/window,
+/area/rogue/indoors/town/church/chapel)
+"aGc" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "aGO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
@@ -1928,26 +1958,6 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"aHA" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"aHF" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"aHI" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aHK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/tavern)
@@ -2048,12 +2058,6 @@
 "aKg" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves)
-"aKi" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "aKj" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
@@ -2061,14 +2065,10 @@
 "aKu" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/bath)
-"aKy" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+"aKz" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aKH" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/dirt/road{
@@ -2102,14 +2102,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town)
-"aLq" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "aLG" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -2122,13 +2114,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"aLR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "aMh" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -2233,18 +2218,15 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2319,12 +2301,12 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2428,10 +2410,23 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"aWh" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"aWt" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aWO" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -2439,15 +2434,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"aWR" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "aXa" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
@@ -2505,12 +2491,22 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"aYo" = (
-/obj/structure/stairs{
+"aYC" = (
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"aYG" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aZj" = (
 /obj/structure/table/vtable,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -2550,11 +2546,6 @@
 "baS" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
-"bbl" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "bbm" = (
 /obj/structure/flora/wildplant/wild_poppy,
 /turf/open/floor/rogue/grass,
@@ -2564,6 +2555,10 @@
 	dir = 10
 	},
 /area/rogue/indoors/town/manor)
+"bbG" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "bbO" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
@@ -2584,6 +2579,13 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
+"bdw" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "bdB" = (
 /obj/structure/statue/saints/knight,
 /turf/open/floor/rogue/blocks,
@@ -2614,26 +2616,19 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"bei" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "ben" = (
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"bep" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "beA" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -2678,6 +2673,15 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"bgb" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bge" = (
 /obj/structure/roguemachine/wizardvend,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2699,10 +2703,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"bgT" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "bgW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -2737,12 +2737,16 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"bhY" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+"bib" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2822,14 +2826,16 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"bkC" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "bkD" = (
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bkL" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -2839,14 +2845,6 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/shop)
-"blx" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "blA" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/dirt/road{
@@ -2891,14 +2889,9 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2939,15 +2932,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"bnU" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "bnV" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -3022,10 +3006,6 @@
 /obj/item/pestle,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"bpA" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "bpD" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
@@ -3074,8 +3054,8 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3107,6 +3087,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"brj" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "brp" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/twig{
@@ -3168,11 +3152,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"btb" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3250,13 +3229,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"buQ" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "bvs" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/tongs,
@@ -3298,6 +3270,13 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"bwb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "bwc" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/cobble,
@@ -3336,6 +3315,11 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town)
+"bwP" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "bwS" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
@@ -3423,13 +3407,12 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
-"bzz" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3459,14 +3442,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"bAs" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "bAw" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -3487,6 +3462,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"bBs" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3503,9 +3482,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3548,15 +3527,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"bEu" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "bEC" = (
 /obj/structure/lever/wall{
 	dir = 4;
@@ -3613,13 +3583,6 @@
 "bFU" = (
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"bGf" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "bGg" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
@@ -3661,9 +3624,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3740,15 +3709,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bKg" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "bKi" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/concrete,
@@ -3761,6 +3721,17 @@
 /obj/item/roguekey/roomhunt,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
+"bLe" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "bLf" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -3776,20 +3747,16 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"bLV" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
+"bMe" = (
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bMh" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"bMt" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "bMK" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road{
@@ -3823,19 +3790,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"bNW" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "bOh" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/metal/barograte,
@@ -3881,18 +3835,27 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "bPz" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
-"bPL" = (
-/obj/structure/rack/rogue,
+"bPH" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3998,9 +3961,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bSF" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "bSW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -4036,24 +3996,20 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"bUD" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "bVa" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4070,10 +4026,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bVJ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "bWj" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -4119,6 +4071,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"bXL" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bXS" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -4151,14 +4110,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"bYK" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "bYM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -4195,6 +4146,15 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"bZo" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "bZB" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/grass,
@@ -4202,12 +4162,6 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"caC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4296,13 +4250,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4335,6 +4284,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"cfb" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cfw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4414,16 +4367,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"chs" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "chN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -4434,10 +4377,6 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors/town/tavern)
-"chY" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "cif" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4477,16 +4416,6 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
-"cix" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ciX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -4515,20 +4444,23 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cjy" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"cjI" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
-"cjJ" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
+"cjJ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4580,15 +4512,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"clm" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4596,6 +4526,13 @@
 	name = "Temple of the One"
 	},
 /turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
+"cly" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "clA" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -4617,9 +4554,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"cmp" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
 "cmB" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/shop)
@@ -4688,25 +4622,6 @@
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"coP" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "cpf" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -4783,6 +4698,15 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cqJ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "crx" = (
 /obj/structure/statue/saints/noble3_l,
 /turf/open/floor/rogue/grass,
@@ -4814,6 +4738,13 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"csw" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "csA" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck{
 	tame = 1
@@ -4899,10 +4830,15 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -5002,10 +4938,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"cxS" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "cxW" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
@@ -5013,11 +4945,10 @@
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"cyK" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"cyy" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "czb" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
@@ -5205,12 +5136,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5244,6 +5178,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cEr" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cEv" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -5398,10 +5338,26 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"cJi" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "cJz" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/dwarfin)
+"cJR" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cKj" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -5455,9 +5411,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5475,9 +5432,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5532,6 +5489,16 @@
 "cNY" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
+"cOn" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "cOz" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -5566,13 +5533,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "cPr" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "cPw" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -5637,10 +5605,14 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/under/cave)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5714,6 +5686,17 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors)
+"cTT" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "cTY" = (
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/cobble,
@@ -5778,6 +5761,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"cVu" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "cVK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -5794,13 +5781,6 @@
 /obj/structure/floordoor/gatehatch/outer,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"cWr" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "cWu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5931,15 +5911,25 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"cZP" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+"cZN" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
+"dad" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -5973,12 +5963,6 @@
 /obj/item/clothing/suit/roguetown/armor/plate/half,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"daJ" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "daO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/storage/roguebag,
@@ -5986,13 +5970,25 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"dbH" = (
-/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
+"dbB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"dbH" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -6019,6 +6015,14 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"dcq" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "dcw" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/churchrough,
@@ -6029,21 +6033,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"dcE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "dcF" = (
 /obj/structure/stairs{
 	dir = 1
@@ -6086,6 +6075,10 @@
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"dcZ" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ddl" = (
 /obj/machinery/light/rogue/torchholder,
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
@@ -6191,6 +6184,16 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"dgS" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dhg" = (
 /obj/structure/roguewindow/stained/yellow,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -6222,6 +6225,16 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"dhJ" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "dhK" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -6290,15 +6303,6 @@
 /obj/item/candle/skull/lit,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
-"djR" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "djX" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -6324,6 +6328,16 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
+"dkD" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "dkI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -6407,6 +6421,21 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
+"dnc" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "dnf" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
 /area/rogue/indoors/town/manor)
@@ -6428,6 +6457,13 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter)
+"dof" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "doK" = (
 /obj/structure/bars,
 /obj/machinery/light/rogue/torchholder{
@@ -6490,10 +6526,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"dqi" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dqq" = (
 /obj/structure/fluff/walldeco/innsign{
 	alpha = 200;
@@ -6510,10 +6542,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
-"dqD" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "dqU" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -6574,17 +6602,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"dte" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "dth" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
@@ -6672,13 +6689,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6711,21 +6724,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"dyi" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
-"dyu" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "dyD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/red,
@@ -6765,8 +6763,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6787,28 +6790,21 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"dAG" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "dBk" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"dBs" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4"
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dBt" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"dBA" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6835,6 +6831,17 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"dCX" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"dDc" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "dDf" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -6875,6 +6882,15 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"dFg" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -6904,12 +6920,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"dFU" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+"dFY" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -6956,12 +6971,25 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"dHx" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dHC" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "dHZ" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
+"dIj" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "dIo" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
 	dir = 1;
@@ -6991,15 +7019,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
-"dJj" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "dJr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7010,26 +7029,23 @@
 	dir = 4
 	},
 /area/rogue/outdoors/bog)
-"dKn" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "dKq" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"dKL" = (
+"dKU" = (
 /obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
+	dir = 4
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dKV" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/herringbone,
@@ -7113,8 +7129,10 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7207,14 +7225,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"dPE" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "dPL" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/rogue/tile,
@@ -7223,10 +7233,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
-"dPZ" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "dQa" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -7256,14 +7262,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"dQz" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "dQJ" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
@@ -7302,6 +7300,25 @@
 /obj/item/rogueweapon/greatsword,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
+"dRp" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
+"dSd" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "dSo" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
@@ -7351,7 +7368,18 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/turf/closed/mineral/rogue,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"dTy" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "dTB" = (
 /obj/structure/table/wood,
@@ -7394,6 +7422,13 @@
 	dir = 8
 	},
 /area/rogue/outdoors/exposed)
+"dTZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dUk" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
@@ -7411,18 +7446,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dUX" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -7463,6 +7486,10 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"dWu" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "dWG" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -7572,18 +7599,16 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains)
 "ebe" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7593,6 +7618,11 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/rtfield)
+"ebC" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ebG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -7678,6 +7708,12 @@
 /obj/item/ingot/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"eda" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "edc" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
@@ -7897,12 +7933,6 @@
 "eiV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
-"eiY" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "eja" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road{
@@ -7945,12 +7975,6 @@
 "ekI" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/shop)
-"ekK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/garrison)
 "ekQ" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -7984,17 +8008,17 @@
 "els" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"elE" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+"elx" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"elO" = (
-/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"ema" = (
+/obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town)
 "emp" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road{
@@ -8029,16 +8053,6 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"emT" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "emX" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -8119,9 +8133,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/structure/closet/crate/chest/reward,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -8153,6 +8167,10 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"eqh" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "eqt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -8162,6 +8180,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"eqw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eqy" = (
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
@@ -8233,13 +8257,6 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
-"ess" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "esv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -8259,6 +8276,18 @@
 "esR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"etc" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ete" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/rogue/firebowl/stump,
@@ -8269,11 +8298,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"ett" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "etu" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/butler{
@@ -8295,6 +8319,14 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"etX" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "euc" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /turf/open/floor/rogue/dirt,
@@ -8382,20 +8414,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"evW" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
-"ewj" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ewq" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjailr"
@@ -8472,50 +8490,50 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/area/rogue/outdoors/rtfield)
-"ezc" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"ezu" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "ezv" = (
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
-"ezK" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "eAh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
+"eAs" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"eAG" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "eAW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8571,13 +8589,6 @@
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"eCx" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "eCK" = (
 /obj/structure/flora/rogueshroom2,
 /turf/open/floor/rogue/grass,
@@ -8615,13 +8626,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
-"eEh" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "eEy" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -8634,6 +8638,13 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"eES" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "eEU" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -8643,12 +8654,6 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
-"eEY" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "eFa" = (
 /obj/effect/landmark/start/wapprentice,
 /obj/structure/bed/rogue/shit,
@@ -8678,6 +8683,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
+"eFI" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "eFO" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -8694,10 +8707,6 @@
 /obj/item/signal_horn,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"eGn" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "eGD" = (
 /obj/item/natural/stone,
 /obj/item/natural/stone,
@@ -8750,6 +8759,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"eHF" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "eHU" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8778,22 +8791,18 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"eIm" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+"eIH" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
-"eIA" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
+/obj/structure/fluff/railing/wood{
 	dir = 1;
-	icon_state = "border"
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/church/chapel)
 "eIK" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -8845,6 +8854,24 @@
 /obj/structure/statue/saints/lady_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eJX" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"eJZ" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "eKa" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river,
@@ -8855,6 +8882,15 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"eKj" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "eKP" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
@@ -8895,22 +8931,30 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"eMm" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "eMz" = (
 /obj/structure/flora/rock,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"eMC" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "eMI" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"eMR" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "eNa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8948,6 +8992,15 @@
 "eOg" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter)
+"eOt" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eOR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop/green{
@@ -8993,6 +9046,18 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eRc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "eRi" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -9002,24 +9067,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"eRE" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "eRQ" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/magelady_r,
@@ -9059,16 +9106,17 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9078,17 +9126,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
-"eSD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"eTk" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+"eSH" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
@@ -9104,6 +9144,13 @@
 "eTw" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eTE" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eTM" = (
 /obj/structure/stairs/fancy/c{
 	dir = 1
@@ -9115,13 +9162,6 @@
 	dir = 1
 	},
 /area/rogue/indoors)
-"eTX" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "eUb" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/town)
@@ -9129,6 +9169,13 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"eUi" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "eUw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood{
@@ -9204,6 +9251,13 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"eVP" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "eVS" = (
 /obj/structure/fluff/wallclock/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -9237,6 +9291,12 @@
 "eWl" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"eWs" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "eWM" = (
 /obj/machinery/light/rogue/chand,
 /obj/effect/landmark/start/jester{
@@ -9323,6 +9383,10 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"faD" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "faE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -9513,18 +9577,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"fhc" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fhg" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9615,13 +9667,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"fks" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/magician)
@@ -9675,13 +9720,6 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
-"fmh" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "fmm" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -9701,6 +9739,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fmV" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "fnc" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -9743,12 +9785,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fnW" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9784,6 +9820,17 @@
 /obj/structure/statue/saints/cephine2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fpk" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "fpQ" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/tribalguard,
@@ -9837,6 +9884,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"fsm" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -9868,11 +9919,6 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
-"ftd" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "ftw" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -9938,10 +9984,12 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fvP" = (
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+"fvS" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "fwp" = (
 /obj/structure/bars,
 /turf/closed/mineral/rogue,
@@ -9954,6 +10002,16 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fwK" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "fwL" = (
 /obj/item/rogueweapon/hammer{
 	color = gold;
@@ -9971,6 +10029,9 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"fwP" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "fwR" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/rack/rogue/shelf/big,
@@ -10031,6 +10092,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"fyv" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fyA" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -10126,6 +10196,18 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors)
+"fBj" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fBp" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
@@ -10135,6 +10217,10 @@
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"fBz" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "fBF" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -10156,12 +10242,6 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"fCr" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "fCw" = (
 /obj/structure/chair/bench/coucha/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -10208,8 +10288,9 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -10218,6 +10299,14 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"fDR" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "fEo" = (
 /obj/item/rogueweapon/woodstaff/wise{
 	color = gold;
@@ -10254,6 +10343,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"fEX" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -10328,10 +10423,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"fIp" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "fIw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
@@ -10349,9 +10440,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fID" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -10369,6 +10462,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
+"fIW" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fIY" = (
 /obj/item/paper,
 /obj/item/paper,
@@ -10386,16 +10490,6 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fJL" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -10435,6 +10529,14 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"fLr" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fLt" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -10444,9 +10546,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10473,15 +10577,18 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"fNp" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "fNw" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"fNz" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "fOo" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -10568,12 +10675,11 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10609,12 +10715,29 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"fRl" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "fRo" = (
 /obj/structure/stairs{
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/tribalfort)
+"fRp" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "fRt" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/herringbone,
@@ -10630,23 +10753,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"fRO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/rtfield)
-"fRS" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -10665,6 +10771,9 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"fSe" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "fSk" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -10704,6 +10813,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"fTX" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fUc" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10743,10 +10859,6 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fUW" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "fVa" = (
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/dirt/road{
@@ -10772,15 +10884,8 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
-"fVN" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10840,6 +10945,11 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fYb" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "fYj" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -10885,14 +10995,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
-"gaA" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "gaC" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement)
@@ -10921,16 +11023,12 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
 /obj/structure/fluff/railing/border{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
 /area/rogue/outdoors/mountains)
 "gbN" = (
@@ -10956,6 +11054,18 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"gcs" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "gcw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/wood,
@@ -11032,23 +11142,10 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves)
-"gfg" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "gfl" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"gfE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "gfG" = (
 /obj/structure/mineral_door/secret/merchant,
 /turf/open/floor/rogue/tile/checkeralt,
@@ -11081,13 +11178,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"ggX" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/ruinedwood{
@@ -11109,8 +11199,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -11282,8 +11375,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "goK" = (
 /obj/effect/decal/cobbleedge{
@@ -11291,6 +11391,28 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"goP" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"goR" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"gpb" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gpe" = (
 /obj/structure/bed/rogue,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -11316,12 +11438,6 @@
 	icon_state = "glyph4"
 	},
 /area/rogue/indoors/town/church/chapel)
-"gpZ" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gqa" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -11330,10 +11446,24 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"gqb" = (
+/obj/structure/gate/bars{
+	gid = "viking1";
+	redstone_id = "viking1"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "gqc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
+"gqo" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -11354,9 +11484,6 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors/town)
-"gre" = (
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -11447,36 +11574,22 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"guw" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "guH" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"guL" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "gvi" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/outdoors/mountains)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11497,6 +11610,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"gvZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gwd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -11510,6 +11631,12 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
+"gww" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11517,6 +11644,20 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"gwF" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "gwJ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11569,6 +11710,23 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"gxP" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "gye" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -11617,6 +11775,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"gzY" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gAc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -11675,6 +11839,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"gBS" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "gBZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -11714,18 +11885,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"gDl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -11749,14 +11908,19 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
+"gEF" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "gEI" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"gEJ" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "gEL" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood{
@@ -11843,6 +12007,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"gHn" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "gHt" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -11901,16 +12069,6 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"gJo" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "gJs" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -11991,12 +12149,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"gLV" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "gLY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -12079,6 +12231,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"gOu" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gOv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -12098,23 +12256,14 @@
 /obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"gOY" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"gPt" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "gPy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor)
+"gPF" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gPI" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -12276,16 +12425,6 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"gTE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "gTT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -12374,10 +12513,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"gXa" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+"gXf" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gXr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -12405,12 +12544,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"gYB" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "gYC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -12435,6 +12568,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"gZn" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "gZr" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -12508,12 +12645,8 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "hby" = (
 /obj/structure/stairs{
@@ -12539,6 +12672,14 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"hcc" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hcg" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/mountains)
@@ -12661,6 +12802,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"hea" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hec" = (
 /obj/structure/mineral_door/wood{
 	lockid = "roomii";
@@ -12688,6 +12837,12 @@
 /area/rogue/indoors/town/dwarfin)
 "hew" = (
 /turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/rtfield)
+"heM" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "heV" = (
 /obj/structure/table/church/m,
@@ -12731,6 +12886,15 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
+"hfA" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hfI" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
@@ -12781,15 +12945,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
-"hgt" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "hgG" = (
 /obj/structure/stairs{
 	dir = 4
@@ -12829,6 +12984,10 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"hiA" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "hiI" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -12864,6 +13023,14 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/town/roofs)
+"hju" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "hjv" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -12978,6 +13145,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"hmr" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hmz" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -13130,10 +13305,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"hpK" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "hpO" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -13147,20 +13318,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"hpV" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "hpY" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/magician)
@@ -13217,10 +13374,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"hsa" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "hsg" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/churchrough,
@@ -13236,20 +13389,10 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"hsD" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+"hsF" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hsQ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -13262,23 +13405,12 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
@@ -13292,18 +13424,12 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"htF" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+"htG" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "htU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -13363,6 +13489,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"hvB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "hvH" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/purple,
@@ -13443,6 +13575,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hzI" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13462,19 +13602,6 @@
 /obj/item/roguekey/manor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"hAe" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"hAf" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hAg" = (
 /obj/item/chair/rogue/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -13513,14 +13640,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"hCt" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hCu" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile{
@@ -13635,11 +13754,11 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hGE" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13754,6 +13873,14 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hKN" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -13799,6 +13926,10 @@
 /obj/effect/rune,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"hMe" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "hMD" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -13821,13 +13952,10 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
-"hMZ" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+"hNB" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "hND" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
@@ -13858,6 +13986,11 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hOb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "hOh" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
@@ -13884,21 +14017,15 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"hON" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hOP" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"hOS" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "hOY" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -13976,6 +14103,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"hRk" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hRl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -14017,6 +14152,15 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town)
+"hSs" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "hSz" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14028,16 +14172,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/bog)
-"hSF" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hSK" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -14090,14 +14224,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"hVn" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "hVo" = (
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/church,
@@ -14146,14 +14272,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"hXt" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hXu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -14161,16 +14279,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"hXE" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hYd" = (
 /turf/open/water/river{
 	dir = 1;
@@ -14198,6 +14306,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"hYH" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hYU" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road{
@@ -14228,6 +14340,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"hZP" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "hZV" = (
 /obj/structure/roguemachine/mail/l{
 	pixel_x = 0
@@ -14264,11 +14381,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"iaM" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "iaR" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14283,6 +14395,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"ibw" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ibW" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -14413,8 +14532,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14437,6 +14557,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"igh" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "igq" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -14447,14 +14571,28 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"ihj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+"igT" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"ihk" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood3"
+	dir = 10;
+	icon_state = "largetable"
 	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
+"ihm" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "iho" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -14497,6 +14635,10 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"iir" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iiH" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/cobble/mossy,
@@ -14526,17 +14668,6 @@
 "ike" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"ikk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "ikt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -14558,10 +14689,16 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -14569,16 +14706,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"ilf" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ilm" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -14648,13 +14775,14 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
-"inf" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
 "int" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"iot" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14695,18 +14823,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"iqo" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -14756,16 +14872,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"irw" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "irz" = (
 /obj/structure/mineral_door/bars{
 	locked = 1
@@ -14783,6 +14889,10 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"ism" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "isI" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/short,
@@ -14794,25 +14904,14 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"isO" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "itv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -14820,12 +14919,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -14917,10 +15012,6 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"iwf" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -14929,10 +15020,6 @@
 "iwV" = (
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"ixl" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "ixt" = (
 /obj/item/grown/log/tree/small,
@@ -15034,12 +15121,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"izB" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "izL" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobblerock,
@@ -15083,6 +15164,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"iBe" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iBA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -15128,10 +15213,6 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"iDe" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "iDg" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/under/roguetown/trou,
@@ -15165,14 +15246,6 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"iEd" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -15206,6 +15279,13 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
+"iEA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -15278,16 +15358,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
-"iGg" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "iGh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15299,6 +15369,16 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"iGx" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "iHm" = (
 /obj/structure/timeddoor,
 /obj/structure/timeddoor,
@@ -15341,15 +15421,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
-"iJu" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "iJC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -15467,11 +15538,7 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/woodturned/nosmooth,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
@@ -15634,14 +15701,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15675,9 +15739,9 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15710,6 +15774,12 @@
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"iVh" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "iVi" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -15753,11 +15823,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -15844,11 +15912,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"iYF" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -15903,21 +15966,10 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"jaB" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "jaF" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"jaR" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "jaU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/naturalstone,
@@ -15959,6 +16011,10 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"jbK" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jcb" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/cobblerock,
@@ -16013,6 +16069,13 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
+"jdI" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "jdK" = (
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
@@ -16044,6 +16107,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"jeS" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "jeW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16066,12 +16138,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"jfz" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "jfF" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/woodturned,
@@ -16086,10 +16152,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"jfQ" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16119,16 +16181,6 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"jgm" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jgs" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
@@ -16136,10 +16188,6 @@
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
-"jhf" = (
-/obj/structure/fluff/wallclock/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16250,20 +16298,15 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
-"jme" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
 /obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+	dir = 6
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
@@ -16299,6 +16342,13 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"jnc" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jnl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -16354,20 +16404,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
-"jpF" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/outdoors/mountains)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16399,6 +16439,10 @@
 "jqC" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
+"jqK" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "jqM" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -16445,10 +16489,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"jtc" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "jtj" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16492,6 +16532,13 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/church/chapel)
+"jvr" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jvt" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/garrison)
@@ -16523,12 +16570,13 @@
 	icon_state = "horzw"
 	},
 /area/rogue/under/town/basement)
-"jwj" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
+"jwm" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jwn" = (
 /obj/structure/mineral_door/wood{
@@ -16619,14 +16667,6 @@
 /obj/structure/closet/crate/chest/reward,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"jzd" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"jzv" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "jzy" = (
 /obj/structure/fluff/statue/tdummy,
 /obj/effect/decal/cleanable/blood/old,
@@ -16638,6 +16678,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"jzM" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "jAb" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -16651,6 +16695,15 @@
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jAC" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "jAG" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
@@ -16661,16 +16714,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"jAT" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "jAV" = (
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
@@ -16685,12 +16728,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jBO" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -16699,8 +16736,10 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -16791,31 +16830,19 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "jEB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"jER" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"jEU" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "jFa" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -16834,6 +16861,11 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"jFG" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jFL" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/worms,
@@ -16896,6 +16928,12 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jHX" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jIy" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -16914,12 +16952,24 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"jJg" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "jJq" = (
 /obj/structure/statue/saints/paladin2_r,
 /turf/open/floor/rogue/blocks,
@@ -16934,10 +16984,29 @@
 /obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"jKi" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"jKP" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "jKW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -16947,6 +17016,10 @@
 "jKY" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/town)
+"jLi" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jLs" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -17093,6 +17166,15 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"jOr" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jOI" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -17167,12 +17249,10 @@
 "jQy" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
-"jQX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+"jQV" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "jRk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -17245,12 +17325,6 @@
 "jTP" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
-"jTZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "jUk" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -17270,6 +17344,13 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
+"jUZ" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -17278,18 +17359,13 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"jVi" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
+"jVO" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"jWd" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17312,16 +17388,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
-"jWX" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"jWZ" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -17401,14 +17467,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"jZi" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "jZn" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/tile,
@@ -17428,6 +17486,23 @@
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"kaf" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"kal" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "kan" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17498,12 +17573,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"kcE" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+"kcu" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kcG" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -17515,18 +17592,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kdb" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
+"kdj" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "kds" = (
 /obj/structure/table/wood,
@@ -17546,6 +17615,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"kdY" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "keq" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -17570,6 +17645,11 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"keX" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "kfe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -17646,12 +17726,17 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -17685,6 +17770,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"kiL" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kiR" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -17704,6 +17795,12 @@
 "kjH" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town)
+"kjI" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kjR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -17740,25 +17837,10 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"kkT" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "kld" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"klm" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "klp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -17767,10 +17849,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"kmo" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "kms" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper,
@@ -17813,19 +17891,16 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"koE" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "kpk" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"kpI" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kpZ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -17849,10 +17924,21 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kqt" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"kqw" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"kqD" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "kqI" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree,
@@ -17863,6 +17949,10 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kqO" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kqT" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -17921,14 +18011,6 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"krZ" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17967,9 +18049,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -18015,6 +18097,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"ktI" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "ktW" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/boss,
 /turf/open/floor/rogue/blocks,
@@ -18055,19 +18141,19 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kve" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -18108,13 +18194,19 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/area/rogue/outdoors/rtfield)
+"kxq" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18128,16 +18220,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"kxz" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "kxB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18287,24 +18369,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"kBS" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kCh" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -18370,6 +18434,14 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kEf" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "kEn" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
@@ -18385,6 +18457,10 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
+"kEE" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "kEI" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -18394,14 +18470,24 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"kEV" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kFc" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 8
 	},
 /area/rogue/indoors)
 "kFh" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18444,6 +18530,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"kGp" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "kGR" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
@@ -18485,9 +18575,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
-"kIt" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
 "kIu" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -18586,13 +18673,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"kLB" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -18773,6 +18853,17 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
+"kQu" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
+"kQC" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
 "kQN" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
@@ -18788,13 +18879,14 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"kRw" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
+"kRc" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/turf/open/floor/rogue/churchrough,
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "kRA" = (
 /obj/effect/landmark/start/mercenary{
@@ -18871,10 +18963,25 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"kTt" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"kTw" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -18996,13 +19103,6 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kZn" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "kZr" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
@@ -19077,10 +19177,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"lbA" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lbB" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/scomstone,
@@ -19094,6 +19190,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"lbH" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "lbV" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
@@ -19107,10 +19211,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"ldc" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ldf" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -19146,6 +19246,14 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"leS" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "leV" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -19159,14 +19267,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"lft" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -19242,27 +19342,14 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"lgX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "lha" = (
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -19272,6 +19359,25 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"lhv" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
+"lhN" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "lhO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -19286,6 +19392,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"lhZ" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "lia" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/blocks,
@@ -19293,6 +19405,14 @@
 "lih" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/shop)
+"lip" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lis" = (
 /obj/structure/bed/rogue/shit,
 /obj/item/soap,
@@ -19350,6 +19470,17 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"ljW" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "ljZ" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/water/swamp,
@@ -19360,10 +19491,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"lku" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "lkv" = (
 /obj/structure/fluff/dryingrack,
 /obj/item/needle/thorn,
@@ -19423,13 +19550,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"lmP" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "lmV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -19441,16 +19561,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"lmZ" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "lnq" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/cobble,
@@ -19495,11 +19605,17 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -19610,6 +19726,10 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"ltl" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ltA" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -19664,6 +19784,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"lvj" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lvr" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19701,24 +19831,10 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"lxc" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "lxe" = (
 /obj/structure/mirror/fancy,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"lxB" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lxQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -19743,16 +19859,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"lyW" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -19771,6 +19877,11 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"lzh" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lzl" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/blocks,
@@ -19858,15 +19969,6 @@
 /obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"lBN" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lCn" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -19901,6 +20003,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"lDI" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lDQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -19921,13 +20029,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"lEz" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "lEB" = (
 /obj/item/rogueweapon/spear/banner{
 	desc = "A blessed standard of Pestra, marking the Champion of her Healing Crafts.";
@@ -19993,9 +20094,20 @@
 "lFV" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"lGo" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "lGI" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
@@ -20071,17 +20183,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"lJr" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
 "lJA" = (
 /obj/structure/chair/stool/rogue{
 	dir = 4
@@ -20126,22 +20227,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"lKp" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
@@ -20164,6 +20249,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"lLn" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lLp" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
@@ -20177,6 +20269,14 @@
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
+"lLV" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
@@ -20200,35 +20300,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town/church/chapel)
-"lNn" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/closed,
-/area/rogue/indoors/town)
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lOd" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"lOh" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "lOl" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20284,6 +20362,15 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"lQe" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "lQy" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -20321,6 +20408,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"lSj" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lSn" = (
 /obj/structure/plough,
 /obj/machinery/light/rogue/torchholder{
@@ -20357,12 +20450,6 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"lUn" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "lUv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -20386,10 +20473,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"lVo" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "lVE" = (
 /obj/structure/bars{
 	alpha = 190
@@ -20409,18 +20492,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"lWe" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "lWv" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/junglebush/b,
@@ -20450,13 +20521,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lXG" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "lXJ" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
@@ -20530,6 +20594,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"lZo" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "lZp" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
@@ -20567,10 +20637,6 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"mbt" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -20594,6 +20660,16 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"mcB" = (
+/obj/structure/chair/bench/church/mid{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "mcC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -20611,12 +20687,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mcY" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "mdo" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20634,10 +20704,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20680,12 +20749,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"men" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "mer" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
@@ -20741,6 +20804,10 @@
 "mfK" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician)
+"mge" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "mgk" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/bog)
@@ -20754,10 +20821,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"mgR" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -20831,11 +20894,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -20844,6 +20905,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"mkj" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "mkk" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -21000,12 +21068,6 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"mpQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "mpX" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -21017,6 +21079,10 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"mrd" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "mrl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21028,8 +21094,8 @@
 	},
 /area/rogue/indoors/town)
 "mrE" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "mrN" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21051,10 +21117,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"mst" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "msw" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble,
@@ -21071,6 +21133,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"msN" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21127,13 +21193,26 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
-"mvg" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
+"muU" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"mvc" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "mvp" = (
 /obj/structure/mineral_door/wood{
 	lockid = "townroom2"
@@ -21226,6 +21305,13 @@
 	},
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town)
+"mzd" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
 /area/rogue/indoors/town)
 "mzk" = (
 /obj/structure/table/wood{
@@ -21404,10 +21490,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mGL" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "mHb" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -21493,17 +21575,29 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"mMb" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"mMs" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "mMv" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"mMB" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "mMJ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -21534,6 +21628,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"mNs" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mNz" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/grass,
@@ -21607,6 +21709,15 @@
 /obj/structure/gate,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
+"mPn" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "mPV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -21627,12 +21738,17 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mQA" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -21672,6 +21788,24 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"mSE" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "mSG" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/chair/bench{
@@ -21681,6 +21815,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"mSY" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "mTd" = (
 /obj/structure/fermenting_barrel/random,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21746,12 +21884,9 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -21783,13 +21918,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"mWP" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "mWV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -21825,13 +21953,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"mXz" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "mYd" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -21874,33 +21995,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mZp" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"mZu" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"mZy" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mZE" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -21993,6 +22087,10 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"ncR" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "nda" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/keyring,
@@ -22026,6 +22124,15 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"ndE" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "ndL" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/twig,
@@ -22067,6 +22174,17 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
+"nes" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
+"neF" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "neP" = (
 /turf/open/water/river{
 	dir = 4;
@@ -22088,12 +22206,6 @@
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"nfX" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22111,18 +22223,25 @@
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"nhz" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "nhC" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph5"
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22152,21 +22271,20 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"niJ" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"niC" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "niU" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"niV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+"njm" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "njq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -22184,6 +22302,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"nkv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22262,16 +22387,13 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
-"nnt" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
+"nnx" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
 	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nnz" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -22326,15 +22448,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"nqe" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "nqf" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/blocks,
@@ -22435,6 +22548,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"ntl" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ntK" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -22452,9 +22572,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"nux" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
+"nuB" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "nuD" = (
 /turf/open/floor/rogue/cobble/mossy,
@@ -22475,11 +22599,19 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -22489,6 +22621,16 @@
 "nvd" = (
 /turf/open/water/bath,
 /area/rogue/indoors/shelter/rtfield)
+"nvk" = (
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "nvA" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
@@ -22568,6 +22710,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"nxn" = (
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nxr" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder/c,
@@ -22615,6 +22761,9 @@
 /obj/machinery/anomalous_crystal,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"nxZ" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "nyb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -22655,6 +22804,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"nyO" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nyP" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -22669,6 +22825,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"nzL" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nzO" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/naturalstone,
@@ -22704,8 +22868,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -22773,21 +22941,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"nEp" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"nEA" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "nFg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shield/wood,
@@ -22853,6 +23006,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"nGK" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "nGL" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/church/line{
@@ -22861,6 +23018,11 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"nGQ" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "nGV" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
@@ -22879,12 +23041,19 @@
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"nHm" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nHz" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"nHM" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nIk" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -22938,9 +23107,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -22989,15 +23160,6 @@
 /obj/structure/roguewindow/stained/yellow,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"nLB" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "nLF" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/copper,
@@ -23043,17 +23205,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"nNy" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "nNJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -23071,6 +23222,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"nNM" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "nNQ" = (
 /obj/structure/closet/dirthole/grave,
 /obj/item/natural/worms,
@@ -23078,6 +23235,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"nNV" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/rtfield)
 "nNX" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	lockid = "farm"
@@ -23264,10 +23431,9 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23278,17 +23444,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"nUr" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "nUw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -23345,6 +23500,20 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
+"nWd" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "nWj" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -23410,6 +23579,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
+"nXF" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "nXI" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -23464,10 +23637,6 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town)
-"nYQ" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "nYR" = (
 /obj/item/roguebin/water/gross,
 /obj/machinery/light/rogue/torchholder{
@@ -23516,17 +23685,14 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"oaX" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "obq" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23541,11 +23707,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town/roofs)
-"obE" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "obL" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -23598,12 +23759,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"oda" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "odi" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
@@ -23640,15 +23795,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"oey" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "oeI" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23714,9 +23860,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
@@ -23780,30 +23925,9 @@
 "ohU" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"ohY" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"oiq" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "oiC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
@@ -23828,10 +23952,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"oje" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ojp" = (
 /obj/structure/closet/dirthole/grave,
 /turf/closed/wall/mineral/rogue/stone,
@@ -23845,15 +23965,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"ojM" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23886,6 +23997,13 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"olm" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "olD" = (
 /turf/open/floor/grass/snow{
 	icon_state = "ice"
@@ -23905,6 +24023,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"olW" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "oma" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
@@ -23932,18 +24056,13 @@
 /obj/item/clothing/neck/roguetown/psicross/astrata,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"omn" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
-"omS" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "one" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -23955,10 +24074,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
-"onl" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "onz" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -23967,6 +24082,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"onQ" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "onR" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
@@ -24024,26 +24143,6 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"oqj" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
-"oqk" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -24157,16 +24256,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"oud" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "ouf" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24189,12 +24278,29 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/fluff/railing/border{
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -24230,6 +24336,19 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"owf" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24272,6 +24391,14 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"oxJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "oxL" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/item/needle,
@@ -24309,10 +24436,6 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"oyI" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "oyJ" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24333,13 +24456,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"oyU" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "oze" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/grass,
@@ -24348,6 +24464,13 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ozu" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ozw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24403,6 +24526,12 @@
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"oAA" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "oAC" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/woodturned,
@@ -24428,6 +24557,21 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"oBs" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "oBx" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
@@ -24438,6 +24582,13 @@
 	icon_state = "knightstatue_r"
 	},
 /turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
+"oBC" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "oBU" = (
 /obj/effect/landmark/start/priest,
@@ -24572,14 +24723,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"oGH" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "oGI" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -24639,16 +24782,16 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"oIb" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "oIv" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -24676,14 +24819,19 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"oJO" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"oJM" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
+"oJO" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -24726,9 +24874,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -24769,6 +24917,9 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"oNn" = (
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "oNx" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -24778,11 +24929,6 @@
 "oNE" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
-"oOf" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "oOh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -24872,6 +25018,13 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
+"oQD" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "oQZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/closed/mineral/rogue,
@@ -24899,12 +25052,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -24954,6 +25106,12 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"oSH" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "oSV" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25023,6 +25181,11 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"oVj" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "oVp" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town)
@@ -25147,12 +25310,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"oYd" = (
-/mob/living/simple_animal/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "oYq" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -25188,10 +25345,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"oZt" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "oZC" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -25260,12 +25413,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"paK" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "pbe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -25337,12 +25484,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"pcC" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "pcK" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -25354,8 +25495,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
@@ -25370,8 +25511,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
@@ -25391,10 +25535,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"peB" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "peN" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -25479,6 +25619,10 @@
 "pgm" = (
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
+"pgW" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "phk" = (
 /obj/structure/closet/crate/chest,
@@ -25578,6 +25722,13 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"pkf" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "pkj" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
@@ -25585,6 +25736,16 @@
 "pku" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/manor)
+"pkD" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pkK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -25612,6 +25773,10 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"plJ" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -25679,15 +25844,6 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"ppb" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "ppi" = (
 /obj/structure/stairs{
 	dir = 1
@@ -25745,12 +25901,6 @@
 /obj/structure/fluff/walldeco/rpainting/forest,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
-"pqm" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "pqr" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -25764,20 +25914,6 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
-"pqI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "pqP" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -25803,10 +25939,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"prC" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "prN" = (
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/cobble,
@@ -25834,6 +25966,13 @@
 "prZ" = (
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"psi" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "psz" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/roguekey/mason,
@@ -25897,12 +26036,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/church/chapel)
-"puf" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "puj" = (
 /obj/structure/gate/bars{
 	gid = "forestgate2";
@@ -25910,6 +26043,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pum" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "pur" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -25917,6 +26055,13 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"puY" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -25935,11 +26080,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"pvC" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "pvI" = (
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/table/wood{
@@ -25972,13 +26112,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"pwO" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "pwQ" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/dirt,
@@ -25988,6 +26121,10 @@
 /obj/effect/landmark/start/tribalvillager,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"pxe" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "pxi" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/wood,
@@ -26052,6 +26189,16 @@
 "pyI" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/twig,
+/area/rogue/outdoors/rtfield)
+"pyO" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"pyT" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "pyY" = (
 /obj/item/rogueweapon/sword/falchion,
@@ -26167,12 +26314,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"pCe" = (
+"pBW" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "pCl" = (
 /obj/structure/handcart,
@@ -26204,14 +26352,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
-"pDm" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "pDy" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -26276,18 +26416,10 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"pFy" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+"pFf" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26369,6 +26501,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"pIB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "pJa" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -26406,9 +26545,20 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
@@ -26464,12 +26614,14 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -26487,6 +26639,20 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pMQ" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"pNc" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "pNd" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/rooftop{
@@ -26850,10 +27016,6 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
-"pYF" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "pYO" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
@@ -26882,10 +27044,6 @@
 /obj/effect/landmark/start/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"qaq" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "qas" = (
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/ruinedwood,
@@ -26979,12 +27137,6 @@
 /obj/structure/statue/saints/mother,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"qcK" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "qcO" = (
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
@@ -27018,28 +27170,6 @@
 /obj/structure/closet/crate/roguecloset/inn/chest,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"qdu" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "qdB" = (
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/dirt/road{
@@ -27073,7 +27203,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -27147,16 +27277,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"qhQ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qhR" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27189,20 +27309,19 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"qin" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"qiv" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qiG" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/shoes/roguetown/boots/furlinedanklets,
@@ -27448,21 +27567,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -27473,6 +27579,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"qqk" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qqm" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/grass,
@@ -27483,6 +27598,11 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"qqz" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "qqA" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -27555,20 +27675,16 @@
 	},
 /area/rogue/indoors/town/manor)
 "qrI" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2"
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qrN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"qsb" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "qse" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/remains/human,
@@ -27614,14 +27730,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"qtA" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
@@ -27648,6 +27756,13 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"quu" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -27662,10 +27777,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
+/obj/structure/bed/rogue/inn/double,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "quT" = (
@@ -27724,14 +27836,11 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -27783,6 +27892,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qzb" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -27806,31 +27922,28 @@
 	},
 /area/rogue/outdoors/bog)
 "qzy" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"qzB" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"qzJ" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -27865,10 +27978,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"qBr" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "qBu" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
@@ -27879,6 +27988,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"qBG" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "qBX" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -27901,21 +28020,28 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/effect/landmark/events/haunts,
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/under/cave)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"qDn" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+"qDl" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
+"qDn" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -27935,9 +28061,21 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qEr" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"qEH" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qEY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -27963,18 +28101,20 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"qGb" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+"qFU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "qGh" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
+"qGB" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -28019,14 +28159,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"qHJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "qIi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/villager,
@@ -28091,14 +28223,6 @@
 "qKq" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cave)
-"qKr" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qKu" = (
 /obj/structure/bars{
 	alpha = 190
@@ -28106,9 +28230,31 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
+"qLk" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28161,30 +28307,12 @@
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"qNq" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"qNR" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"qOe" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "qOf" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -28202,6 +28330,11 @@
 "qOW" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
+"qPg" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qPm" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -28254,15 +28387,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"qQR" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -28281,16 +28405,41 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"qRm" = (
+"qRh" = (
 /obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"qRm" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "qRp" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/closed/wall/mineral/rogue/wood,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
@@ -28315,6 +28464,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"qSx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qSA" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/outdoors/town)
@@ -28371,26 +28524,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"qUQ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "qUX" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
-"qVz" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
 /area/rogue/indoors/town/garrison)
 "qVD" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -28412,18 +28550,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"qWc" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+"qWg" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qWh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -28438,13 +28571,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"qXo" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -28490,8 +28616,11 @@
 /area/rogue/indoors/town)
 "qYw" = (
 /obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -28530,6 +28659,16 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"ras" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
@@ -28588,12 +28727,6 @@
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
-"rce" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "rcg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -28601,10 +28734,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"rch" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -28612,9 +28741,11 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/bookcase/random,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -28725,12 +28856,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -28760,14 +28890,10 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -28789,6 +28915,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"rhx" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rhD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -28810,6 +28942,22 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"rhV" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"ril" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rio" = (
 /obj/structure/winch{
 	gid = "forestgate1";
@@ -28843,10 +28991,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"rjQ" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "rjZ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -28888,13 +29032,24 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"rlG" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"rlz" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"rlG" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -28976,6 +29131,15 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"rnv" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "rnN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -29169,6 +29333,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"rtS" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "rtV" = (
 /obj/structure/bars,
 /turf/open/water/sewer,
@@ -29395,6 +29565,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"rCR" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rDg" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
@@ -29514,23 +29688,16 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/chest/reward,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -29635,17 +29802,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"rMj" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "rMl" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -29711,6 +29867,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
+"rOc" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rOe" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/belt/rogue/pouch/coins/mid,
@@ -29718,11 +29878,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"rOi" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rOt" = (
 /obj/structure/stairs{
 	dir = 1;
@@ -29791,14 +29946,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"rQE" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
@@ -29817,13 +29964,10 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "rRB" = (
 /obj/structure/stairs{
@@ -29838,8 +29982,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
 /area/rogue/indoors/town)
 "rSc" = (
 /obj/structure/long_sleep,
@@ -29848,10 +29996,6 @@
 "rSg" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -29941,19 +30085,21 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"rUf" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -29971,6 +30117,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"rUQ" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "rVl" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "TeleportOut";
@@ -30113,18 +30266,6 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"rZn" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rZs" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -30148,6 +30289,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"rZP" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "rZU" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -30158,6 +30303,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"rZV" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rZY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -30178,10 +30327,25 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"saT" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "saW" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
+"sbp" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sby" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/herringbone,
@@ -30191,20 +30355,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30285,6 +30439,22 @@
 /obj/structure/statue/saints/magelady2_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"sdN" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sdR" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair/wood/rogue{
@@ -30310,22 +30480,19 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"sep" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "sey" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/turf/closed/wall/mineral/rogue/wood,
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "seR" = (
 /obj/structure/crabnest,
@@ -30525,6 +30692,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"slH" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "slS" = (
 /obj/item/clothing/shoes/roguetown/boots/armoriron,
 /turf/open/floor/rogue/dirt/road{
@@ -30561,11 +30732,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"smn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "smt" = (
 /obj/item/grown/log/tree/small,
 /obj/structure/fluff/railing/wood,
@@ -30625,6 +30791,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"soa" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "soi" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -30676,20 +30846,20 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"spD" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "spJ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"spM" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "spP" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
@@ -30823,10 +30993,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"suC" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "suG" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors/town)
@@ -30841,9 +31007,13 @@
 	},
 /area/rogue/outdoors/beach)
 "suN" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/church/chapel)
+"suQ" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "suY" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -30852,13 +31022,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"svd" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"svu" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "svx" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -30898,15 +31068,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
-"swT" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"swU" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
 "swX" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/cobblerock,
@@ -30922,17 +31083,10 @@
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"sxJ" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "sxM" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -30962,6 +31116,16 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
+/area/rogue/indoors/town)
+"syB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
+"syH" = (
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "syL" = (
 /obj/structure/chair/bench,
@@ -31213,6 +31377,16 @@
 "sIl" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"sIu" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sIy" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
@@ -31221,15 +31395,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
+/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/rtfield)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -31260,16 +31428,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"sKt" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "sKL" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -31301,13 +31459,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"sLu" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31345,6 +31496,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"sNU" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "sNY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -31369,12 +31528,6 @@
 "sPu" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"sPD" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sPH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -31392,21 +31545,6 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"sPR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "sPZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -31421,17 +31559,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"sQD" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
+"sRu" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "sRD" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -31448,14 +31585,6 @@
 /obj/item/reagent_containers/powder,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
-"sSu" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "sSC" = (
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -31546,11 +31675,29 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sUJ" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "sUQ" = (
 /obj/structure/table/church/m,
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"sUU" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "sUV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grass,
@@ -31581,10 +31728,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"sWc" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
@@ -31601,10 +31744,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"sWX" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "sXa" = (
 /obj/effect/landmark/start/hand{
 	dir = 8
@@ -31667,14 +31806,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"sZw" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -31689,8 +31820,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -31866,9 +31997,9 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -31906,6 +32037,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"thU" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "til" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/tile,
@@ -31927,9 +32064,13 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -31971,12 +32112,6 @@
 /obj/item/rogueweapon/flail/sflail,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"tkn" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tkq" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -32043,12 +32178,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"tlQ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
+"tlP" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/garrison)
+"tlQ" = (
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "tlX" = (
 /obj/structure/table/wood{
@@ -32072,6 +32211,12 @@
 "tmI" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
+"tmR" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "tmW" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -32119,6 +32264,15 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"tnB" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "tnQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32131,14 +32285,6 @@
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
-"tpi" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32184,10 +32330,6 @@
 /obj/structure/roguemachine/money/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"tro" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "trv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "royal";
@@ -32226,13 +32368,6 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"tsI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32253,6 +32388,9 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ttR" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -32274,6 +32412,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"tuE" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tuJ" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -32387,10 +32535,17 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"txm" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"txs" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "txC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -32404,24 +32559,10 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"txD" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "txR" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"tyd" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "tyl" = (
 /obj/structure/dye_bin,
 /turf/open/floor/rogue/ruinedwood,
@@ -32504,6 +32645,12 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"tAc" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "tAf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -32536,13 +32683,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tAL" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "tAN" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/blocks,
@@ -32562,21 +32702,11 @@
 /obj/item/clothing/cloak/tabard/knight/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"tBm" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "tBA" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"tBC" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "tBH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 8
@@ -32646,23 +32776,12 @@
 /obj/structure/mineral_door/secret/vault,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"tDc" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
 "tDf" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/outdoors/town/roofs)
 "tDl" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/under/town/basement)
-"tDm" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "tDo" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -32675,30 +32794,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"tDE" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "tDJ" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -32707,6 +32802,22 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"tDK" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"tDO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"tEg" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tEs" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -32834,13 +32945,6 @@
 /obj/item/roguegem/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"tIc" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "tIi" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -32878,9 +32982,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -32893,6 +32999,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"tKx" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tKE" = (
 /obj/structure/bars/pipe{
 	dir = 5
@@ -32908,16 +33018,17 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"tLe" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "tLm" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"tLq" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -32952,6 +33063,16 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"tMO" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tMZ" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/dirt/road{
@@ -33033,6 +33154,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tOW" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "tOZ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt/road{
@@ -33055,12 +33182,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"tQZ" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33073,12 +33194,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"tRt" = (
-/obj/structure/stairs{
-	dir = 4
+"tRG" = (
+/obj/machinery/anvil{
+	pixel_x = -1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "tRV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -33099,10 +33220,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"tSM" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
 "tTb" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0;
@@ -33143,14 +33260,12 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/cave)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
@@ -33159,15 +33274,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "tUT" = (
 /obj/structure/closet/crate/chest,
@@ -33249,15 +33361,9 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"tYe" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+"tYk" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "tYm" = (
 /turf/open/transparent/openspace,
@@ -33315,21 +33421,12 @@
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"uac" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "uaj" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -33530,6 +33627,16 @@
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"uiO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "uiQ" = (
 /obj/structure/fluff/walldeco/rpainting/crown,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -33552,29 +33659,9 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"ujy" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ujO" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
-"ujT" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"ujU" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "ujX" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -33591,6 +33678,20 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"ukj" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"ukm" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ukv" = (
 /obj/item/roguebin/crackers,
 /obj/item/storage/foodbag/hardtack,
@@ -33638,6 +33739,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"umA" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "umH" = (
 /obj/structure/bars/pipe{
 	dir = 5
@@ -33672,12 +33777,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"uoi" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "uot" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -33749,10 +33848,6 @@
 "uqe" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"uqf" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "uqs" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -33777,19 +33872,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"urG" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -33843,16 +33927,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"usp" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "ust" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/tribalfort)
@@ -33867,6 +33941,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"usK" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "usR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobble,
@@ -33913,6 +33993,20 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"utQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"utS" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uuq" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
@@ -33953,21 +34047,13 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
-"uvj" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uvu" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -33983,11 +34069,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
 "uwa" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34036,25 +34119,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -34079,6 +34153,15 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
+"uyA" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uyE" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
@@ -34098,17 +34181,27 @@
 "uzx" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/warehouse)
+"uzR" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uzS" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34196,6 +34289,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"uBQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "uCF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -34227,12 +34327,18 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -34243,14 +34349,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"uDD" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
 "uDM" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -34261,12 +34359,9 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"uEk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
+"uEq" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "uEG" = (
 /obj/machinery/light/rogue/torchholder{
@@ -34285,26 +34380,21 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"uFz" = (
-/obj/structure/gate/bars{
-	gid = "viking1";
-	redstone_id = "viking1"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -34314,6 +34404,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uFN" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uGc" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -34383,12 +34477,15 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"uHk" = (
-/turf/open/floor/rogue/wood,
+/obj/effect/landmark/start/templar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
+"uHk" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -34398,6 +34495,12 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"uIc" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "uIk" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
@@ -34412,6 +34515,16 @@
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
+"uJM" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"uJV" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -34424,10 +34537,6 @@
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
-"uKJ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "uKK" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -34510,13 +34619,6 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"uMi" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "uMA" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow/lit,
@@ -34528,6 +34630,11 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"uNa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uNf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -34549,6 +34656,28 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"uOs" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
+"uOz" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -34596,6 +34725,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"uPw" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uPB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34658,14 +34794,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"uRy" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -34687,14 +34815,20 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"uSF" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "uSS" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"uTd" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uTf" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -34711,12 +34845,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"uTo" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "uTH" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -34768,6 +34896,11 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uVd" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -34795,12 +34928,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"uVR" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "uVU" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
@@ -34922,7 +35049,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/turf/open/floor/rogue/hexstone,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
@@ -34976,6 +35107,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"vbx" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "vbC" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -35011,14 +35148,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"vcF" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -35058,13 +35187,6 @@
 "veg" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
-"veo" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "vey" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/oat,
@@ -35087,6 +35209,14 @@
 /obj/item/reagent_containers/food/snacks/grown/oat,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"vez" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "veC" = (
 /obj/structure/plasticflaps,
 /turf/open/water/cleanshallow,
@@ -35112,30 +35242,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
-"vfg" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35159,11 +35271,6 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomright,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"vfT" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vfV" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -35173,11 +35280,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vgy" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "vgz" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -35197,21 +35299,16 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vhe" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "vhg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors)
-"vhx" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vhA" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -35262,17 +35359,36 @@
 "viq" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
+"viw" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "viI" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -35322,19 +35438,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"vlp" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "vlK" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
@@ -35357,17 +35460,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"vmi" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
+"vmp" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "vmx" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -35405,21 +35503,18 @@
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
-"vnH" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vnK" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"vnR" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vnX" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
@@ -35435,10 +35530,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/tomb)
-"voh" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "voi" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -35458,16 +35549,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -35499,13 +35583,6 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
-"vpZ" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "vqc" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -35572,14 +35649,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35618,16 +35693,6 @@
 "vtw" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church/chapel)
-"vtB" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "vtE" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/item/grown/log/tree/small,
@@ -35639,6 +35704,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"vua" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vuh" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -35653,6 +35726,12 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"vum" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "vup" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -35740,11 +35819,6 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
-"vwm" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "vwJ" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
@@ -35786,6 +35860,10 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"vyk" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -35843,6 +35921,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"vzG" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"vzO" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "vzR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -35869,6 +35957,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town)
+"vAn" = (
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "vAB" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -35903,6 +35995,25 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"vAY" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -35967,6 +36078,14 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"vDn" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4"
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "vDp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -36061,11 +36180,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
@@ -36085,21 +36206,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/chapel)
 "vGQ" = (
-/obj/machinery/light/rogue/forge{
-	pixel_x = -1
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vGT" = (
 /obj/structure/spacevine,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -36110,19 +36226,23 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
-"vHi" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"vHr" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vIa" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
@@ -36174,15 +36294,6 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"vKP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "vKQ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -36193,7 +36304,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "vLD" = (
@@ -36271,6 +36385,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"vNE" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "vOa" = (
 /obj/structure/stairs{
 	dir = 8
@@ -36303,14 +36423,8 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -36352,11 +36466,10 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36447,14 +36560,11 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"vTy" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+"vTG" = (
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "vTK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
@@ -36465,14 +36575,8 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -36482,15 +36586,6 @@
 "vUT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"vUV" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "vUX" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/shop)
@@ -36498,6 +36593,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vVo" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "vVG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -36510,12 +36609,6 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"vVX" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "vWa" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -36564,12 +36657,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -36582,10 +36671,6 @@
 	icon_state = "paving"
 	},
 /area/rogue/outdoors/town)
-"vXE" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "vXF" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -36629,14 +36714,13 @@
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"vZt" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
+"vZi" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
 	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "vZv" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/chaincoif,
@@ -36673,16 +36757,25 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"wae" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wan" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
-"waz" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "waE" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"waG" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "waI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -36721,17 +36814,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"wbx" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
-"wbF" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -36757,6 +36839,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"wdp" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wdJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
@@ -36835,12 +36923,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36867,11 +36950,6 @@
 "whb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
-"whe" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "whx" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -36891,6 +36969,12 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
+"wis" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -36918,6 +37002,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wkz" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
@@ -36927,10 +37017,6 @@
 "wlq" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
-"wlC" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "wlD" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
@@ -36951,29 +37037,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town)
-"wlO" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "wlU" = (
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"wlY" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wmj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -37026,16 +37095,17 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "wou" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37063,9 +37133,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
@@ -37115,36 +37184,21 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"wqU" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "wra" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
-"wru" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "wsR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37209,6 +37263,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"wvt" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "wvy" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -37251,6 +37309,19 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"wwK" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -37272,22 +37343,9 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"wxY" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "wxZ" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"wyq" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "wyr" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -37297,9 +37355,9 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -37312,14 +37370,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"wza" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+"wzk" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -37327,12 +37381,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"wzC" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "wzL" = (
 /obj/structure/fluff/railing/fence,
 /obj/structure/fluff/railing/fence{
@@ -37347,13 +37395,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
-"wzZ" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -37433,6 +37474,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"wCy" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "wCB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/rogue,
@@ -37483,20 +37531,23 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37517,10 +37568,6 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
-"wEL" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "wER" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -37542,8 +37589,24 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
+"wFy" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -37612,14 +37675,16 @@
 	dir = 4
 	},
 /area/rogue/outdoors/bog)
-"wIH" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
-"wIU" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+"wID" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wJm" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/dirt/road{
@@ -37671,13 +37736,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"wKi" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "wKl" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
@@ -37719,15 +37777,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"wLx" = (
-/turf/open/water/swamp,
-/area/rogue/outdoors/bog)
-"wLB" = (
+"wLf" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"wLx" = (
+/turf/open/water/swamp,
+/area/rogue/outdoors/bog)
 "wLL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -37745,6 +37806,16 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wLQ" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"wLX" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -37761,12 +37832,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
-"wMm" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "wMn" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/shirt/undershirt/random,
@@ -37786,10 +37851,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"wMG" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "wNb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bog)
@@ -37811,13 +37872,6 @@
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"wNW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "wOm" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/ruinedwood,
@@ -37825,16 +37879,6 @@
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
-"wOG" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -37870,10 +37914,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"wPo" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wPt" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw"
@@ -37902,6 +37942,16 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
+"wPQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "wPU" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/woodturned,
@@ -37935,10 +37985,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
-"wQC" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "wQD" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -37959,21 +38005,16 @@
 /obj/structure/roguemachine/vendor,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/shop)
-"wQW" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "wQY" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wRi" = (
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "wRy" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -37992,32 +38033,46 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "wSJ" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"wSN" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
 "wSO" = (
 /turf/open/floor/rogue/blocks{
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
+"wSS" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wSU" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -38039,24 +38094,18 @@
 "wTU" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
-"wUh" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "wUw" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38086,6 +38135,22 @@
 "wVI" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wVL" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "wWC" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -38098,19 +38163,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"wWL" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "wXf" = (
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -38160,11 +38212,23 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"wYx" = (
+/obj/structure/stairs{
+	dir = 8
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"wYz" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38174,6 +38238,10 @@
 /obj/item/rogueweapon/thresher,
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
+"wYQ" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "wYW" = (
 /obj/machinery/light/rogue/firebowl/church,
@@ -38203,14 +38271,8 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38251,9 +38313,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38283,6 +38346,22 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"xcZ" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"xde" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "xdq" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
@@ -38302,14 +38381,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38337,6 +38414,16 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xfa" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "xff" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -38370,6 +38457,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"xgn" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xgo" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -38389,10 +38482,6 @@
 /obj/item/burial_shroud,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"xgG" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "xgL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -38424,20 +38513,6 @@
 "xhF" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"xhI" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "xhM" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/rtfield)
@@ -38495,13 +38570,6 @@
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"xiE" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "xiK" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/sewer,
@@ -38555,30 +38623,37 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"xjJ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "xjP" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"xkj" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
+"xkl" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xkm" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -38606,23 +38681,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"xlg" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"xli" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "xll" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobblerock,
@@ -38651,16 +38709,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"xmB" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "xna" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -38753,12 +38801,6 @@
 "xou" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"xoQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "xoR" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -38802,16 +38844,9 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -38894,6 +38929,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"xsJ" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "xtc" = (
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
@@ -38975,6 +39016,12 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
+"xuT" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "xvs" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -39024,8 +39071,13 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39061,20 +39113,6 @@
 "xxa" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/shop)
-"xxe" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "xxp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -39095,18 +39133,18 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
+"xxB" = (
+/mob/living/simple_animal/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "xxF" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"xxS" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "xxT" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/churchrough,
@@ -39145,6 +39183,13 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xyK" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xyL" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue/shelf,
@@ -39176,11 +39221,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
@@ -39239,6 +39281,13 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
+"xCo" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "xCw" = (
 /obj/item/natural/stone,
 /turf/open/water/swamp,
@@ -39322,13 +39371,6 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/beach)
-"xDd" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "xDi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
@@ -39372,20 +39414,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xEG" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xET" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39466,9 +39501,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"xHe" = (
-/turf/open/floor/rogue/carpet,
+"xGX" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"xHe" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39487,9 +39531,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
-"xHy" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "xHC" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
@@ -39501,14 +39542,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"xHV" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "xHX" = (
 /obj/effect/landmark/start/vagrant,
 /obj/structure/bed/rogue/shit{
@@ -39536,9 +39569,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "xJe" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/church/chapel)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39603,14 +39635,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"xLH" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
+"xLE" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "xLK" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -39626,15 +39656,18 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"xLO" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xLQ" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors)
-"xLV" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "xMn" = (
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/metal/barograte,
@@ -39650,6 +39683,16 @@
 "xMr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
+"xMA" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xMZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -39681,14 +39724,10 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"xOf" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+"xNQ" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xOt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -39703,6 +39742,13 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"xOC" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "xOE" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -39731,14 +39777,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xPf" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "xPu" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/herringbone,
@@ -39780,10 +39818,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"xQq" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "xQK" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -39898,9 +39932,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"xTQ" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
 "xTU" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/wood,
@@ -39924,13 +39955,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xUj" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xUl" = (
 /obj/structure/fluff/railing/border,
 /obj/effect/decal/cobbleedge{
@@ -40073,6 +40097,18 @@
 "xYz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"xYA" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xYM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -40085,18 +40121,6 @@
 /obj/item/natural/poo/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"xZj" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "xZs" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -40180,6 +40204,12 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"ybA" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ybH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/border{
@@ -40207,14 +40237,10 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -40263,12 +40289,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"yeA" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "yeF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -40322,6 +40342,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"yft" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "yfu" = (
 /obj/structure/roguemachine/merchantvend,
 /obj/structure/roguemachine/scomm,
@@ -40392,14 +40418,19 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"yih" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "yiw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -40426,21 +40457,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/stairs{
+	dir = 4
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"ykb" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "yke" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -40476,6 +40502,16 @@
 "ykt" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/rtfield)
+"ykH" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "ykQ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -40484,9 +40520,13 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"yla" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
+"yld" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "ylk" = (
 /obj/structure/bars,
@@ -184088,13 +184128,13 @@ bpD
 bpD
 bpD
 bpD
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -184490,13 +184530,13 @@ bpD
 bpD
 bpD
 bpD
-dNL
-eoz
-ifg
-ifg
-men
-eoz
-dNL
+bPv
+rGY
+xaD
+xaD
+rUr
+rGY
+bPv
 bpD
 bpD
 bpD
@@ -184892,17 +184932,17 @@ bpD
 bpD
 bpD
 bpD
-dNL
-ifg
-ifg
-men
-ifg
-wra
-dNL
-dNL
-dNL
-dNL
-dNL
+bPv
+xaD
+xaD
+rUr
+xaD
+bBs
+bPv
+bPv
+bPv
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -185294,17 +185334,17 @@ bpD
 bpD
 bpD
 bpD
-dNL
-ovj
-gfE
-ifg
-ifg
-ifg
-ifg
-ifg
-dqi
-dNL
-dNL
+bPv
+dCX
+nkv
+xaD
+xaD
+xaD
+xaD
+xaD
+jbK
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -185696,17 +185736,17 @@ bpD
 bpD
 bpD
 bpD
-dNL
-cRP
-cRP
-fJL
-tLq
-cLL
-ifg
-men
-dqi
-dNL
-dNL
+bPv
+wDZ
+wDZ
+utQ
+ybA
+xAh
+xaD
+rUr
+jbK
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -186098,17 +186138,17 @@ bpD
 bpD
 bpD
 bpD
-dNL
-bLV
-cRP
-cRP
-ujT
-wlC
-ifg
-ifg
-ifg
-lOd
-dNL
+bPv
+rhx
+wDZ
+wDZ
+gvZ
+qRm
+xaD
+xaD
+xaD
+oSH
+bPv
 bpD
 bpD
 bpD
@@ -186500,17 +186540,17 @@ bpD
 bpD
 bpD
 bpD
-dNL
-daJ
-cRP
-cRP
-kwN
-wlC
-ifg
-ifg
-ifg
-lOd
-dNL
+bPv
+nJy
+wDZ
+wDZ
+vGQ
+qRm
+xaD
+xaD
+xaD
+oSH
+bPv
 bpD
 bpD
 bpD
@@ -186902,17 +186942,17 @@ sSS
 sSS
 sSS
 sSS
-dNL
-cRP
-cRP
-cix
-ifg
-cLL
-ifg
-men
-dqi
-dNL
-dNL
+bPv
+wDZ
+wDZ
+dbB
+xaD
+xAh
+xaD
+rUr
+jbK
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -187304,17 +187344,17 @@ sSS
 sSS
 sSS
 sSS
-dNL
-eMR
-wKi
-ifg
-ifg
-ifg
-ifg
-ifg
-dqi
-dNL
-dNL
+bPv
+kqD
+dTZ
+xaD
+xaD
+xaD
+xaD
+xaD
+jbK
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -187706,17 +187746,17 @@ sSS
 sSS
 sSS
 sSS
-dNL
-ifg
-ifg
-ifg
-ifg
-wra
-dNL
-dNL
-dNL
-dNL
-dNL
+bPv
+xaD
+xaD
+xaD
+xaD
+bBs
+bPv
+bPv
+bPv
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -188108,13 +188148,13 @@ sSS
 sSS
 sSS
 sSS
-dNL
-eoz
-ifg
-men
-men
-eoz
-dNL
+bPv
+rGY
+xaD
+rUr
+rUr
+rGY
+bPv
 bpD
 bpD
 bpD
@@ -188510,13 +188550,13 @@ sSS
 sSS
 sSS
 sSS
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
 bpD
 bpD
 bpD
@@ -227475,7 +227515,7 @@ acD
 acD
 fhw
 acD
-oud
+aPR
 acD
 acD
 acD
@@ -227878,8 +227918,8 @@ acD
 acD
 acD
 vuH
-vjs
-xAh
+dbH
+tUp
 acD
 azH
 azH
@@ -228277,7 +228317,7 @@ vRu
 vRu
 acD
 qgC
-xAh
+tUp
 qgC
 vuH
 qgC
@@ -228678,12 +228718,12 @@ vRu
 vRu
 vRu
 acD
-xAh
+tUp
 qgC
-vjs
+dbH
 vuH
-vjs
-xAh
+dbH
+tUp
 acD
 qgC
 qgC
@@ -229081,11 +229121,11 @@ vRu
 vRu
 acD
 qgC
-xAh
+tUp
 qgC
 vuH
-vjs
-xAh
+dbH
+tUp
 acD
 qgC
 qgC
@@ -229482,12 +229522,12 @@ vRu
 vRu
 vRu
 acD
-xAh
+tUp
 qgC
 qgC
 vuH
-vjs
-xAh
+dbH
+tUp
 acD
 qgC
 qgC
@@ -229886,9 +229926,9 @@ vRu
 acD
 qgC
 qgC
-gXa
+sRu
 vuH
-vjs
+dbH
 qgC
 acD
 vRu
@@ -230289,7 +230329,7 @@ acD
 acD
 acD
 acD
-nqe
+rnv
 acD
 acD
 acD
@@ -231090,12 +231130,12 @@ vRu
 vRu
 acD
 qgC
-xAh
-ikk
+tUp
+abZ
 vuH
 ffw
 qgC
-xAh
+tUp
 acD
 vRu
 vRu
@@ -231493,7 +231533,7 @@ vRu
 acD
 qgC
 qgC
-ikk
+abZ
 qgC
 vuH
 vuH
@@ -231894,9 +231934,9 @@ vRu
 vRu
 acD
 qgC
-xAh
+tUp
 qgC
-ikk
+abZ
 vuH
 vuH
 qgC
@@ -232698,9 +232738,9 @@ vRu
 vRu
 acD
 qgC
-wEL
+nTR
 qgC
-wEL
+nTR
 ffw
 vuH
 qgC
@@ -233101,11 +233141,11 @@ vRu
 acD
 qgC
 vRu
-ikk
+abZ
 vuH
 vuH
 vuH
-xAh
+tUp
 acD
 vRu
 vRu
@@ -233505,8 +233545,8 @@ acD
 acD
 acD
 acD
-vwm
-uqf
+qCT
+oMa
 acD
 acD
 vRu
@@ -280574,12 +280614,12 @@ hcW
 hcW
 hcW
 cWT
-xTQ
-xTQ
-xTQ
-xTQ
-xTQ
-xTQ
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
 uSw
 uSw
 uSw
@@ -280599,36 +280639,36 @@ uSw
 uSw
 uSw
 uSw
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-hcW
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+cWT
 hcW
 hcW
 hcW
@@ -280975,12 +281015,12 @@ uaL
 uaL
 uaL
 uaL
-dAf
-mQr
-qaq
+uwa
+vPA
+pgW
 mwq
 mwq
-urG
+cjJ
 nrw
 nrw
 nrw
@@ -281010,27 +281050,27 @@ ykt
 ykt
 ykt
 ykt
-fxx
-fxx
-fxx
-fxx
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
+uwa
 kVc
 kVc
 kVc
-dAf
-kVc
-kVc
-wSn
-wSn
-wSn
-hcW
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+cWT
 hcW
 hcW
 hcW
@@ -281377,62 +281417,62 @@ wSn
 wSn
 uaL
 uaL
-dAf
-mQr
-wyA
+uwa
+vPA
+njm
 mwq
 mwq
 mwq
 nrw
 nrw
-tyd
-fDB
-fDB
-rRD
-rRD
-vfT
+spM
+tlQ
+tlQ
+obq
+obq
+tDK
 nrw
 kzQ
-kFh
-kFh
-kFh
+bqt
+bqt
+bqt
 kzQ
-tUR
-ogC
-ogC
-wQW
-rMj
+bLe
+xbW
+xbW
+eMC
+rlz
 nrw
 mwq
 mwq
-fIB
+itC
 uaL
-oYd
+xxB
 paf
 qvR
 qvR
-bPv
-fxx
-fxx
-fxx
-fxx
-fxx
-dAf
+sIE
+uaL
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
-dAf
-kVc
-kVc
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-wSn
-wSn
-wSn
-wSn
-wSn
-hcW
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+cWT
 hcW
 hcW
 hcW
@@ -281779,66 +281819,66 @@ wSn
 wSn
 tzK
 uaL
-dAf
-mQr
-iaM
+uwa
+vPA
+wae
 mwq
 mwq
-wxY
+hNB
 nrw
 nrw
-wlY
-fDB
-mQA
-bCb
-bCb
-bCb
+kcu
+tlQ
+mjP
+mVz
+mVz
+mVz
 nrw
 jlO
-kFh
-xiE
-kFh
+bqt
+kQu
+bqt
 jlO
-tUR
-ogC
-ogC
-lyW
-vGN
+bLe
+xbW
+xbW
+iGx
+aem
 nrw
 mwq
 mwq
-fIB
+itC
 uaL
-oYd
+xxB
 paf
 qvR
 qvR
-bPv
-fxx
-fxx
-fxx
-fxx
-fxx
-dAf
-dAf
+sIE
+uaL
+uaL
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-kVc
-dAf
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-hcW
-hcW
-hcW
-hcW
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+cWT
+cWT
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -282181,66 +282221,66 @@ wSn
 uaL
 uaL
 uaL
-dAf
-mQr
-dbH
+uwa
+vPA
+suQ
 mwq
 mwq
-wxY
+hNB
 nrw
 nrw
-jwj
-fDB
-fDB
-fDB
-fDB
-fDB
-rUr
+svu
+tlQ
+tlQ
+tlQ
+tlQ
+tlQ
+cwd
 jlO
-kFh
-iEd
-wbF
+bqt
+jJg
+eSH
 jlO
 evo
-hbc
-ogC
-bnU
-ogC
+rRD
+xbW
+uOs
+xbW
 nrw
 mwq
 mwq
-fIB
+itC
 uaL
 uaL
 paf
 qvR
 qvR
-bPv
+sIE
 fxx
-fxx
-fxx
-fxx
-fxx
-dAf
-dAf
+aJj
+wSn
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-kVc
-dAf
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-hcW
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+cWT
 hcW
 hcW
 hcW
@@ -282583,66 +282623,66 @@ wSn
 uaL
 uaL
 uaL
-dAf
-mQr
-mQr
-xwi
-xwi
-pYF
-mQr
+uwa
+vPA
+vPA
+dbt
+dbt
+pyT
+vPA
 nrw
-wsR
-ezc
-mQA
-fDB
-mQA
-fDB
-rUr
+sbp
+alw
+mjP
+tlQ
+mjP
+tlQ
+cwd
 jlO
-kFh
-hgt
-kFh
+bqt
+pMn
+bqt
 jlO
 nrw
-ogC
-ogC
-ogC
-ogC
-auL
+wVL
+xbW
+xbW
+xbW
+qiv
 mwq
 mwq
-fIB
+itC
 uaL
 uaL
-eza
+kwN
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
-fxx
-fxx
-fxx
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-wSn
-uaL
 wSn
 wSn
-wSn
-uaL
-wSn
-uaL
-uaL
-uaL
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -282985,68 +283025,68 @@ wSn
 wSn
 uaL
 uaL
-dAf
-mQr
-dbH
-xwi
-xwi
-pYF
-mQr
+uwa
+vPA
+suQ
+dbt
+dbt
+pyT
+vPA
 nrw
-aym
-fDB
-fDB
-wSl
-wSl
-wSl
+nBf
+tlQ
+tlQ
+hbc
+hbc
+hbc
 nrw
 jlO
-kFh
-qWc
-kFh
+bqt
+wFy
+bqt
 jlO
 nrw
-wYv
-ogC
-jWd
+eMm
+xbW
+tKx
 mwq
-auL
+qiv
 mwq
 mwq
-fIB
+itC
 ykt
 ykt
 ykt
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
-fxx
-fxx
-fxx
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-uaL
 wSn
-wSn
-wSn
-uaL
-wSn
-uaL
-uaL
-uaL
-dAf
-dAf
+aJj
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 hcW
 hcW
 uaL
@@ -283348,7 +283388,7 @@ cWT
 hcW
 hcW
 hcW
-dUX
+cJi
 wSn
 wSn
 wSn
@@ -283387,69 +283427,69 @@ uaL
 uaL
 uaL
 uaL
-dAf
-mQr
-qaq
-xwi
-xwi
-xwi
-fRO
-fDB
-fDB
-mQA
-vHi
-bCb
-bCb
-sQD
+uwa
+vPA
+pgW
+dbt
+dbt
+dbt
+nNV
+tlQ
+tlQ
+mjP
+uFN
+mVz
+mVz
+hZP
 nrw
-ajm
-kFh
-kFh
-kFh
-onl
+jwm
+bqt
+bqt
+bqt
+fmV
 nrw
-hbc
-ogC
-jWd
+rRD
+xbW
+tKx
 mwq
-auL
-qYw
+qiv
+rHj
 mwq
-fIB
+itC
 uaL
 uaL
-eza
+kwN
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
-fxx
-fxx
-fxx
-dAf
-dAf
-dAf
-kVc
-kVc
-fxx
-kVc
-kVc
-kVc
-dAf
-qvR
-uaL
-wSn
-wSn
 wSn
 uaL
-uaL
-uaL
-uaL
-uaL
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 uaL
 uaL
 wSn
@@ -283789,68 +283829,68 @@ hcW
 hcW
 uaL
 uaL
-dAf
-mQr
-wyA
-xwi
-xwi
-xwi
-mQr
+uwa
+vPA
+njm
+dbt
+dbt
+dbt
+vPA
 nrw
-rUr
-nrw
-nrw
+cwd
 nrw
 nrw
 nrw
 nrw
 nrw
-onl
-txD
+nrw
+nrw
+fmV
+vVo
 jlO
 jlO
 nrw
-eTk
+xgn
+xbW
+mwq
+puY
+nrw
 ogC
 mwq
-mwq
-nrw
-tJC
-mwq
-fIB
-qcK
+itC
+fLK
 uaL
 paf
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
-fxx
-fxx
-dAf
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-qvR
-wSn
-wSn
 wSn
 uaL
-uaL
-qvR
-qvR
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 wSn
@@ -284191,67 +284231,67 @@ hcW
 hcW
 uaL
 uaL
-dAf
-mQr
-iaM
-mXz
-xwi
-xwi
-gfg
+uwa
+vPA
+wae
+xOC
+dbt
+dbt
+rcr
 mwq
 mwq
-jhf
+syH
 mwq
 mwq
 mwq
 mwq
 mwq
 nrw
-hOS
+aCa
 nrw
 jlO
 jlO
 nrw
-cZP
-woq
+jAC
+mkj
 mwq
-jtc
+wCy
 nrw
-qYw
+rHj
 mwq
-fIB
-nfX
+itC
+tOW
 uaL
 paf
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
-fxx
-fxx
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-qvR
-wSn
-wSn
-wSn
 uaL
-pPy
-uaL
-dAf
-dAf
-dAf
+wSn
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 qvR
@@ -284593,65 +284633,65 @@ hcW
 hcW
 hcW
 uaL
-tzK
-mQr
-mQr
-mQr
-mQr
+uwa
+vPA
+vPA
+vPA
+vPA
 nrw
 nrw
 mwq
 mwq
 mwq
 mwq
-jWd
+tKx
 mwq
 mwq
 mwq
 mwq
 mwq
 nrw
-nhR
+qzJ
 nrw
 nrw
 nrw
 nrw
-sLu
+mzd
 nrw
 nrw
 mwq
 mwq
-fIB
+itC
 lsD
 lsD
-oqj
+bZo
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-kVc
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-qvR
 wSn
-wSn
-wSn
-qvR
-uaL
-uaL
-dAf
+uwa
+kVc
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
@@ -284995,65 +285035,65 @@ hcW
 hcW
 uaL
 uaL
-uaL
-qvR
-qvR
-qvR
-qvR
+uwa
+uwa
+uwa
+uwa
+uwa
 evo
 nrw
 nrw
-arv
-arv
-jEB
-wqU
-itC
-itC
-itC
-lGI
+wLX
+wLX
+nyO
+ism
+jdI
+jdI
+jdI
+fwP
 mwq
 nrw
-fDB
-gpZ
-jWX
-uvu
-voh
-qYw
-tJC
-qYw
+tlQ
+aWh
+wkz
+xET
+onQ
+rHj
+ogC
+rHj
 mwq
 mwq
-fIB
+itC
 rhD
 rhD
 rhD
 rhD
 rhD
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-kVc
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
 uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-dAf
-dAf
+uwa
+kVc
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 uaL
@@ -285401,31 +285441,31 @@ uaL
 uaL
 qvR
 qvR
-qvR
+uwa
 evo
-bMt
-tJC
+jzM
+ogC
 cbG
 cbG
-vfg
-lGI
-gPt
-wzZ
-xHV
-lGI
-jWd
+vjs
+fwP
+sNU
+vZi
+jKP
+fwP
+tKx
 nrw
-fDB
-iWj
-fDB
-nhR
+tlQ
+lSj
+tlQ
+qzJ
 mwq
 mwq
-qYw
+rHj
 mwq
 mwq
 mwq
-xxS
+usK
 fxx
 fxx
 fxx
@@ -285436,26 +285476,26 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-kVc
-dAf
-kVc
-kVc
-dAf
-kVc
-kVc
-kVc
-dAf
-qvR
+aJj
 wSn
-wSn
-wSn
-wSn
-uaL
-wSn
-dAf
-dAf
+uwa
+uwa
+kVc
+kVc
+uwa
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 uaL
@@ -285803,61 +285843,61 @@ uaL
 uaL
 qvR
 qvR
-gre
+fSe
 evo
-kmo
-tJC
+nXF
+ogC
 cbG
 cbG
-jEB
-lGI
-xlg
-oGH
-dyu
-lGI
+nyO
+fwP
+nuB
+fRl
+csw
+fwP
 mwq
-vnH
-fDB
-mQA
-fDB
-nhR
-mwq
-mwq
+dTy
+tlQ
+mjP
+tlQ
+qzJ
 mwq
 mwq
 mwq
 mwq
-xxS
+mwq
+mwq
+usK
 fxx
 fxx
-kcE
-fxx
-fxx
-fxx
-fxx
-fxx
+heM
 fxx
 fxx
 fxx
 fxx
-dAf
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
+fxx
+fxx
+fxx
 uaL
 wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-dAf
-dAf
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 wSn
@@ -286205,31 +286245,31 @@ uaL
 uaL
 qvR
 qvR
-gre
+fSe
 evo
-evW
-tJC
+omn
+ogC
 cbG
 cbG
-jEB
-lGI
-aLq
-tAL
-aBA
-lGI
+nyO
+fwP
+fDR
+xCo
+gqo
+fwP
 mwq
 nrw
-wLB
-rlG
-fDB
-nhR
+lDI
+vnR
+tlQ
+qzJ
 mwq
 mwq
 mwq
 mwq
 mwq
 mwq
-xxS
+usK
 fxx
 fxx
 fxx
@@ -286240,26 +286280,26 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
+uaL
+uaL
 kVc
-dAf
-dAf
-kVc
-kVc
+uwa
+uwa
 kVc
 kVc
 kVc
-dAf
-qvR
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-dAf
-dAf
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 uaL
@@ -286571,7 +286611,7 @@ uaL
 uaL
 hcW
 hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -286607,61 +286647,61 @@ uaL
 uaL
 qvR
 qvR
-gre
+fSe
 evo
 nrw
 nrw
-aYo
-aYo
-jEB
-lGI
-tlQ
-tlQ
-tlQ
-lGI
-jWd
+wYx
+wYx
+nyO
+fwP
+viw
+viw
+viw
+fwP
+tKx
 nrw
-fnW
-tIc
-fDB
-uvu
+yih
+ntl
+tlQ
+xET
 mwq
 mwq
-qYw
+rHj
 mwq
 mwq
 mwq
-fIB
+itC
 rhD
 rhD
 rhD
 rhD
 rhD
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
+aJj
 kVc
-dAf
-dAf
-dAf
-kVc
-kVc
+uwa
+uwa
+uwa
 kVc
 kVc
-dAf
-qvR
-qvR
-wSn
-wSn
-wSn
-qvR
-dAf
-dAf
-dAf
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 uaL
@@ -287009,14 +287049,14 @@ uaL
 uaL
 qvR
 qvR
-qvR
+uwa
 evo
 nrw
 mwq
 mwq
 mwq
 mwq
-jWd
+tKx
 mwq
 mwq
 mwq
@@ -287025,45 +287065,45 @@ mwq
 nrw
 nrw
 nrw
-blx
+cld
 nrw
-voh
-qYw
-tJC
-qYw
+onQ
+rHj
+ogC
+rHj
 mwq
 mwq
-fIB
-vpZ
+itC
+nes
 qvR
 qvR
 qvR
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-kVc
-dAf
-dAf
-dAf
-kVc
-kVc
-dAf
-kVc
-dAf
-qvR
-qvR
-wSn
-wSn
-wSn
 uaL
-dAf
+aJj
+uwa
+uwa
+uwa
 kVc
-dAf
+kVc
+uwa
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+kVc
+uwa
 kVc
 qvR
 qvR
@@ -287411,61 +287451,61 @@ uaL
 uaL
 uaL
 qvR
-qvR
+uwa
 evo
 nrw
-qrI
+oQD
 mwq
-fvP
-mwq
-mwq
+ema
 mwq
 mwq
 mwq
-nrw
-nrw
-nrw
-nrw
-lbA
-fDB
-nrw
-nrw
-ykb
-nrw
-nrw
-qYw
 mwq
-fIB
+mwq
+nrw
+nrw
+nrw
+nrw
+sxM
+tlQ
+nrw
+nrw
+eda
+nrw
+nrw
+rHj
+mwq
+itC
 uaL
 uaL
 uaL
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-dAf
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-qvR
 wSn
-wSn
-wSn
-qvR
-dAf
-dAf
-dAf
+aJj
+uwa
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 wSn
@@ -287782,7 +287822,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -287811,9 +287851,9 @@ uaL
 uaL
 uaL
 hcW
-uaL
-qvR
-qvR
+uwa
+uwa
+uwa
 evo
 nrw
 nrw
@@ -287825,47 +287865,47 @@ nrw
 nrw
 nrw
 nrw
-uEX
-uEX
+dcq
+dcq
 nrw
-lbA
-fDB
-lbA
-niJ
-nux
-rRD
+sxM
+tlQ
+sxM
+cJR
+kqO
+obq
 nrw
-tJC
+ogC
 mwq
-fIB
+itC
 uaL
 uaL
 uaL
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-kVc
-dAf
-dAf
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-vRq
 wSn
-wSn
-wSn
-qvR
-dAf
+aJj
+kVc
+uwa
+uwa
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+eHF
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
@@ -288214,60 +288254,60 @@ hcW
 hcW
 hcW
 hcW
-hcW
-xTQ
-xTQ
-xTQ
-xTQ
-lbA
-lbA
-lbA
-uEX
-uEX
-lbA
-lbA
-lbA
-fDB
-qKU
+cWT
+yiI
+yiI
+yiI
+yiI
+sxM
+sxM
+sxM
+dcq
+dcq
+sxM
+sxM
+sxM
+tlQ
+cMs
 nrw
-aHI
-fDB
-mQA
-fDB
-iWj
-fDB
-aHA
-qYw
+gOu
+tlQ
+mjP
+tlQ
+lSj
+tlQ
+aym
+rHj
 mwq
-fIB
+itC
 qvR
 qvR
 qvR
 qvR
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-kVc
-dAf
-kVc
-dAf
-kVc
-kVc
-kVc
-dAf
-wSn
-qvR
 wSn
 wSn
-wSn
-uaL
-dAf
+kVc
+uwa
+kVc
+uwa
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
@@ -288614,63 +288654,63 @@ hcW
 hcW
 hcW
 hcW
+kFh
 hcW
-hcW
-hcW
-xTQ
+cWT
+yiI
 iJR
-swU
-iGg
-fDB
-mdB
-qKU
-qKU
-mdB
-mdB
-qKU
-mdB
-mdB
-fDB
-kmo
-nux
-fDB
-fDB
-fDB
-mQA
-fDB
-uvu
+soa
+cCS
+tlQ
+sbF
+cMs
+cMs
+sbF
+sbF
+cMs
+sbF
+sbF
+tlQ
+nXF
+kqO
+tlQ
+tlQ
+tlQ
+mjP
+tlQ
+xET
 mwq
 mwq
-fIB
+itC
 uaL
 uaL
 uaL
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-kVc
-dAf
-wSn
-oZH
 wSn
 wSn
-wSn
-qvR
-dAf
-dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 lyL
@@ -288980,6 +289020,22 @@ uaL
 uaL
 hcW
 hcW
+kFh
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+kFh
+hcW
+hcW
+kFh
+hcW
+hcW
+hcW
+hcW
+kFh
 hcW
 hcW
 hcW
@@ -288991,88 +289047,72 @@ hcW
 hcW
 hcW
 hcW
+kFh
+hcW
+hcW
+hcW
+kFh
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-xTQ
+cWT
+yiI
 iJR
-hsa
-iGg
-fDB
-mdB
-smn
-mpQ
-mdB
-qKU
-smn
-qKU
-qKU
-mQA
+vhe
+cCS
+tlQ
+sbF
+uNa
+hvB
+sbF
+cMs
+uNa
+cMs
+cMs
+mjP
 nrw
-fDB
-fDB
-wSl
-wSl
-fDB
-fDB
-uvu
+tlQ
+tlQ
+hbc
+hbc
+tlQ
+tlQ
+xET
 mwq
 mwq
-fIB
+itC
 uaL
 uaL
 uaL
 uaL
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-dAf
-kVc
-kVc
-kVc
-dAf
-kVc
-kVc
-dAf
-qvR
-qvR
+uaL
 wSn
-wSn
-wSn
-qvR
-dAf
-dAf
+uwa
+kVc
+kVc
+kVc
+uwa
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 qvR
@@ -289416,65 +289456,65 @@ hcW
 hcW
 hcW
 hcW
+kFh
 hcW
 hcW
 hcW
-hcW
-hcW
-xTQ
-xTQ
-xTQ
-xTQ
-lbA
-lbA
-lbA
-lOh
-lOh
-lbA
-lbA
-lbA
-qKU
-fDB
-lNn
-fDB
-fDB
-uvj
-wPo
-wTs
-lbA
+cWT
+yiI
+yiI
+yiI
+yiI
+sxM
+sxM
+sxM
+hKN
+hKN
+sxM
+sxM
+sxM
+cMs
+tlQ
+cPr
+tlQ
+tlQ
+tUR
+eoz
+uxV
+sxM
 nrw
 mwq
 mwq
-fIB
-bEu
+itC
+fRp
 qvR
 qvR
 qvR
 qvR
-bPv
+sIE
 fxx
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-dAf
-kVc
-dAf
-kVc
-kVc
-kVc
-kVc
-dAf
-qvR
-qvR
 wSn
-wSn
-wSn
-qvR
-dAf
-dAf
+uwa
+kVc
+uwa
+kVc
+kVc
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 qvR
@@ -289811,6 +289851,7 @@ hcW
 hcW
 hcW
 hcW
+kFh
 hcW
 hcW
 hcW
@@ -289821,12 +289862,11 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-xTQ
+cWT
+cWT
+cWT
+cWT
+yiI
 nrw
 nrw
 nrw
@@ -289860,23 +289900,23 @@ fxx
 fxx
 fxx
 fxx
-fxx
+uaL
 kVc
 kVc
-dAf
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-qvR
-qvR
-wSn
-wSn
-wSn
-xis
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 uaL
@@ -290195,6 +290235,7 @@ qvR
 uaL
 uaL
 hcW
+kFh
 hcW
 hcW
 hcW
@@ -290212,6 +290253,14 @@ hcW
 hcW
 hcW
 hcW
+kFh
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+kFh
 hcW
 hcW
 hcW
@@ -290219,20 +290268,11 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-dTa
-dTa
-dTa
-dTa
+cWT
+fSe
+fSe
+vWY
+vWY
 evo
 ykt
 ykt
@@ -290262,22 +290302,22 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
+uaL
+aJj
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-qvR
-qvR
-wSn
-wSn
-wSn
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 qvR
@@ -290598,7 +290638,7 @@ qvR
 qvR
 hcW
 hcW
-hcW
+kFh
 hcW
 kYc
 kYS
@@ -290607,6 +290647,7 @@ mzx
 kYc
 mzx
 hcW
+kFh
 hcW
 hcW
 hcW
@@ -290630,9 +290671,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-dTa
-dTa
+vWY
+fSe
 evo
 evo
 evo
@@ -290664,22 +290704,22 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-dAf
-fxx
+uaL
+uaL
+uaL
+uwa
+uaL
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 qvR
@@ -291012,6 +291052,16 @@ hcW
 hcW
 hcW
 hcW
+kFh
+hcW
+hcW
+hcW
+kFh
+hcW
+hcW
+hcW
+hcW
+kFh
 hcW
 hcW
 hcW
@@ -291024,17 +291074,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 hLK
 vra
 fxx
@@ -291064,14 +291104,14 @@ fxx
 fxx
 fxx
 fxx
+rZt
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+uaL
+uaL
+aJj
+uaL
+fTe
 kVc
 ykt
 xKz
@@ -291412,6 +291452,18 @@ msk
 ntQ
 hcW
 hcW
+kFh
+hcW
+hcW
+hcW
+hcW
+hcW
+kFh
+hcW
+hcW
+hcW
+hcW
+kFh
 hcW
 hcW
 hcW
@@ -291424,19 +291476,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 hLK
 vra
 fxx
@@ -291471,18 +291511,18 @@ fxx
 fxx
 fxx
 fxx
+uaL
+uaL
+uaL
 fxx
 fxx
-fxx
-fxx
-fxx
-xDd
-wUw
-wUw
-wUw
-wUw
-wUw
-xDd
+xcZ
+gip
+gip
+gip
+gip
+gip
+xcZ
 wSn
 uaL
 uaL
@@ -291803,7 +291843,7 @@ sJZ
 sJZ
 qvR
 hcW
-hcW
+kFh
 hcW
 hcW
 ldI
@@ -291838,7 +291878,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+cWT
 lcg
 bdN
 oZE
@@ -291878,13 +291918,13 @@ fxx
 fxx
 fxx
 fxx
-hMZ
+elx
 peN
 peN
 peN
 peN
 peN
-buQ
+axV
 fxx
 fxx
 fxx
@@ -292193,7 +292233,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+kFh
 hcW
 hcW
 qvR
@@ -292225,6 +292265,13 @@ hcW
 hcW
 hcW
 hcW
+kFh
+hcW
+kFh
+hcW
+hcW
+hcW
+kFh
 hcW
 hcW
 hcW
@@ -292233,18 +292280,11 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+cWT
+cWT
+cWT
+cWT
 uaL
 ykt
 ykt
@@ -292280,13 +292320,13 @@ fxx
 fxx
 fxx
 fxx
-wUw
+gip
 peN
 peN
 peN
-dPZ
+kGp
 peN
-wUw
+gip
 fxx
 fxx
 fxx
@@ -292630,10 +292670,10 @@ hcW
 hcW
 hcW
 hcW
+kFh
+kFh
 hcW
-hcW
-hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -292654,14 +292694,14 @@ wSn
 wSn
 wSn
 xKz
-qHJ
-kvj
+lLV
+cRP
 lLa
 xKz
 xKz
-lgX
-dyi
-vUV
+dad
+dAf
+kal
 xKz
 jeb
 jeb
@@ -293027,8 +293067,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+kFh
+kFh
 hcW
 hcW
 hcW
@@ -293056,18 +293096,18 @@ wSn
 wSn
 wSn
 xKz
-yiI
+ltl
 iYQ
 fVQ
-uDi
+qYw
 qpt
 sDa
 peN
 kIf
-emT
-uDi
+lvj
+qYw
 fVQ
-xjJ
+jKi
 xKz
 qvR
 qvR
@@ -293084,13 +293124,13 @@ wSn
 uaL
 fTe
 wSn
-niV
-wbx
-jQX
-jQX
-jQX
-wbx
-niV
+uvu
+xyK
+jHX
+jHX
+jHX
+xyK
+uvu
 uaL
 uaL
 uaL
@@ -293431,7 +293471,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -293458,18 +293498,18 @@ wSn
 wSn
 wSn
 xKz
-fNp
-kvj
+sUU
+cRP
 fVQ
 lLa
 qpt
 sDa
 peN
 kIf
-emT
+lvj
 lLa
 fVQ
-uzT
+qzb
 xKz
 qvR
 qvR
@@ -293489,7 +293529,7 @@ uaL
 xKz
 bOK
 jeb
-qDn
+xkF
 jeb
 bOK
 xKz
@@ -293826,14 +293866,14 @@ hcW
 hcW
 hcW
 hcW
+kFh
 hcW
 hcW
 hcW
 hcW
+kFh
 hcW
-hcW
-hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -293860,18 +293900,18 @@ wSn
 wSn
 wSn
 xKz
-yiI
+ltl
 iYQ
 fVQ
-kBS
+qLk
 qpt
 sDa
 peN
 kIf
-emT
+lvj
 hmU
 fVQ
-uzT
+qzb
 xKz
 qvR
 qvR
@@ -293891,7 +293931,7 @@ uaL
 bOK
 tYP
 tYP
-pcC
+kiL
 tYP
 tYP
 xKz
@@ -294204,7 +294244,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+kFh
 hcW
 qvR
 qvR
@@ -294226,7 +294266,7 @@ ndD
 kYc
 msk
 nxV
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -294262,8 +294302,8 @@ wSn
 wSn
 wSn
 xKz
-fNp
-kvj
+sUU
+cRP
 fVQ
 jeb
 jeb
@@ -294273,7 +294313,7 @@ kIf
 jeb
 jeb
 fVQ
-uzT
+qzb
 xKz
 qvR
 qvR
@@ -294290,11 +294330,11 @@ uaL
 qvR
 qvR
 uaL
-lXG
+ibw
 tYP
-veo
+vsg
 tYP
-qOe
+quu
 tYP
 xKz
 qvR
@@ -294664,18 +294704,18 @@ wSn
 wSn
 wSn
 xKz
-uaj
+uBQ
 iYQ
 fVQ
 fVQ
 jeb
-khc
+bdw
 peN
 kIf
 jeb
 fVQ
 tYP
-bmL
+wLf
 xKz
 qvR
 qvR
@@ -294693,7 +294733,7 @@ qvR
 uaL
 wSn
 xKz
-lEz
+bzl
 tYP
 tYP
 tYP
@@ -295018,7 +295058,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -295066,7 +295106,7 @@ wSn
 wSn
 wSn
 xKz
-qVz
+wis
 lLa
 fVQ
 fVQ
@@ -295077,7 +295117,7 @@ kIf
 hZF
 fVQ
 sCg
-qNR
+hOb
 xKz
 qvR
 uaL
@@ -295096,10 +295136,10 @@ uaL
 wSn
 bOK
 tYP
-mbt
+wLQ
 tYP
 sCg
-sWc
+umA
 xKz
 qvR
 qvR
@@ -295427,7 +295467,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -295468,18 +295508,18 @@ xKz
 xKz
 xKz
 xKz
-qVz
+wis
 lLa
-fVQ
-fVQ
+kMi
+bXL
 jeb
-khc
+bdw
 peN
 kIf
 jeb
 fVQ
 sCg
-qNR
+hOb
 xKz
 qvR
 uaL
@@ -295499,9 +295539,9 @@ wSn
 xKz
 xKz
 xKz
-wou
+dDc
 sCg
-qNR
+hOb
 xKz
 qvR
 qvR
@@ -295872,8 +295912,8 @@ mDY
 fVQ
 fVQ
 fVQ
-fVQ
-fVQ
+kMi
+uBQ
 jeb
 sDa
 peN
@@ -295881,7 +295921,7 @@ kIf
 jeb
 fVQ
 tYP
-qNR
+hOb
 xKz
 qvR
 qvR
@@ -295903,7 +295943,7 @@ xKz
 xKz
 tYP
 sCg
-qNR
+hOb
 xKz
 qvR
 qvR
@@ -296213,7 +296253,7 @@ hcW
 wSn
 uaL
 hcW
-hcW
+kFh
 hcW
 hcW
 hcW
@@ -296273,17 +296313,17 @@ xKz
 mDY
 fVQ
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 qpt
 sDa
 peN
 kIf
-emT
+lvj
 lLa
 fVQ
-clm
+wdp
 xKz
 qvR
 uaL
@@ -296303,9 +296343,9 @@ wSn
 xKz
 xKz
 xKz
-wou
+dDc
 sCg
-sWc
+umA
 xKz
 qvR
 uaL
@@ -296615,6 +296655,7 @@ wSn
 wSn
 uaL
 hcW
+kFh
 hcW
 hcW
 hcW
@@ -296623,8 +296664,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+kFh
 wSn
 wSn
 qvR
@@ -296671,7 +296711,7 @@ xqL
 wSn
 wSn
 xKz
-kZn
+bXL
 gqa
 fVQ
 fVQ
@@ -296682,10 +296722,10 @@ qpt
 sDa
 peN
 kIf
-emT
+lvj
 lLa
 fVQ
-qXo
+olm
 xKz
 qvR
 qvR
@@ -296705,7 +296745,7 @@ uaL
 xKz
 xKz
 xKz
-xmB
+jlY
 xKz
 xKz
 xKz
@@ -297014,19 +297054,19 @@ fyc
 cWT
 cWT
 wSn
+kFh
+kFh
+kFh
+kFh
+hcW
+kFh
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+kFh
+kFh
+kFh
+kFh
 wSn
 wSn
 qvR
@@ -297073,21 +297113,21 @@ aJj
 uaL
 qvR
 xKz
-yiI
+ltl
 iYQ
 lLa
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 qpt
 sDa
 peN
 kIf
-emT
-htf
+lvj
+vAY
 fVQ
-xEG
+aYG
 xKz
 uaL
 uaL
@@ -297416,9 +297456,9 @@ fyc
 cWT
 cWT
 uaL
-hcW
-hcW
-hcW
+kFh
+kFh
+kFh
 hcW
 hcW
 hcW
@@ -297475,18 +297515,18 @@ evo
 evo
 evo
 xKz
-uaj
-kvj
+uBQ
+cRP
 kds
-xUj
+vHr
 xKz
-kBS
+qLk
 fVQ
 xKz
+txs
+mMs
+saT
 wgn
-eAG
-iJu
-ekK
 xKz
 xKz
 xKz
@@ -297886,29 +297926,29 @@ xKz
 xKz
 xKz
 uWL
-tRt
-tRt
+vum
+vum
 xKz
 xKz
-jIP
-jIP
-cwd
-cwd
-cwd
-cwd
-cwd
-cwd
-jlY
-jlY
-cwd
-cwd
-jIP
-jIP
-jIP
-jIP
-cwd
-cwd
-cwd
+iug
+iug
+vTG
+vTG
+vTG
+vTG
+vTG
+vTG
+ezu
+ezu
+vTG
+vTG
+iug
+iug
+iug
+iug
+vTG
+vTG
+vTG
 axq
 dnx
 axl
@@ -305123,7 +305163,7 @@ xKz
 wVI
 wbg
 wbg
-qCT
+wyA
 wbg
 wbg
 wbg
@@ -305479,7 +305519,7 @@ mcK
 nBW
 mOY
 nBW
-sWX
+rZP
 nBW
 wtF
 wbg
@@ -307093,7 +307133,7 @@ wtF
 wbg
 wbg
 wbg
-qCT
+wyA
 wbg
 wbg
 wbg
@@ -309218,7 +309258,7 @@ bwS
 lVe
 hHF
 goK
-bgT
+kQC
 sux
 pYf
 pYf
@@ -310353,12 +310393,12 @@ wbg
 wbg
 wVI
 wVI
-dbt
+lMZ
 nHz
 wVI
 wVI
 wVI
-nnt
+xfa
 wVI
 wVI
 tUw
@@ -310395,7 +310435,7 @@ fxx
 fxx
 fxx
 fxx
-rch
+iSJ
 fxx
 boU
 fxx
@@ -310413,13 +310453,13 @@ qvR
 wSn
 cyr
 hHF
-fks
+bwb
 wlD
 sIG
 wlD
 wlD
 wlD
-bgT
+kQC
 wlD
 sIG
 wlD
@@ -310720,7 +310760,7 @@ wbg
 xXq
 yhZ
 yhZ
-jWZ
+wzk
 yhZ
 yhZ
 xXq
@@ -310734,7 +310774,7 @@ wbg
 wbg
 wbg
 wbg
-qCT
+wbg
 wbg
 wbg
 wbg
@@ -311133,13 +311173,13 @@ xez
 wbg
 wbg
 wbg
+wyA
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
+wyA
 wbg
 wbg
 wbg
@@ -311187,7 +311227,7 @@ fxx
 fxx
 fxx
 fxx
-rch
+iSJ
 fxx
 fxx
 fxx
@@ -311555,6 +311595,7 @@ wbg
 wbg
 wbg
 wbg
+wyA
 wbg
 wbg
 wbg
@@ -311562,8 +311603,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
-qCT
+wyA
 wbg
 wbg
 wbg
@@ -312762,17 +312802,17 @@ wbg
 wbg
 wbg
 wbg
-qzH
+rfO
 hUt
 vFj
-qzH
+rfO
 wbg
 wbg
 wbg
-qzH
+rfO
 xGM
-qzH
-adK
+rfO
+wsR
 ukb
 wvE
 rLt
@@ -312813,7 +312853,7 @@ trG
 ryI
 fZw
 fxx
-rch
+iSJ
 rhD
 qvR
 qvR
@@ -313171,10 +313211,10 @@ wew
 wxZ
 nRo
 bQf
-vKP
+bgb
 iPY
-puf
-adK
+xkj
+wsR
 ukb
 wvE
 wvE
@@ -313528,7 +313568,7 @@ aOn
 aOn
 lpa
 nCh
-qCT
+wyA
 wbg
 wbg
 hOh
@@ -313561,9 +313601,9 @@ pUl
 rJX
 tCr
 guP
-lmZ
+lhv
 guP
-tsI
+asR
 wbg
 qtV
 iPY
@@ -313573,10 +313613,10 @@ wew
 wVI
 weX
 wVI
-vKP
+bgb
 iPY
-puf
-adK
+xkj
+wsR
 xMr
 yho
 wvE
@@ -313963,7 +314003,7 @@ rJX
 eai
 tCr
 guP
-wWL
+sUJ
 guP
 iGf
 viq
@@ -313975,10 +314015,10 @@ wew
 wxZ
 wVI
 bQf
-gDl
+khc
 nXd
-jAT
-adK
+ykH
+wsR
 dHZ
 xww
 wvE
@@ -314367,20 +314407,20 @@ fQm
 guP
 guP
 guP
-mgR
+iot
 uTQ
 qtV
 nXd
 nXd
 nXd
-aWR
+jeS
 wVI
 wVI
 wVI
 wVI
 wVI
 rmJ
-adK
+wsR
 pht
 vwQ
 vwQ
@@ -314437,7 +314477,7 @@ lVe
 uxL
 sZI
 xlx
-tDc
+slH
 iTv
 cXU
 iTv
@@ -314715,7 +314755,7 @@ uOL
 jxy
 vbO
 oif
-wIU
+dWu
 oif
 uJk
 tOz
@@ -314772,16 +314812,16 @@ sxR
 sxR
 abh
 wbg
-uFp
-uFp
+iRN
+iRN
 aSH
-uFp
+iRN
 wVI
 wVI
 wVI
 wVI
 wVI
-dFU
+qzy
 oUn
 xMr
 vwQ
@@ -314824,7 +314864,7 @@ hLK
 nht
 fxx
 fxx
-uFz
+gqb
 wxd
 wSn
 wSn
@@ -315163,7 +315203,7 @@ tYm
 oAn
 wbg
 wbg
-xPf
+woq
 dTB
 tVP
 tVP
@@ -315172,7 +315212,7 @@ tCG
 tVP
 tVP
 tCG
-kkT
+oJM
 wbg
 wVI
 wVI
@@ -315574,9 +315614,9 @@ tVP
 tVP
 tVP
 tVP
-xdw
+ndE
 qtV
-aSD
+uPw
 rZY
 wVI
 wxZ
@@ -315964,21 +316004,21 @@ pAS
 sZN
 sZN
 xdq
-aok
+uHk
 wbg
 wbg
-xPf
+woq
 rJC
 tVP
-paK
+tmR
 tVP
 tVP
-dqD
+ihm
 tVP
 tVP
-xdw
+ndE
 qtV
-aSD
+uPw
 rZY
 wVI
 wxZ
@@ -315988,7 +316028,7 @@ wVI
 bQf
 wVI
 rZY
-uMi
+jvr
 kjH
 kjH
 kjH
@@ -316018,7 +316058,7 @@ vLS
 uaL
 sjP
 wSn
-fxx
+iSJ
 fxx
 lcg
 fQg
@@ -316372,17 +316412,17 @@ wbg
 wKT
 kFS
 tVP
-oyI
-jpF
-qdu
-whe
+muU
+dFg
+qRh
+nGQ
 tVP
 tCG
-xdw
+ndE
 wbg
 wbg
 wVI
-suC
+iir
 wVI
 wVI
 wVI
@@ -316718,7 +316758,7 @@ oif
 oif
 oif
 oif
-tiH
+cyy
 eUJ
 eUJ
 jxy
@@ -316768,7 +316808,7 @@ sZN
 sZN
 lzC
 xdq
-aok
+uHk
 wbg
 wbg
 wKT
@@ -316777,7 +316817,7 @@ yfY
 ijS
 mmb
 tZZ
-vGQ
+uaj
 yfY
 yfY
 wKT
@@ -316786,8 +316826,8 @@ qEa
 vXm
 vXm
 vXm
-xxe
-wyq
+gwF
+lhN
 wVI
 wVI
 wVI
@@ -317188,12 +317228,12 @@ wbg
 uqe
 ewM
 uqe
-coP
+kTw
 wew
 wVI
 wVI
 rZY
-xhI
+ikM
 rZY
 jXw
 xgi
@@ -317572,7 +317612,7 @@ pDy
 sZN
 sZN
 xdq
-aok
+uHk
 wbg
 wbg
 cCQ
@@ -317584,18 +317624,18 @@ yfY
 yfY
 yfY
 yfY
-ycz
+lQe
 wbg
-fLK
+bbG
 uqe
 uqe
 uqe
-tDm
+qFU
 wew
 weX
 wVI
 rZY
-sbF
+oBs
 rZY
 jXw
 xgi
@@ -317637,7 +317677,7 @@ gkv
 hLK
 njv
 fxx
-rch
+iSJ
 wxd
 wxd
 wSn
@@ -317943,7 +317983,7 @@ wrj
 jDm
 jDm
 mwE
-tro
+qEH
 mwE
 wbg
 wbg
@@ -317979,20 +318019,20 @@ wbg
 wbg
 cJz
 yfY
-bpA
+lhd
 kfr
-lUn
-vGQ
+tRG
+uaj
 tZZ
-xpM
-pFy
+igT
+eJX
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-tDm
+qFU
 wew
 wVI
 wVI
@@ -318376,7 +318416,7 @@ ygF
 ygF
 uDv
 xdq
-aok
+uHk
 wbg
 wbg
 wKT
@@ -318394,8 +318434,8 @@ qEa
 gGZ
 gGZ
 gGZ
-tDE
-aWR
+ovj
+jeS
 wqq
 wqq
 wqq
@@ -318782,14 +318822,14 @@ qls
 wbg
 wbg
 wKT
-jpw
-fCr
-urF
-qRm
-urF
-qRm
-urF
-qRm
+rtS
+yft
+ksK
+vQV
+ksK
+vQV
+ksK
+vQV
 wKT
 wbg
 wbg
@@ -319582,7 +319622,7 @@ pMj
 pPI
 xdq
 xdq
-aok
+uHk
 wbg
 wbg
 wKT
@@ -319600,13 +319640,13 @@ wbg
 usR
 ncb
 ncb
-tpi
+oxJ
 wbg
 wVI
 wVI
 wVI
 wVI
-uKJ
+qSx
 wVI
 wVI
 wbg
@@ -319984,18 +320024,18 @@ pOs
 pRW
 xdq
 qls
-jTZ
+bVa
 wbg
 wbg
 wKT
 wKT
 jCs
-urF
-rHj
-urF
-rHj
-urF
-rHj
+ksK
+wFp
+ksK
+wFp
+ksK
+wFp
 wKT
 wbg
 wbg
@@ -320385,7 +320425,7 @@ xdq
 xdq
 xdq
 xdq
-dKn
+xdw
 wbg
 wbg
 wbg
@@ -320403,7 +320443,7 @@ wbg
 wbg
 vAB
 bnQ
-agj
+mMb
 nWM
 wbg
 kjH
@@ -321189,7 +321229,7 @@ dCV
 csA
 dCV
 hXf
-aok
+uHk
 wbg
 wbg
 wbg
@@ -321591,7 +321631,7 @@ dCV
 dCV
 dCV
 qee
-jTZ
+bVa
 wbg
 wbg
 wbg
@@ -322397,11 +322437,11 @@ xMr
 xMr
 gGZ
 qCy
-isO
+hju
 wVI
 weX
 wVI
-spD
+nvk
 wbg
 ekQ
 qDx
@@ -322798,7 +322838,7 @@ bmi
 mgx
 xMr
 xAt
-gvi
+uiO
 wbg
 wVI
 wVI
@@ -323201,11 +323241,11 @@ oVp
 xMr
 qnO
 oZC
-ikM
+ebe
 wVI
 xbo
 wVI
-spD
+nvk
 wbg
 hOh
 qDx
@@ -323603,11 +323643,11 @@ nTe
 qhC
 wbg
 wbg
-ikM
+ebe
 wVI
 wVI
 wVI
-spD
+nvk
 wbg
 hOh
 qDx
@@ -324003,7 +324043,7 @@ oXn
 oXn
 oXn
 xMr
-vtB
+tuE
 wbg
 wbg
 wVI
@@ -324405,13 +324445,13 @@ paz
 bmi
 bmi
 xMr
-dKn
+xdw
 wbg
-isO
+hju
 wVI
 weX
 wVI
-spD
+nvk
 wbg
 lHf
 rfx
@@ -324807,7 +324847,7 @@ gVS
 gVS
 bmi
 xMr
-aok
+uHk
 wbg
 wbg
 wbg
@@ -325209,7 +325249,7 @@ poR
 pPs
 bmi
 qhR
-dKn
+xdw
 wbg
 wbg
 wbg
@@ -326013,7 +326053,7 @@ orY
 orY
 bmi
 xMr
-aok
+uHk
 wbg
 wbg
 wbg
@@ -326036,7 +326076,7 @@ ewt
 cEF
 wbg
 xll
-obE
+oVj
 aOn
 jHc
 mwE
@@ -326415,7 +326455,7 @@ bmi
 mou
 bmi
 xMr
-aok
+uHk
 wbg
 wbg
 wbg
@@ -326896,8 +326936,8 @@ wxd
 wxd
 wxd
 hcW
-hcW
-hcW
+cWT
+cWT
 tUO
 hcW
 tUO
@@ -327298,8 +327338,8 @@ wxd
 kVc
 kVc
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -327700,8 +327740,8 @@ kVc
 kVc
 kVc
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -328102,8 +328142,8 @@ kVc
 kVc
 kVc
 hcW
-hcW
-kVc
+cWT
+uwa
 hcW
 hcW
 hcW
@@ -328504,8 +328544,8 @@ kVc
 kVc
 kVc
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -328906,8 +328946,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -329308,8 +329348,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -329622,9 +329662,9 @@ xKF
 xKF
 xKF
 xKF
-xET
-hpK
-rcr
+dRp
+plJ
+ncR
 xKF
 xKF
 xKF
@@ -329710,8 +329750,8 @@ xqL
 kVc
 kVc
 kVc
-kVc
-kVc
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -330018,10 +330058,10 @@ uaL
 xAt
 xAt
 xKF
-jVi
-xHe
-xHe
-xbW
+mQA
+dIj
+dIj
+rCR
 xKF
 xKF
 eBN
@@ -330029,10 +330069,10 @@ eBN
 eBN
 mGn
 mGn
-vVX
+aha
 trI
-wDz
-wDz
+cdn
+cdn
 hcp
 tkZ
 xKF
@@ -330112,8 +330152,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -330420,10 +330460,10 @@ paf
 xAt
 xAt
 xKF
-jfQ
-xHe
-xHe
-xbW
+jqK
+dIj
+dIj
+rCR
 xKF
 xKF
 ejY
@@ -330433,9 +330473,9 @@ mGn
 mGn
 ejY
 trI
-wDz
+cdn
 rTm
-wDz
+cdn
 obL
 xKF
 vtw
@@ -330514,8 +330554,8 @@ sJZ
 wxd
 wxd
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -330822,10 +330862,10 @@ afX
 xAt
 xAt
 xKF
-vXE
-xHe
-xHe
-xbW
+nHm
+dIj
+dIj
+rCR
 xKF
 xKF
 xKF
@@ -330835,9 +330875,9 @@ xKF
 xKF
 xKF
 xKF
-wDz
-wDz
-wDz
+cdn
+cdn
+cdn
 oiC
 xKF
 vtw
@@ -330916,8 +330956,8 @@ sJZ
 sJZ
 feP
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -331224,22 +331264,22 @@ paf
 xAt
 xAt
 xKF
-mrE
-xHe
-xHe
-bhY
+fsm
+dIj
+dIj
+lhZ
 xKF
 xKF
 xKF
 xKF
-tQZ
+xuT
 ofq
 eBN
-wDz
-suN
-wDz
+cdn
+uHj
+cdn
 bok
-wDz
+cdn
 tkZ
 xKF
 vtw
@@ -331318,8 +331358,8 @@ sJZ
 sJZ
 wxd
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -331626,10 +331666,10 @@ paf
 xAt
 xAt
 xKF
-goz
-xHe
-xHe
-lWe
+utS
+dIj
+dIj
+etc
 xKF
 xKF
 iuo
@@ -331638,8 +331678,8 @@ ofq
 ofq
 eBN
 bok
-suN
-wDz
+uHj
+cdn
 nrx
 idG
 obL
@@ -331720,8 +331760,8 @@ qet
 sJZ
 wxd
 kVc
-kVc
-kVc
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -332028,10 +332068,10 @@ paf
 xAt
 xAt
 xKF
-fUW
-xHe
-tBm
-uoi
+hiA
+dIj
+eJZ
+niC
 xKF
 xKF
 iuo
@@ -332039,9 +332079,9 @@ wVy
 ofq
 ofq
 eBN
-wDz
-suN
-wDz
+cdn
+uHj
+cdn
 iIl
 xKF
 xKF
@@ -332122,8 +332162,8 @@ qet
 qet
 wxd
 kVc
-kVc
-kVc
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -332430,10 +332470,10 @@ paf
 xAt
 xAt
 xKF
-eEh
-oyU
+anR
+uZC
 xKF
-wMm
+vbx
 xKF
 xKF
 xKF
@@ -332442,8 +332482,8 @@ xKF
 ofq
 eBN
 bok
-suN
-wDz
+uHj
+cdn
 tkZ
 xKF
 vtw
@@ -332524,8 +332564,8 @@ qet
 qet
 wxd
 kVc
-kVc
-kVc
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -332831,21 +332871,21 @@ uaL
 afX
 xAt
 xAt
-oMa
+eqh
 fCM
 fCM
 cNo
 twX
 cNo
-vmi
+eIH
 eeO
-omS
+jOr
 xKF
 eBN
 eBN
-wDz
-suN
-wDz
+cdn
+uHj
+cdn
 vCr
 xKF
 vtw
@@ -332926,8 +332966,8 @@ sJZ
 sJZ
 xSK
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -333233,20 +333273,20 @@ uaL
 paf
 xAt
 xAt
-oMa
+eqh
 fCM
 fCM
 fCM
 fCM
-fVN
-wNW
+tfp
+jVO
 dsW
 sKd
 xgL
-wDz
-wDz
-wDz
-wDz
+cdn
+cdn
+cdn
+cdn
 nrx
 obL
 xKF
@@ -333328,8 +333368,8 @@ sJZ
 sJZ
 wxd
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -333636,21 +333676,21 @@ uaL
 xAt
 xAt
 xKF
-iSJ
+mrd
 iuo
 iuo
 iuo
-fVN
+tfp
 wPC
 dsW
 sKd
 xgL
-oIv
-wDz
-wDz
-wDz
-wDz
-wDz
+mdB
+cdn
+cdn
+cdn
+cdn
+cdn
 xKF
 vtw
 vWe
@@ -333730,8 +333770,8 @@ sJZ
 sJZ
 sJZ
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -333776,7 +333816,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 ovn
@@ -334038,21 +334078,21 @@ paf
 xAt
 xAt
 xKF
-uTo
-uTo
-uTo
+xsJ
+xsJ
+xsJ
 iuo
 fCM
 sKd
 sKd
 vSM
-lJr
-wDz
-wDz
+oIv
+cdn
+cdn
 wIl
 dXw
 uHg
-wDz
+cdn
 xKF
 vtw
 vWe
@@ -334063,7 +334103,7 @@ vtw
 qZh
 ltk
 mwE
-tro
+qEH
 mwE
 mwE
 aOv
@@ -334132,8 +334172,8 @@ sJZ
 sJZ
 sJZ
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -334179,7 +334219,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 ovn
@@ -334440,11 +334480,11 @@ paf
 xAt
 xAt
 xKF
-kLB
-nNy
-loE
+cly
+ljW
+ihk
 iuo
-eiY
+olW
 sKd
 sKd
 xKF
@@ -334534,14 +334574,14 @@ sJZ
 qet
 sJZ
 kVc
+cWT
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
-gdC
-gdC
-gdC
-gdC
-gdC
-gdC
-hcW
 whb
 whb
 whb
@@ -334581,7 +334621,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -334850,7 +334890,7 @@ xKF
 xKF
 xKF
 xKF
-ihj
+hmr
 eCn
 eCn
 xKF
@@ -334936,8 +334976,8 @@ sJZ
 sJZ
 sJZ
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -334985,12 +335025,12 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
 whb
-whb
-whb
+qli
 whb
 whb
 whb
@@ -335338,8 +335378,8 @@ sJZ
 qet
 sJZ
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -335389,13 +335429,13 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
-whb
-whb
-whb
-whb
+qli
+qli
+qli
 whb
 whb
 whb
@@ -335740,8 +335780,8 @@ sJZ
 sJZ
 sJZ
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -336142,8 +336182,8 @@ sJZ
 sJZ
 wxd
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -336467,7 +336507,7 @@ oOU
 smO
 buj
 smO
-vZt
+eFI
 kSh
 sKd
 uHb
@@ -336544,8 +336584,8 @@ kVc
 kVc
 wxd
 kVc
-hcW
-gdC
+cWT
+sue
 gdC
 gdC
 gdC
@@ -336946,8 +336986,8 @@ kVc
 kVc
 wxd
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -337348,8 +337388,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -337750,14 +337790,14 @@ kVc
 kVc
 kVc
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -337817,9 +337857,9 @@ whb
 whb
 whb
 whb
+qli
 whb
-whb
-whb
+qli
 dVO
 dVO
 ovn
@@ -338152,8 +338192,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -338554,8 +338594,8 @@ wxd
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -338956,14 +338996,14 @@ wxd
 wxd
 kVc
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -339022,7 +339062,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -339358,14 +339398,14 @@ wxd
 wxd
 wxd
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -339425,7 +339465,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -339760,14 +339800,14 @@ wxd
 wxd
 wxd
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -339827,7 +339867,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -340162,8 +340202,8 @@ wxd
 wxd
 wxd
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340564,8 +340604,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340630,6 +340670,10 @@ whb
 whb
 whb
 whb
+qli
+whb
+whb
+qli
 whb
 whb
 whb
@@ -340638,11 +340682,7 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+qli
 whb
 whb
 whb
@@ -340966,8 +341006,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -341034,17 +341074,17 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
+qli
 whb
+qli
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+qli
+qli
+qli
 whb
 whb
 whb
@@ -341368,8 +341408,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -341770,8 +341810,8 @@ wxd
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342172,8 +342212,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342574,8 +342614,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342976,8 +343016,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -343378,8 +343418,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -343780,8 +343820,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344182,8 +344222,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344584,8 +344624,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344986,8 +345026,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -345388,8 +345428,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -345790,8 +345830,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -346192,8 +346232,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -346594,8 +346634,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -346996,8 +347036,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -383487,31 +383527,31 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-qeY
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
+iME
+iME
+iME
+iME
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 erZ
 erZ
 erZ
@@ -383525,8 +383565,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -383889,31 +383929,31 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-qeY
-seC
+iME
+iME
+iME
+iME
+qpX
 rST
-eEY
-nBf
-nBf
+bMe
+uxZ
+uxZ
+qpX
+uxZ
+uxZ
+qpX
+dFY
+iME
+lzh
+iME
 seC
-nBf
-nBf
-seC
-bPL
-qeY
-cyK
-qeY
-irw
-qeY
-qeY
-quL
-qeY
-qeY
+iME
+iME
 vLA
-veW
+iME
+iME
+rOc
+vNE
 erZ
 erZ
 erZ
@@ -383927,8 +383967,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -384291,31 +384331,31 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-qeY
-seC
+iME
+iME
+iME
+iME
+qpX
 rST
-uDD
-nBf
-nBf
-seC
-nBf
-nBf
-seC
-bPz
-qeY
-qeY
-bPz
-seC
-qeY
-qeY
-seC
-mGL
-qeY
-eGn
-veW
+fNz
+uxZ
+uxZ
+qpX
+uxZ
+uxZ
+qpX
+vzO
+iME
+iME
+vzO
+qpX
+iME
+iME
+qpX
+rZV
+iME
+wou
+vNE
 erZ
 erZ
 erZ
@@ -384330,8 +384370,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -384693,31 +384733,31 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-qeY
-seC
-seC
-seC
-chY
-nBf
-seC
-nBf
-nBf
-seC
-rgO
-fRS
-qeY
-aPR
-seC
-fIp
-qeY
-seC
-cWr
-kpI
-txm
-veW
+iME
+iME
+iME
+iME
+qpX
+qpX
+qpX
+nGK
+uxZ
+qpX
+uxZ
+uxZ
+qpX
+qRp
+vHd
+iME
+owf
+qpX
+ifg
+iME
+qpX
+eTE
+qWg
+quL
+vNE
 erZ
 erZ
 erZ
@@ -384732,8 +384772,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -385095,47 +385135,47 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-qeY
-seC
-seC
-seC
-chY
-nBf
-seC
-nBf
-nBf
-seC
+iME
+iME
+iME
+iME
+qpX
+qpX
+qpX
+nGK
+uxZ
+qpX
+uxZ
+uxZ
+qpX
+ycz
+iME
+iME
+faD
+qpX
+iME
+iME
+qpX
+qpX
+qpX
+qpX
+qpX
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 ebb
-qeY
-qeY
-pdm
-seC
-qeY
-qeY
-seC
-seC
-seC
-seC
-seC
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-bqt
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -385497,47 +385537,47 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-qeY
-seC
-seC
-seC
-guw
-nBf
-seC
-nBf
-nBf
-seC
+iME
+iME
+iME
+iME
+qpX
+qpX
+qpX
+fYb
+uxZ
+qpX
+uxZ
+uxZ
+qpX
+ycz
+iME
+ifg
+faD
+qpX
+iME
+ifg
+qpX
+qpX
+qpX
+qpX
+qpX
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 ebb
-qeY
-fIp
-pdm
-seC
-qeY
-fIp
-seC
-seC
-seC
-seC
-seC
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-bqt
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -385556,8 +385596,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 aUc
 vIa
 erZ
@@ -385899,31 +385939,31 @@ erZ
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-seC
-seC
-seC
-seC
-seC
-qhQ
-seC
-seC
-seC
-seC
-qzy
-nuH
-qeY
-bNW
-seC
-qeY
-fIp
-quL
-qeY
-eGn
+iME
+iME
+iME
+qpX
+qpX
+qpX
+qpX
+qpX
+tMO
+qpX
+qpX
+qpX
+qpX
+kEV
+qzH
+iME
+uDi
+qpX
+iME
+ifg
 vLA
-veW
+iME
+wou
+rOc
+vNE
 erZ
 erZ
 erZ
@@ -385938,8 +385978,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -385958,9 +385998,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -386301,31 +386341,31 @@ vIa
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-seC
-mWP
-nBf
-nBf
-nBf
-nBf
-peB
-seC
-iYF
-qeY
-qeY
-fIp
-qeY
-bPz
-seC
-qeY
-qeY
-seC
-qeY
-qeY
-qeY
-veW
+iME
+iME
+iME
+qpX
+goP
+uxZ
+uxZ
+uxZ
+uxZ
+mQr
+qpX
+kdj
+iME
+iME
+ifg
+iME
+vzO
+qpX
+iME
+iME
+qpX
+iME
+iME
+iME
+vNE
 erZ
 erZ
 erZ
@@ -386340,8 +386380,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -386359,10 +386399,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -386703,31 +386743,31 @@ vIa
 erZ
 erZ
 erZ
-qeY
-qeY
-qeY
-seC
-sxJ
-nBf
-nBf
-nBf
-nBf
-bVJ
-seC
-iYF
-qeY
-dBs
-qeY
-jzd
-bPz
-seC
-qeY
-qeY
-seC
-btb
-ebe
-txm
-veW
+iME
+iME
+iME
+qpX
+rlG
+uxZ
+uxZ
+uxZ
+uxZ
+tEg
+qpX
+kdj
+iME
+vDn
+iME
+aKz
+vzO
+qpX
+iME
+iME
+qpX
+qPg
+hzI
+quL
+vNE
 erZ
 erZ
 erZ
@@ -386742,8 +386782,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -386760,11 +386800,11 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -387105,31 +387145,31 @@ vIa
 vIa
 erZ
 erZ
-qeY
-qeY
-qeY
-seC
-yla
-nBf
-nBf
-nBf
-nBf
-bVJ
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-usp
-usp
-seC
-seC
-seC
-seC
-seC
+iME
+iME
+iME
+qpX
+wYQ
+uxZ
+uxZ
+uxZ
+uxZ
+tEg
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+uTd
+uTd
+qpX
+qpX
+qpX
+qpX
+qpX
 erZ
 erZ
 erZ
@@ -387145,7 +387185,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -387162,10 +387202,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -387510,24 +387550,24 @@ erZ
 erZ
 erZ
 erZ
-seC
-lVo
-nBf
-nBf
-nBf
-nBf
-peB
-seC
-wMG
-hAf
-aBY
-bUi
-aBY
-hAf
-sPD
-nBf
-nBf
-cjJ
+qpX
+bCb
+uxZ
+uxZ
+uxZ
+uxZ
+mQr
+qpX
+pFf
+keX
+bmL
+tYk
+bmL
+keX
+oAA
+uxZ
+uxZ
+cVu
 erZ
 erZ
 erZ
@@ -387547,7 +387587,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -387563,9 +387603,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -387912,24 +387952,24 @@ erZ
 erZ
 erZ
 erZ
-seC
-lxc
-nBf
-nBf
-nBf
-nBf
-tBC
-seC
-nBf
-xkF
-xkF
-nBf
-mvg
-mvg
-nBf
-uHj
-nBf
-cjJ
+qpX
+jnc
+uxZ
+uxZ
+uxZ
+uxZ
+vUf
+qpX
+uxZ
+pyO
+pyO
+uxZ
+psi
+psi
+uxZ
+xpM
+uxZ
+cVu
 erZ
 erZ
 erZ
@@ -387949,7 +387989,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -387965,9 +388005,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -388314,24 +388354,24 @@ erZ
 erZ
 erZ
 erZ
-seC
-rOi
-nBf
-nBf
-nBf
-nBf
-oaX
-xLH
-nBf
-nBf
-nBf
-uHj
-nBf
-nBf
-uHj
-nBf
-nBf
-cjJ
+qpX
+ebC
+uxZ
+uxZ
+uxZ
+uxZ
+fVM
+yld
+uxZ
+uxZ
+uxZ
+xpM
+uxZ
+uxZ
+xpM
+uxZ
+uxZ
+cVu
 erZ
 erZ
 erZ
@@ -388351,7 +388391,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -388367,9 +388407,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -388716,24 +388756,24 @@ erZ
 erZ
 erZ
 erZ
-seC
-iDe
-nBf
-nBf
-nBf
-nBf
-tBC
-seC
-nBf
-mcY
-mcY
-nBf
-nBf
-eSD
-eSD
-uHj
-nBf
-cjJ
+qpX
+xNQ
+uxZ
+uxZ
+uxZ
+uxZ
+vUf
+qpX
+uxZ
+gzY
+gzY
+uxZ
+uxZ
+fQq
+fQq
+xpM
+uxZ
+cVu
 erZ
 erZ
 erZ
@@ -388753,7 +388793,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -388769,9 +388809,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -389118,24 +389158,24 @@ erZ
 erZ
 erZ
 erZ
-seC
-ett
-nBf
-nBf
-nBf
-nBf
-prC
-seC
-wMG
-aBY
-aBY
-sPD
-nBf
-nBf
-eEY
-ezK
-nBf
-cjJ
+qpX
+dNL
+uxZ
+uxZ
+uxZ
+uxZ
+gXf
+qpX
+pFf
+bmL
+bmL
+oAA
+uxZ
+uxZ
+bMe
+fEX
+uxZ
+cVu
 erZ
 erZ
 erZ
@@ -389155,8 +389195,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -389170,10 +389210,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -389520,24 +389560,24 @@ erZ
 erZ
 erZ
 erZ
-seC
-xQq
-nBf
-nBf
-nBf
-nBf
-prC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-wru
-wru
-seC
+qpX
+vox
+uxZ
+uxZ
+uxZ
+uxZ
+gXf
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+pkD
+pkD
+qpX
 erZ
 erZ
 erZ
@@ -389557,8 +389597,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -389572,10 +389612,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -389922,28 +389962,28 @@ erZ
 erZ
 erZ
 erZ
-seC
-iDe
-nBf
-nBf
-nBf
-nBf
-oOf
-seC
-wlO
-nEA
-uac
-gTE
-uac
-nEA
-gTE
-ezK
-nBf
-seC
-seC
-seC
-seC
-seC
+qpX
+xNQ
+uxZ
+uxZ
+uxZ
+uxZ
+gPF
+qpX
+uEX
+lGI
+qDl
+wPQ
+qDl
+lGI
+wPQ
+fEX
+uxZ
+qpX
+qpX
+qpX
+qpX
+qpX
 erZ
 erZ
 erZ
@@ -389960,7 +390000,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -389974,10 +390014,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -390323,29 +390363,29 @@ erZ
 erZ
 aUc
 erZ
-seC
-seC
-chY
-nBf
-nBf
-nBf
-nBf
-kTt
-seC
-nBf
-uHj
-nBf
-nBf
-nBf
-nBf
-uHj
-nBf
-nBf
-quL
-qeY
-qeY
+qpX
+qpX
+nGK
+uxZ
+uxZ
+uxZ
+uxZ
+koE
+qpX
+uxZ
+xpM
+uxZ
+uxZ
+uxZ
+uxZ
+xpM
+uxZ
+uxZ
 vLA
-veW
+iME
+iME
+rOc
+vNE
 erZ
 erZ
 erZ
@@ -390362,7 +390402,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -390376,10 +390416,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -390725,29 +390765,29 @@ vIa
 vIa
 aUc
 aUc
-seC
-seC
-chY
-nBf
-nBf
-nBf
-nBf
-oaX
-seC
-xgG
-nBf
-nBf
-uHj
-uHj
-nBf
-nBf
-nBf
-nBf
-seC
-nEp
-qeY
-qeY
-veW
+qpX
+qpX
+nGK
+uxZ
+uxZ
+uxZ
+uxZ
+fVM
+qpX
+ukj
+uxZ
+uxZ
+xpM
+xpM
+uxZ
+uxZ
+uxZ
+uxZ
+qpX
+oRp
+iME
+iME
+vNE
 erZ
 erZ
 erZ
@@ -390764,7 +390804,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -390778,10 +390818,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -391127,29 +391167,29 @@ vIa
 vIa
 aUc
 aUc
-jCr
-jCr
-chY
-oIb
-oaX
-nBf
-nBf
-nBf
-kxz
-nBf
-nBf
-nBf
-uHj
-uHj
-nBf
-nBf
-nBf
-nBf
-seC
-mGL
-qeY
-qeY
-veW
+nxZ
+nxZ
+nGK
+aBG
+fVM
+uxZ
+uxZ
+uxZ
+bib
+uxZ
+uxZ
+uxZ
+xpM
+xpM
+uxZ
+uxZ
+uxZ
+uxZ
+qpX
+rZV
+iME
+iME
+vNE
 erZ
 erZ
 erZ
@@ -391166,7 +391206,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -391180,9 +391220,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -391530,28 +391570,28 @@ vIa
 vIa
 vIa
 aUc
-jCr
-jCr
-jCr
-oaX
-oaX
-nBf
-nBf
-vcF
-aHF
-uHj
-nBf
-nBf
-nBf
-nBf
-uHj
-nBf
-nBf
-seC
-oje
-qeY
-qeY
-veW
+nxZ
+nxZ
+nxZ
+fVM
+fVM
+uxZ
+uxZ
+vua
+eUi
+xpM
+uxZ
+uxZ
+uxZ
+uxZ
+xpM
+uxZ
+uxZ
+qpX
+wpm
+iME
+iME
+vNE
 erZ
 erZ
 erZ
@@ -391568,7 +391608,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -391582,9 +391622,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -391934,26 +391974,26 @@ vIa
 vIa
 aUc
 aUc
+nxZ
+nxZ
+fVM
+fVM
+fVM
+qpX
+qpX
+gbA
+gbA
+mPn
+gbA
+fEX
+uxZ
+uxZ
+uxZ
+qpX
+uEq
+quL
 jCr
-jCr
-oaX
-oaX
-oaX
-seC
-seC
-vsg
-vsg
-nLB
-vsg
-ezK
-nBf
-nBf
-nBf
-seC
-ldc
-txm
-xLV
-veW
+vNE
 erZ
 erZ
 erZ
@@ -391970,7 +392010,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -391984,9 +392024,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -392337,25 +392377,25 @@ vIa
 vIa
 aUc
 aUc
-jCr
-jCr
-jCr
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-uSF
-uSF
-uSF
-uSF
-seC
-seC
-seC
-seC
-seC
+nxZ
+nxZ
+nxZ
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+dcZ
+dcZ
+dcZ
+dcZ
+qpX
+qpX
+qpX
+qpX
+qpX
 erZ
 erZ
 erZ
@@ -392372,8 +392412,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -392386,9 +392426,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -392743,7 +392783,7 @@ aUc
 aUc
 aUc
 aUc
-bqt
+ebb
 erZ
 erZ
 erZ
@@ -392774,9 +392814,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -392787,10 +392827,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -393178,20 +393218,20 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -393584,15 +393624,15 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -393987,13 +394027,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-cMs
-gip
-gip
-gip
-gip
-vWY
+oJO
+qGh
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -394389,13 +394429,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-iME
-gip
-gip
-gip
-gip
-vWY
+oJO
+veW
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -394767,12 +394807,12 @@ xKz
 xKz
 xKz
 xKz
-lxB
-aKy
-hSF
-hXE
-qKr
-oJO
+qGB
+xHe
+ras
+bHX
+tiH
+nhR
 xKz
 erZ
 erZ
@@ -394791,13 +394831,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-cMs
-gip
-cMs
-tSM
-gip
-vWY
+oJO
+qGh
+qeY
+qGh
+mSY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -395164,10 +395204,10 @@ erZ
 fVQ
 fVQ
 xKz
-ewj
-vPA
-vPA
-aem
+bPH
+fyv
+fyv
+wSS
 xKz
 fVQ
 fVQ
@@ -395193,13 +395233,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-gip
-gip
-iME
-cMs
-gip
-vWY
+oJO
+qeY
+qeY
+veW
+qGh
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -395574,14 +395614,14 @@ xKz
 fVQ
 fVQ
 jeb
-mZy
+aFc
 fVQ
-rQE
+fLr
 xKz
 fVQ
 bvN
 tYP
-jzv
+pxe
 jeb
 erZ
 erZ
@@ -395595,13 +395635,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-gip
-gip
-cMs
-tSM
-gip
-vWY
+oJO
+qeY
+qeY
+qGh
+mSY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -395972,18 +396012,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-tUp
+qqk
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-tUp
+qqk
 fVQ
 bvN
 tYP
-vFz
+gBS
 jeb
 erZ
 erZ
@@ -395997,13 +396037,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-cMs
-gip
-gip
-gip
-gip
-vWY
+oJO
+qGh
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -396368,24 +396408,24 @@ erZ
 erZ
 erZ
 xKz
-sIE
+xkl
 vdg
 fVQ
 fVQ
 lLa
-rZn
+eSt
 jeb
-oey
-jgm
-vhx
-qQR
+vFz
+sIu
+eza
+eOt
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-jER
+tDO
 jeb
 erZ
 erZ
@@ -396399,13 +396439,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-iME
-gip
-gip
-gip
-gip
-vWY
+oJO
+veW
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -396770,12 +396810,12 @@ erZ
 erZ
 erZ
 xKz
-oRp
+dAG
 vdg
 fVQ
 fVQ
 lLa
-rZn
+eSt
 jeb
 xKz
 xKz
@@ -396787,7 +396827,7 @@ xKz
 fVQ
 tYP
 tYP
-abZ
+htf
 jeb
 erZ
 erZ
@@ -396801,13 +396841,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-cMs
-gip
-cMs
-tSM
-gip
-vWY
+oJO
+qGh
+qeY
+qGh
+mSY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -397172,24 +397212,24 @@ erZ
 erZ
 erZ
 xKz
-ajl
+gww
 vdg
 fVQ
 fVQ
 fVQ
 fVQ
-tUp
+qqk
 fVQ
-hCt
-wOG
-qGh
+cZN
+wID
+tlP
 fVQ
-bYK
+kqw
 xKz
 fVQ
 bvN
 tYP
-jzv
+pxe
 jeb
 erZ
 erZ
@@ -397203,13 +397243,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-gip
-gip
-iME
-cMs
-gip
-vWY
+oJO
+qeY
+qeY
+veW
+qGh
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -397574,24 +397614,24 @@ erZ
 erZ
 erZ
 xKz
-qGb
+xLO
 vdg
 fVQ
-tkn
+eqw
 fVQ
 fVQ
 jeb
-krZ
+ril
 fVQ
 fVQ
 fVQ
 fVQ
-gYB
+thU
 xKz
 fVQ
 bvN
 tYP
-vFz
+gBS
 jeb
 erZ
 erZ
@@ -397605,13 +397645,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-cMs
-gip
-cMs
-tSM
-gip
-vWY
+oJO
+qGh
+qeY
+qGh
+mSY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -397980,20 +398020,20 @@ xKz
 xKz
 xKz
 xKz
-nUr
+fIW
 xKz
 xKz
-yeA
+xLE
 fVQ
 jeb
-mZy
+aFc
 fVQ
-qwp
+bep
 xKz
 fVQ
 tYP
 tYP
-jER
+tDO
 jeb
 erZ
 erZ
@@ -398007,13 +398047,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-iME
-gip
-gip
-gip
-gip
-vWY
+oJO
+veW
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -398385,7 +398425,7 @@ fVQ
 fVQ
 fVQ
 xKz
-hXt
+wYz
 fVQ
 fVQ
 fVQ
@@ -398395,7 +398435,7 @@ xKz
 fVQ
 tYP
 tYP
-abZ
+htf
 jeb
 erZ
 erZ
@@ -398409,13 +398449,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-cMs
-gip
-gip
-gip
-gip
-vWY
+oJO
+qGh
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -398787,17 +398827,17 @@ vZP
 lLa
 fVQ
 xKz
-cjy
-sKt
-fhc
-qpX
+xMA
+wSl
+fBj
+sdN
 fVQ
-htF
+xYA
 xKz
 fVQ
-lhd
+fIB
 tYP
-jzv
+pxe
 jeb
 erZ
 erZ
@@ -398811,13 +398851,13 @@ erZ
 erZ
 erZ
 erZ
-wSN
-gip
-gip
-gip
-gip
-gip
-vWY
+oJO
+qeY
+qeY
+qeY
+qeY
+qeY
+gvi
 erZ
 erZ
 erZ
@@ -399187,7 +399227,7 @@ fVQ
 lLa
 noC
 lLa
-rQE
+fLr
 xKz
 xKz
 xKz
@@ -399197,7 +399237,7 @@ xKz
 xKz
 xKz
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 jeb
@@ -399213,10 +399253,10 @@ erZ
 erZ
 erZ
 erZ
-wSN
-gip
+oJO
+qeY
 xKz
-ilf
+dgS
 bOK
 jeb
 xKz
@@ -399598,7 +399638,7 @@ fVQ
 fVQ
 xKz
 xKz
-nUr
+fIW
 xKz
 xKz
 xKz
@@ -399615,8 +399655,8 @@ erZ
 erZ
 erZ
 erZ
-wSN
-gip
+oJO
+qeY
 jeb
 fVQ
 ugK
@@ -418871,7 +418911,7 @@ ygF
 ygF
 ygF
 ygF
-ygF
+mge
 jYR
 lHe
 lHe
@@ -431731,8 +431771,8 @@ wAm
 wAm
 wAm
 wAm
-uxZ
-uxZ
+kRc
+kRc
 wAm
 wAm
 wAm
@@ -432133,9 +432173,9 @@ rwH
 uSx
 teW
 kqc
-iqo
+eRc
 jjS
-bei
+pKQ
 vMQ
 vsf
 rwH
@@ -432143,8 +432183,8 @@ nKu
 jiv
 rwH
 teW
-vox
-hpV
+uzR
+eAs
 wte
 enq
 fZJ
@@ -432532,10 +432572,10 @@ teW
 dvD
 jiv
 jiv
-rGY
+hcc
 teW
-wDZ
-bVa
+eVP
+goz
 jiv
 jiv
 jiv
@@ -432546,7 +432586,7 @@ jiv
 jjS
 teW
 hqI
-xHy
+oNn
 uGf
 enq
 fZJ
@@ -432937,7 +432977,7 @@ jiv
 teW
 teW
 vMQ
-bVa
+goz
 jiv
 jiv
 jiv
@@ -432948,7 +432988,7 @@ jiv
 vIX
 teW
 hqI
-xHy
+oNn
 uGf
 enq
 fZJ
@@ -433350,7 +433390,7 @@ wAm
 wAm
 wAm
 jGT
-xHy
+oNn
 uGf
 enq
 fZJ
@@ -433744,15 +433784,15 @@ jiv
 xSI
 jiv
 jiv
-dJj
-ujU
+hSs
+fBz
 htU
 teW
 ael
 hqI
 hqI
 hqI
-xHy
+oNn
 uGf
 enq
 fZJ
@@ -434143,8 +434183,8 @@ xSI
 tML
 tML
 tML
-rRA
-rRA
+tnB
+tnB
 tML
 aGb
 tML
@@ -434154,7 +434194,7 @@ pDA
 hqI
 hqI
 hqI
-xHy
+oNn
 uGf
 enq
 fZJ
@@ -434549,14 +434589,14 @@ nyc
 ntK
 ntK
 cAe
-djR
-oda
+gEF
+qDn
 teW
 ulu
 hqI
 fVE
-xHy
-xHy
+oNn
+oNn
 uGf
 enq
 fZJ
@@ -434950,15 +434990,15 @@ swm
 nyc
 ntK
 ntK
-tak
+mcB
 xrf
 xrf
 teW
 uNz
 hqI
 hqI
-xHy
-lKp
+oNn
+mvc
 ojc
 enq
 fZJ
@@ -435352,9 +435392,9 @@ swm
 nyc
 ntK
 ntK
+qBG
 rSg
-yjP
-yjP
+rSg
 teW
 ajj
 lLK
@@ -435755,8 +435795,8 @@ ntK
 ntK
 ntK
 lYl
-gLV
-gLV
+uJM
+uJM
 ohA
 bcN
 bcN
@@ -436554,11 +436594,11 @@ uKB
 aur
 uZa
 cPw
-qzB
+htG
 ntK
 ntK
 ntK
-sep
+tak
 ybm
 ybm
 ohA
@@ -436961,12 +437001,12 @@ nyc
 ntK
 ntK
 cAe
-oda
-oda
+qDn
+qDn
 teW
 eYI
-uZC
-uZC
+vGN
+vGN
 tML
 tML
 ffv
@@ -437362,13 +437402,13 @@ swm
 nyc
 ntK
 ntK
-tak
+mcB
 xrf
 xrf
 tML
-eSt
-eSt
-eSt
+cTT
+cTT
+cTT
 wAm
 tML
 tML
@@ -437764,13 +437804,13 @@ aXE
 nyc
 ntK
 ntK
-vlp
-gJo
-chs
+loE
+fwK
+dhJ
 tML
-aac
-aac
-aac
+pcQ
+pcQ
+pcQ
 wAm
 hKU
 hKU
@@ -437787,7 +437827,7 @@ squ
 squ
 squ
 rTC
-kIt
+ttR
 squ
 squ
 squ
@@ -438163,7 +438203,7 @@ tML
 teW
 tML
 tML
-bAs
+xwi
 fnF
 tML
 aGb
@@ -438177,7 +438217,7 @@ wpe
 fQd
 eCn
 sNY
-ess
+ozu
 teW
 teW
 teW
@@ -438189,7 +438229,7 @@ squ
 squ
 squ
 rTC
-kIt
+ttR
 rTC
 rTC
 rTC
@@ -438583,7 +438623,7 @@ eCn
 teW
 aor
 xfh
-wUh
+gcs
 teW
 squ
 squ
@@ -438979,8 +439019,8 @@ cfY
 cfY
 teW
 aTF
-oqk
-mVz
+fpk
+jUZ
 eCn
 mYi
 gbX
@@ -439381,8 +439421,8 @@ uZy
 cfY
 alk
 eCn
-uRy
-eCx
+hRk
+tLe
 eCn
 mYi
 gbX
@@ -439765,14 +439805,14 @@ erZ
 fZJ
 fZJ
 rxp
-wzC
+kjI
 uKB
 uBv
 tML
 tML
 tML
 xnv
-vTy
+lbH
 tML
 rMM
 cfY
@@ -439787,9 +439827,9 @@ eCn
 eCn
 eCn
 teW
-eRE
-xli
-iRN
+mSE
+hfA
+eKj
 teW
 squ
 squ
@@ -440571,8 +440611,8 @@ fZJ
 rxp
 uKB
 uKB
-cld
-pcQ
+igh
+uJV
 uKB
 nIr
 swm
@@ -440591,8 +440631,8 @@ eCn
 teW
 mYi
 teW
-lMZ
-lMZ
+xJe
+xJe
 teW
 squ
 squ
@@ -440993,8 +441033,8 @@ teW
 teW
 eCn
 teW
-lMZ
-lMZ
+xJe
+xJe
 teW
 squ
 squ
@@ -441370,14 +441410,14 @@ vIa
 vIa
 aUc
 teW
-qtA
+pMQ
 teW
 uKB
 uKB
-ixl
-mMB
-gEJ
-nJy
+brj
+kvj
+iBe
+xGX
 tML
 swm
 swm
@@ -441395,8 +441435,8 @@ eCn
 fQd
 eCn
 teW
-lMZ
-lMZ
+xJe
+xJe
 teW
 eQa
 rTC
@@ -441772,10 +441812,10 @@ vIa
 vIa
 aUc
 teW
-aoB
+gHn
 teW
-dPE
-kRw
+kxq
+rhV
 tML
 tML
 ydR
@@ -441791,15 +441831,15 @@ idu
 sct
 sNp
 cfY
-xOf
-dKL
-hVn
-cPr
+qKU
+nnx
+nzL
+leS
 eCn
 teW
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
 aUc
 aUc
 aUc
@@ -442186,20 +442226,20 @@ pjB
 swm
 swm
 tML
-fVM
+lZo
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-xOf
-bzz
-pvC
-lmP
+qKU
+wvt
+pum
+oBC
 eCn
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -442590,18 +442630,18 @@ swm
 tML
 rMM
 eVa
-bKg
+xde
 tcW
 tcW
 tcW
 eVa
-sSu
-bGf
-gaA
-dwO
+aGc
+uFp
+lip
+kEf
 eCn
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -442978,7 +443018,7 @@ vIa
 vIa
 aUc
 teW
-jaB
+gZn
 nMd
 uKB
 uKB
@@ -442987,7 +443027,7 @@ tML
 tML
 tML
 wAm
-vTy
+lbH
 wAm
 wAm
 teW
@@ -443003,7 +443043,7 @@ eCn
 grk
 eCn
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -443382,22 +443422,22 @@ aUc
 teW
 teW
 teW
-pcQ
+uJV
 uKB
 uKB
-fQq
+pIB
 iYx
-pqm
-uHk
-uHk
+rRA
+aok
+aok
 teW
-iYx
-iYx
 iYx
 iYx
-lMZ
-lMZ
-lMZ
+iYx
+iYx
+xJe
+xJe
+xJe
 teW
 teW
 teW
@@ -443405,7 +443445,7 @@ teW
 teW
 teW
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -443781,33 +443821,33 @@ vIa
 vIa
 vIa
 aUc
-lMZ
-lMZ
+xJe
+xJe
 teW
-pcQ
+uJV
 uKB
 uKB
-ggX
+vmp
 iYx
 vaa
-uHk
-vQV
+aok
+kdY
 teW
-xaD
-jBO
-oiq
+cqJ
+tAc
+msN
 iYx
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
 lAs
 lAs
 vIa
@@ -444184,22 +444224,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
+xJe
 teW
-pcQ
+uJV
 uKB
 uKB
-cCS
+dof
 iYx
-xoQ
-uHk
-uHk
+uIc
+aok
+aok
 teW
-guL
-uHk
-uHk
+pNc
+aok
+aok
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -444586,22 +444626,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
+xJe
 teW
-swT
+jFG
 uKB
 uKB
-ohY
+gxP
 iYx
-ftd
-uHk
-uHk
-qin
-uHk
-uHk
-dQz
+uVd
+aok
+aok
+mNs
+aok
+aok
+kaf
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -444988,22 +445028,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
+xJe
 teW
 teW
 teW
 teW
 teW
 iYx
-pKQ
-uHk
-iwf
+lGo
+aok
+cfb
 iYx
-vgy
-bzl
-bbl
+kve
+wYv
+qqz
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -445390,22 +445430,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
 iYx
 iYx
 iYx
 iYx
-pqm
-uHk
-caC
+rRA
+aok
+hGr
 iYx
 iYx
 iYx
 iYx
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -445794,20 +445834,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-caC
-iug
+hGr
+fTX
 iYx
 iYx
-uHk
-iwf
+aok
+cfb
 iYx
-xaD
-jBO
-oiq
+cqJ
+tAc
+msN
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -446196,20 +446236,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-guL
-uHk
-bAs
-uHk
-uHk
-uHk
+pNc
+aok
+xwi
+aok
+aok
+aok
 iYx
-guL
-uHk
-uHk
+pNc
+aok
+aok
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -446598,20 +446638,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-uHk
-uHk
+aok
+aok
 iYx
-uHk
-uHk
-uHk
-qin
-uHk
-uHk
-dQz
+aok
+aok
+aok
+mNs
+aok
+aok
+kaf
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -447000,20 +447040,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-rjQ
-bbl
+vyk
+qqz
 iYx
-uHk
-lku
-hsD
+aok
+jLi
+nuH
 iYx
-vgy
-bzl
-bbl
+kve
+wYv
+qqz
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -447403,18 +447443,18 @@ vIa
 vIa
 vIa
 aUc
-inf
+aac
 iYx
 iYx
 iYx
-lft
+jEB
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-inf
+aac
 aUc
 vIa
 vIa
@@ -447808,14 +447848,14 @@ aUc
 aUc
 iYx
 iYx
-bkC
+neF
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-lMZ
+xJe
 aUc
 aUc
 vIa
@@ -448209,15 +448249,15 @@ vIa
 vIa
 aUc
 iYx
-nYQ
-bSF
+kEE
+wTs
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-lMZ
+xJe
 vIa
 vIa
 vIa
@@ -448611,15 +448651,15 @@ vIa
 vIa
 aUc
 iYx
-wIH
-bSF
+suN
+wTs
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-lMZ
+xJe
 vIa
 vIa
 vIa
@@ -449013,15 +449053,15 @@ vIa
 vIa
 aUc
 iYx
-aKi
-wQC
-uZC
-uZC
-uZC
+nhz
+jQV
+vGN
+vGN
+vGN
 iYx
 iYx
 iYx
-lMZ
+xJe
 vIa
 vIa
 vIa
@@ -449417,13 +449457,13 @@ aUc
 iYx
 iYx
 iYx
-elO
-elO
-qBr
+mrE
+mrE
+hYH
 iYx
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
 vIa
 vIa
 vIa
@@ -485993,36 +486033,36 @@ vIa
 aUc
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-seC
-bUD
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+vAn
 erZ
 erZ
 erZ
@@ -486392,39 +486432,39 @@ vIa
 vIa
 vIa
 vIa
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-qeY
-uwa
-seC
-seC
-seC
-qeY
-qeY
-qeY
-qeY
-qeY
-quL
-qeY
-seC
-eTX
-jZi
-ojM
-gOY
-wpm
-gOY
-mZp
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+iME
+iVh
+qpX
+qpX
+qpX
+iME
+iME
+iME
+iME
+iME
+vLA
+iME
+qpX
+lLn
+qEr
+gpb
+qwp
+jpw
+qwp
+uyA
 erZ
 erZ
 erZ
@@ -486794,39 +486834,39 @@ vIa
 erZ
 erZ
 erZ
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-qeY
-rce
-seC
-seC
-seC
-qeY
-qeY
-mZu
-uEk
-uEk
-seC
-qeY
-qUQ
-wpm
-wpm
-wpm
-wpm
-wpm
-wpm
-tYe
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+iME
+syB
+qpX
+qpX
+qpX
+iME
+iME
+cOn
+eES
+eES
+qpX
+iME
+bPz
+jpw
+jpw
+jpw
+jpw
+jpw
+jpw
+dkD
 erZ
 erZ
 erZ
@@ -487196,39 +487236,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-qeY
-qeY
-pdm
-seC
-rgO
-pMn
-obq
-vUf
-seC
-seC
-seC
-quL
-seC
-mjP
-wpm
-wpm
-wpm
-wpm
-wpm
-lBN
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+iME
+iME
+faD
+qpX
+qRp
+cjI
+dwO
+dHx
+qpX
+qpX
+qpX
+vLA
+qpX
+nNM
+jpw
+jpw
+jpw
+jpw
+jpw
+aYC
 erZ
 erZ
 erZ
@@ -487598,39 +487638,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-qeY
-qeY
-pdm
-seC
-nTR
-qeY
-qeY
-xJe
-seC
-oje
-qeY
-qeY
-seC
-pDm
-hAe
-ujy
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+iME
+iME
+faD
+qpX
+cLL
+iME
+iME
+nxn
+qpX
 wpm
-wpm
-wpm
-mZp
+iME
+iME
+qpX
+etX
+wDz
+vez
+jpw
+jpw
+jpw
+uyA
 erZ
 erZ
 erZ
@@ -488000,39 +488040,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-quL
-seC
-seC
-seC
-nTR
-qeY
-qeY
-xJe
-seC
-cxS
-qeY
-qeY
-bUD
-uxV
-aLR
-ppb
-dcE
-wpm
-wpm
-tYe
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+vLA
+qpX
+qpX
+qpX
+cLL
+iME
+iME
+nxn
+qpX
+dTa
+iME
+iME
+vAn
+yjP
+pdm
+bUi
+aew
+jpw
+jpw
+dkD
 erZ
 erZ
 erZ
@@ -488402,39 +488442,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-seC
-ksK
-ksK
-cdn
-seC
-rgO
-nuH
-qeY
-aPR
-seC
-qeY
-obq
-qeY
-bUD
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+qpX
+hsF
+hsF
+pBW
+qpX
+qRp
+qzH
+iME
+owf
+qpX
+iME
+dwO
+iME
+vAn
 wQI
-eIm
+eWs
 wQI
-sPR
-wpm
-wpm
-lBN
+dnc
+jpw
+jpw
+aYC
 erZ
 erZ
 erZ
@@ -488804,39 +488844,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+ebb
 fIL
 wQD
 aUc
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-rgO
-nuH
-qeY
-vUf
-seC
-nTR
-obq
-obq
-xJe
-seC
-qeY
-qeY
-qeY
-bUD
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+qRp
+qzH
+iME
+dHx
+qpX
+cLL
+dwO
+dwO
+nxn
+qpX
+iME
+iME
+iME
+vAn
 wQI
 wQI
 wQI
-gbA
-wpm
-wpm
-mZp
+wwK
+jpw
+jpw
+uyA
 erZ
 erZ
 erZ
@@ -489211,34 +489251,34 @@ eNY
 hby
 aUc
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-nTR
-qeY
-qeY
-xJe
-seC
-nTR
-qeY
-qeY
-xJe
-seC
-cxS
-qeY
-cxS
-bUD
-bHX
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+cLL
+iME
+iME
+nxn
+qpX
+cLL
+iME
+iME
+nxn
+qpX
+dTa
+iME
+dTa
+vAn
+hMe
 wQI
-bHX
-jme
-wpm
-wpm
-tYe
+hMe
+dSd
+jpw
+jpw
+dkD
 erZ
 erZ
 erZ
@@ -489614,33 +489654,33 @@ twI
 aUc
 aUc
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
 ebb
-qeY
-ksK
-pdm
-seC
-rgO
-nuH
-qeY
-aPR
-seC
-oje
-qeY
-obq
-seC
-seC
-seC
-seC
-hAe
-hAe
-hAe
-xZj
+ebb
+ebb
+ebb
+ebb
+qpX
+ycz
+iME
+hsF
+faD
+qpX
+qRp
+qzH
+iME
+owf
+qpX
+wpm
+iME
+dwO
+qpX
+qpX
+qpX
+qpX
+wDz
+wDz
+wDz
+wUw
 erZ
 erZ
 erZ
@@ -490015,30 +490055,30 @@ twI
 twI
 twI
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-elE
-nuH
-qeY
-mZu
-seC
 ebb
-qeY
-qeY
-pdm
-seC
-qeY
-obq
-qeY
-vHd
-qeY
-cxS
-kqt
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+jIP
+qzH
+iME
+cOn
+qpX
+ycz
+iME
+iME
+faD
+qpX
+iME
+dwO
+iME
+rUf
+iME
+dTa
+hON
 erZ
 erZ
 erZ
@@ -490416,31 +490456,31 @@ aUc
 aUc
 xGC
 oWI
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-svd
-nuH
-qeY
-vUf
-seC
-nTR
-qeY
-qeY
-xJe
-seC
-vHd
-qeY
-qeY
-qeY
-eIA
-klm
-wza
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+waG
+qzH
+iME
+dHx
+qpX
+cLL
+iME
+iME
+nxn
+qpX
+rUf
+iME
+iME
+iME
+ukm
+auL
+qrI
 erZ
 erZ
 erZ
@@ -490818,31 +490858,31 @@ vIa
 aUc
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
 ebb
-ksK
-qeY
-xJe
-seC
-rgO
-nuH
-qeY
-aPR
-seC
-cxS
-qeY
-obq
-qeY
-rfO
-qNq
-pwO
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+ycz
+hsF
+iME
+nxn
+qpX
+qRp
+qzH
+iME
+owf
+qpX
+dTa
+iME
+dwO
+iME
+akO
+fvS
+rUQ
 erZ
 erZ
 erZ
@@ -491217,34 +491257,34 @@ erZ
 erZ
 erZ
 bQB
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-nTR
-qeY
-qeY
-pdm
-seC
-pdm
-obq
-obq
-xJe
-seC
-oje
-vHd
-qeY
-qeY
-rfO
-waz
-mst
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+cLL
+iME
+iME
+faD
+qpX
+faD
+dwO
+dwO
+nxn
+qpX
+wpm
+rUf
+iME
+iME
+akO
+nHM
+iWj
 erZ
 erZ
 erZ
@@ -491619,34 +491659,34 @@ erZ
 erZ
 erZ
 bQB
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+qRp
+qzH
+iME
 rgO
-nuH
-qeY
-uVR
-uVR
-uVR
-qeY
-qeY
-uVR
-uVR
-obq
-qeY
-vHd
-vHd
-rfO
-waz
-mst
+rgO
+rgO
+iME
+iME
+rgO
+rgO
+dwO
+iME
+rUf
+rUf
+akO
+nHM
+iWj
 erZ
 erZ
 erZ
@@ -492021,34 +492061,34 @@ erZ
 erZ
 erZ
 bQB
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-nTR
-ksK
-qeY
-kdb
-seC
-qzy
-nuH
-qeY
-bNW
-seC
-oje
-obq
-qeY
-cxS
-jEU
-jEU
-sZw
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+cLL
+hsF
+iME
+uOz
+qpX
+kEV
+qzH
+iME
+uDi
+qpX
+wpm
+dwO
+iME
+dTa
+cEr
+cEr
+hea
 erZ
 erZ
 erZ
@@ -492423,37 +492463,37 @@ erZ
 erZ
 erZ
 bQB
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-nTR
-qeY
-ksK
-qeY
-quL
-qeY
-qeY
-qeY
-seC
-seC
-seC
-seC
-seC
-oje
-qeY
-qeY
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+cLL
+iME
+hsF
+iME
+vLA
+iME
+iME
+iME
+qpX
+qpX
+qpX
+qpX
+qpX
+wpm
+iME
+iME
 uLh
 uLh
-qsb
-tfp
+bwP
+fDB
 uLh
 erZ
 erZ
@@ -492825,39 +492865,39 @@ erZ
 erZ
 erZ
 bQB
-bqt
+ebb
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-dte
-nuH
-qeY
-pqI
-seC
-seC
-seC
-seC
-seC
-seC
-bqt
-bqt
-seC
-qeY
-qeY
-cxS
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+dKU
+qzH
+iME
+nWd
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+ebb
+ebb
+qpX
+iME
+iME
+dTa
 uLh
-izB
-wFp
-fmh
+vzG
+urF
+pkf
 uLh
-sxM
+wRi
 erZ
 erZ
 erZ
@@ -493221,46 +493261,46 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
 hqA
 pCW
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-seC
-seC
-seC
-seC
-seC
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-cxS
-qeY
-qeY
-aFP
-wFp
-wFp
-jfz
-tfp
-wFp
-wFp
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+dTa
+iME
+iME
+aSD
+urF
+urF
+bkL
+fDB
+urF
+urF
 erZ
 erZ
 erZ
@@ -493618,13 +493658,13 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
 lgg
 lgg
 lgg
@@ -493636,33 +493676,33 @@ lgg
 lgg
 lgg
 lgg
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-seC
-seC
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-cxS
-qeY
-qeY
-aFP
-wFp
-wFp
-wFp
-aFP
-wFp
-wFp
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+qpX
+qpX
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+dTa
+iME
+iME
+aSD
+urF
+urF
+urF
+aSD
+urF
+urF
 erZ
 erZ
 erZ
@@ -494016,13 +494056,13 @@ vIa
 vIa
 vIa
 vIa
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
 lgg
 lgg
 lgg
@@ -494042,29 +494082,29 @@ lgg
 lgg
 vIa
 vIa
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-oje
-qeY
-qeY
-aFP
-wFp
-wFp
-wFp
-tfp
-wFp
-wFp
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+wpm
+iME
+iME
+aSD
+urF
+urF
+urF
+fDB
+urF
+urF
 erZ
 erZ
 erZ
@@ -494447,25 +494487,25 @@ vIa
 vIa
 vIa
 vIa
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-seC
-jaR
-qeY
-qeY
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+qpX
+aWt
+iME
+iME
 uLh
-oZt
-wFp
-wFp
+ktI
+urF
+urF
 uLh
-sxM
+wRi
 erZ
 erZ
 erZ
@@ -494851,22 +494891,22 @@ vIa
 vIa
 vIa
 aUc
-bqt
-seC
-qRp
-qRp
-qRp
-qRp
-qRp
-qRp
-qRp
-dBA
-dBA
+ebb
+qpX
+tJC
+tJC
+tJC
+tJC
+tJC
+tJC
+tJC
+goR
+goR
 uLh
 uLh
-hGr
-hGr
-pCe
+uzT
+uzT
+iEA
 erZ
 erZ
 erZ
@@ -495253,8 +495293,8 @@ vIa
 vIa
 vIa
 vIa
-bqt
-bqt
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -496875,14 +496915,14 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -497272,19 +497312,19 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -497674,24 +497714,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -498076,24 +498116,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -498476,26 +498516,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -498878,26 +498918,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -499280,26 +499320,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -499682,26 +499722,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -500084,26 +500124,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -500486,7 +500526,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+wra
 iJC
 bOK
 nEd
@@ -500494,18 +500534,18 @@ nEd
 nEd
 bOK
 iJC
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -500888,7 +500928,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+wra
 bOK
 fVQ
 fVQ
@@ -500896,18 +500936,18 @@ bmG
 fVQ
 fVQ
 bOK
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -501290,7 +501330,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+wra
 nEd
 fVQ
 lgN
@@ -501298,18 +501338,18 @@ jJC
 lgN
 fVQ
 nEd
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -501692,7 +501732,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+wra
 nEd
 fVQ
 qxZ
@@ -501706,12 +501746,12 @@ vxC
 vxC
 vxC
 ppx
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -502094,7 +502134,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+wra
 nEd
 fVQ
 fVQ
@@ -502108,12 +502148,12 @@ fZJ
 fZJ
 fZJ
 kZS
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wra
+wra
+wra
+wra
+wra
+wra
 erZ
 erZ
 erZ
@@ -543479,8 +543519,8 @@ vIa
 vIa
 vIa
 vIa
-cmp
-cmp
+adK
+adK
 lAs
 woj
 qPA
@@ -543881,8 +543921,8 @@ vIa
 vIa
 vIa
 vIa
-cmp
-cmp
+adK
+adK
 lAs
 woj
 qPA
@@ -544283,8 +544323,8 @@ vIa
 vIa
 vIa
 vIa
-cmp
-cmp
+adK
+adK
 lAs
 woj
 qPA
@@ -544685,8 +544725,8 @@ vIa
 vIa
 vIa
 vIa
-cmp
-cmp
+adK
+adK
 lAs
 eJN
 bHY
@@ -545087,8 +545127,8 @@ vIa
 vIa
 vIa
 vIa
-cmp
-cmp
+adK
+adK
 lAs
 lAs
 lAs
@@ -545489,7 +545529,7 @@ vIa
 vIa
 vIa
 vIa
-cmp
+adK
 vIa
 vIa
 vIa
@@ -545891,7 +545931,7 @@ vIa
 vIa
 vIa
 vIa
-cmp
+adK
 vIa
 vIa
 vIa
@@ -546293,7 +546333,7 @@ vIa
 vIa
 vIa
 vIa
-cmp
+adK
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,12 +7,11 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/stairs{
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 1
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -499,19 +498,21 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/wood{
-	dir = 8
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -990,10 +991,9 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "adK" = (
 /obj/structure/fluff/railing/border{
-	dir = 1
+	dir = 4
 	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
 "adL" = (
@@ -1149,13 +1149,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "aev" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1257,17 +1260,16 @@
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"ahX" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
-"aiu" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "aiH" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -1277,16 +1279,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"aiR" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"aiZ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "ajj" = (
 /obj/structure/statue/saints/father,
@@ -1330,6 +1322,10 @@
 /obj/item/roguebin/crackers,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"aky" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "akM" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -1345,6 +1341,12 @@
 	layer = 2.81
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"als" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
 /area/rogue/indoors/town/church/chapel)
 "alL" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -1376,6 +1378,19 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"ams" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "amt" = (
 /obj/structure/table/church,
 /turf/open/floor/rogue/churchmarble,
@@ -1400,15 +1415,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "aok" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1489,6 +1501,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"asr" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "asE" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -1509,10 +1525,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"atE" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "atM" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -1553,13 +1565,9 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1577,13 +1585,6 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town)
-"avO" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "avQ" = (
 /obj/structure/bars/grille,
@@ -1671,29 +1672,16 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"ayc" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ayi" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
@@ -1777,16 +1765,6 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
-"aBW" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1811,17 +1789,6 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"aDD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1890,6 +1857,13 @@
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"aFJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aFS" = (
 /obj/structure/chair/wood/rogue,
 /obj/item/rogueweapon/whip,
@@ -1968,9 +1942,13 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"aIl" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
+"aIp" = (
+/obj/structure/gate/bars{
+	gid = "viking1";
+	redstone_id = "viking1"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "aIx" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/closet/crate/roguecloset,
@@ -2031,6 +2009,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"aJC" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aJR" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -2038,6 +2022,14 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
+"aKc" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "aKd" = (
 /obj/structure/winch{
 	dir = 4;
@@ -2131,23 +2123,11 @@
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"aNu" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "aNE" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
 	},
-/area/rogue/indoors/town)
-"aNG" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "aNN" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -2162,6 +2142,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"aNU" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "aNW" = (
 /obj/structure/table/wood,
 /obj/item/chair/rogue,
@@ -2211,6 +2195,16 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"aPE" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aPF" = (
 /obj/structure/flora/roguetree/stump/burnt,
 /turf/open/floor/rogue/dirt/road{
@@ -2218,11 +2212,8 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2233,6 +2224,13 @@
 /mob/living/carbon/human/species/halforc/orc_raider/savage_orc/ambush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"aQx" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "aQA" = (
 /obj/structure/stairs{
 	dir = 1
@@ -2296,18 +2294,13 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"aSo" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "aSD" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2422,11 +2415,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"aWQ" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "aXa" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
@@ -2444,16 +2432,13 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"aXv" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+"aXs" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
 	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "aXx" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/spacevine,
@@ -2494,16 +2479,14 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"aZg" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"aYP" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "aZj" = (
 /obj/structure/table/vtable,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -2532,13 +2515,6 @@
 "bau" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
-"bay" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "baE" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -2649,6 +2625,12 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"bfD" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "bfK" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2726,6 +2708,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"biQ" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "bjd" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -2751,6 +2739,15 @@
 /obj/item/rogueweapon/tongs,
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
+"bjN" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/closed,
 /area/rogue/indoors/town)
 "bjO" = (
 /obj/structure/lever/wall{
@@ -2824,12 +2821,6 @@
 	icon_state = "roof"
 	},
 /area/rogue/outdoors/mountains)
-"bmc" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "bmd" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt/road{
@@ -2841,19 +2832,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"bmj" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"bmk" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "bmu" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road{
@@ -2867,20 +2845,16 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"bmM" = (
 /obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
-"bmO" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -3043,10 +3017,8 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/garrison)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3063,6 +3035,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"bqL" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "bqP" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/bath)
@@ -3124,6 +3100,10 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"bsB" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "bsC" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/churchmarble,
@@ -3155,6 +3135,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"bty" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "btA" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -3170,6 +3158,22 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"btY" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "buc" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/cobble/mossy,
@@ -3295,6 +3299,15 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town)
+"bwO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bwS" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
@@ -3349,6 +3362,13 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"byw" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "byB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -3382,17 +3402,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
+/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3409,16 +3425,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"bzU" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "bAi" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell2";
@@ -3452,20 +3458,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"bBc" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
-"bBo" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3481,16 +3473,20 @@
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"bCb" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+"bBR" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
+"bCb" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3542,13 +3538,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"bEJ" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "bEL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -3596,10 +3585,12 @@
 "bFU" = (
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"bFX" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"bGe" = (
+/mob/living/simple_animal/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "bGg" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
@@ -3641,9 +3632,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3680,6 +3674,12 @@
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"bIP" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "bIZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -3732,16 +3732,6 @@
 /obj/item/roguekey/roomhunt,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
-"bKE" = (
-/obj/structure/closet/crate/chest/reward,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"bLa" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bLf" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -3751,6 +3741,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"bLu" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "bLD" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
@@ -3839,12 +3833,24 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "bPz" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
+"bPF" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3962,6 +3968,20 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"bTg" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bTy" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/vikingarea)
@@ -3977,6 +3997,12 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"bUc" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town)
 "bUf" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -3985,26 +4011,15 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "bVa" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/under/cave)
-"bVe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4021,6 +4036,18 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"bVT" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
+"bVV" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bWj" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -4092,14 +4119,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"bYy" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "bYA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4142,6 +4161,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"bZw" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "bZB" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/grass,
@@ -4149,16 +4172,10 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"bZX" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+"cag" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4247,12 +4264,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4263,11 +4276,6 @@
 /obj/structure/table/vtable/v2,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
-"cdQ" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "cev" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/ruinedwood{
@@ -4369,6 +4377,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"chw" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "chN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -4433,6 +4451,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"cjf" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "cjm" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/beastmonger,
@@ -4446,19 +4471,19 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cjy" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cjJ" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"cjZ" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4482,6 +4507,12 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/garrison)
+"ckv" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "ckw" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -4510,9 +4541,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4550,12 +4583,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"cmQ" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cna" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -4718,14 +4745,6 @@
 "csk" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors)
-"csm" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "csr" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -4738,6 +4757,16 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"csH" = (
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
+"csJ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4773,12 +4802,6 @@
 "cue" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"cuh" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "cur" = (
 /obj/structure/bed/rogue/inn/pileofshit,
 /turf/open/floor/carpet/royalblack,
@@ -4821,11 +4844,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4"
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "cwh" = (
@@ -4931,10 +4951,6 @@
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"cye" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
@@ -5081,7 +5097,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
@@ -5118,13 +5135,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5168,6 +5180,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"cEJ" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "cEK" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -5231,10 +5249,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"cGQ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "cGX" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -5246,6 +5260,14 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"cHt" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cHy" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/blocks,
@@ -5273,10 +5295,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"cHY" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "cIa" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/shop)
@@ -5330,6 +5348,19 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
+"cKp" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "cKr" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/leather,
@@ -5357,6 +5388,14 @@
 	dir = 4
 	},
 /area/rogue/indoors)
+"cKL" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cLm" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5377,11 +5416,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5398,13 +5437,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"cMj" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "cMs" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/well/fountain{
+	pixel_x = -14
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5428,6 +5470,10 @@
 "cNg" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
+"cNj" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "cNk" = (
 /obj/effect/landmark/start/nightmaiden{
@@ -5471,13 +5517,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"cOS" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -5507,6 +5546,11 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"cPx" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/hexstone,
@@ -5539,10 +5583,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"cQP" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "cQY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/dirt/road{
@@ -5567,10 +5607,12 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5625,12 +5667,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"cSR" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "cTr" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -5660,15 +5696,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"cUj" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "cUu" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -5692,6 +5719,13 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cUS" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "cUW" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5768,13 +5802,19 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"cWS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+"cWM" = (
+/obj/structure/roguewindow/stained/silver,
+/obj/structure/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "cWT" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/rtfield)
+"cXg" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cXk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -5792,6 +5832,17 @@
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"cXK" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "cXU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -5873,12 +5924,14 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"cZx" = (
-/obj/machinery/anvil{
-	pixel_x = -1
+"cZz" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -5919,13 +5972,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
-"dbH" = (
-/obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/under/cave)
+"dbH" = (
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"dbN" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -5997,10 +6052,6 @@
 /obj/item/storage/box/matches,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"dcU" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "dcV" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/copper,
@@ -6160,10 +6211,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"diu" = (
-/obj/machinery/light/rogue/smelter,
+"diq" = (
+/obj/structure/fluff/statue/myth,
 /turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "diA" = (
 /mob/living/simple_animal/hostile/mushroom{
 	faction = list("undead")
@@ -6180,6 +6231,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"diR" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "diU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shovel,
@@ -6228,6 +6287,11 @@
 	name = "Hammer of Malum"
 	},
 /obj/item/rogueweapon/tongs,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -6241,16 +6305,6 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"dkw" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "dkI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -6304,6 +6358,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"dmf" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "dmw" = (
 /obj/structure/fluff/walldeco/painting/queen{
 	pixel_y = 32
@@ -6355,16 +6416,15 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter)
-"dol" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
+"doi" = (
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "doK" = (
 /obj/structure/bars,
 /obj/machinery/light/rogue/torchholder{
@@ -6474,13 +6534,6 @@
 /obj/item/clothing/suit/roguetown/shirt/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"dsq" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "dsr" = (
 /obj/structure/statue/saints/cephine{
 	desc = "Her radiant angel that shall serve as our guiding light during end times."
@@ -6503,6 +6556,13 @@
 "dsB" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
+"dsP" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "dsW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -6510,10 +6570,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"dtf" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "dth" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
@@ -6588,13 +6644,6 @@
 "dwl" = (
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"dwu" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dwK" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -6608,15 +6657,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/stairs/stone{
+	dir = 1
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6649,6 +6694,12 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"dyt" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dyD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/red,
@@ -6688,8 +6739,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6725,6 +6776,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"dCr" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6771,6 +6830,26 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"dEf" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"dEk" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dEA" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet,
@@ -6784,14 +6863,9 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"dFa" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+"dEW" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
@@ -6822,6 +6896,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dFV" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -6847,14 +6926,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"dGv" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dGG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6888,6 +6959,11 @@
 	max_integrity = 99999
 	},
 /area/rogue/indoors/town/shop)
+"dIP" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "dIU" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/item/grown/log/tree/small,
@@ -6916,13 +6992,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"dJz" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "dJO" = (
 /turf/open/floor/rogue/twig{
 	dir = 4
@@ -6934,6 +7003,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"dKU" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dKV" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/herringbone,
@@ -7010,30 +7083,37 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"dNo" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dNu" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dNz" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+"dNI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
 	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "dNL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/machinery/anvil{
+	pixel_x = -1
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7146,14 +7226,6 @@
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"dQi" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "dQp" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/clinic,
@@ -7209,17 +7281,6 @@
 /obj/item/rogueweapon/greatsword,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
-"dSi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "dSo" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
@@ -7268,11 +7329,17 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
+"dSY" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "dTa" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7331,10 +7398,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dUD" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -7484,16 +7547,13 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "ebe" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7503,10 +7563,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/rtfield)
-"ebt" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "ebG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -7592,6 +7648,13 @@
 /obj/item/ingot/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"edb" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "edc" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
@@ -7628,6 +7691,10 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"edP" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "edW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -7784,10 +7851,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"eil" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "eit" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -7806,6 +7869,12 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"eiG" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eiQ" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/powder,
@@ -7965,10 +8034,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"enF" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "enI" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -8008,9 +8073,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -8070,6 +8138,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"eqI" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "eqK" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
 	max_integrity = 99999
@@ -8100,6 +8175,10 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves)
+"erP" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "erX" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/structure/gravemarker,
@@ -8166,6 +8245,18 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"etF" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "etS" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -8259,12 +8350,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ewf" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "ewq" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjailr"
@@ -8275,17 +8360,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"ewu" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "ewB" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
@@ -8302,18 +8376,13 @@
 /obj/structure/pillory/town_square/reinforced,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"exq" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+"ewS" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "exG" = (
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
-"exJ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "exP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -8334,6 +8403,12 @@
 /obj/item/rogue/instrument/drum,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"exW" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "eyq" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = -32
@@ -8352,6 +8427,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"eyN" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "eyR" = (
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/concrete,
@@ -8361,12 +8443,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8386,13 +8465,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"eAP" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "eAW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8485,12 +8557,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
-"eEp" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "eEy" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -8536,6 +8602,14 @@
 	},
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors)
+"eFt" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eFy" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
@@ -8556,12 +8630,6 @@
 /obj/item/signal_horn,
 /obj/item/signal_horn,
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
-"eGy" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
 /area/rogue/indoors/town/garrison)
 "eGD" = (
 /obj/item/natural/stone,
@@ -8615,16 +8683,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"eHv" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "eHU" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8653,17 +8711,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"eIr" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
-"eIC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "eIK" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -8698,6 +8745,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
+"eJE" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eJI" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -8719,13 +8772,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"eKb" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "eKe" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -8759,6 +8805,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"eLR" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "eMc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -8781,6 +8835,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"eMZ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "eNa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8830,12 +8891,6 @@
 	lockid = "priest"
 	},
 /turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
-"ePv" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
 /area/rogue/indoors/town/church/chapel)
 "ePQ" = (
 /turf/open/floor/rogue/dirt/road{
@@ -8898,14 +8953,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"eSj" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eSl" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -8925,12 +8972,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8954,6 +8997,19 @@
 "eTw" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eTL" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "eTM" = (
 /obj/structure/stairs/fancy/c{
 	dir = 1
@@ -8972,13 +9028,6 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"eUt" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "eUw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood{
@@ -9115,12 +9164,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
-"eYG" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "eYI" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora1";
@@ -9179,18 +9222,6 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"eZX" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
-"far" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "faE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -9213,6 +9244,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fbB" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "fbO" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -9231,10 +9271,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"fcf" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "fco" = (
 /obj/structure/statue/saints/martyr2,
 /turf/open/floor/rogue/blocks,
@@ -9294,6 +9330,12 @@
 	dir = 4
 	},
 /area/rogue/indoors)
+"fdG" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "fdM" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
@@ -9364,15 +9406,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"ffN" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+"fgh" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "fgl" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -9421,18 +9464,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"fhK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "fhN" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
@@ -9469,6 +9500,14 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
+"fjB" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fjJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -9496,6 +9535,21 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"fkp" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"fkq" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/magician)
@@ -9557,6 +9611,14 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"fmp" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "fmR" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomi{
@@ -9574,6 +9636,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"fnf" = (
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fnl" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
@@ -9596,16 +9662,6 @@
 "fnA" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
-"fnD" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "fnF" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -9620,6 +9676,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fnL" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9635,14 +9695,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"foQ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "foS" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomiv{
@@ -9663,6 +9715,15 @@
 /obj/structure/statue/saints/cephine2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fpz" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fpQ" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/tribalguard,
@@ -9688,6 +9749,11 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fqo" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
@@ -9699,12 +9765,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
-"frp" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
 "frB" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/exposed)
@@ -9722,6 +9782,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"fsD" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -9761,18 +9825,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"ftE" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ftF" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks,
@@ -9826,21 +9878,10 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"fvl" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "fvr" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fvW" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "fwp" = (
 /obj/structure/bars,
 /turf/closed/mineral/rogue,
@@ -9891,15 +9932,16 @@
 "fxx" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"fxA" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "fxK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"fxX" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "fyb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9968,12 +10010,6 @@
 "fzQ" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"fzR" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fzS" = (
 /obj/effect/landmark/start/farmer{
 	dir = 8
@@ -9988,6 +10024,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fAd" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fAs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -10049,6 +10097,13 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"fBK" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "fBL" = (
 /obj/structure/flora/shroomstump,
 /turf/open/floor/rogue/grass,
@@ -10112,18 +10167,31 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"fDD" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
 /area/rogue/indoors/town/church/chapel)
+"fDF" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -10132,12 +10200,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
-"fEa" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "fEo" = (
 /obj/item/rogueweapon/woodstaff/wise{
 	color = gold;
@@ -10174,6 +10236,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"fEZ" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -10248,6 +10314,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fIs" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "fIw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
@@ -10281,6 +10354,11 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fIG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fIL" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10304,12 +10382,6 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fJl" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -10332,20 +10404,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"fKs" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"fKy" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "fKC" = (
 /turf/open/water/river{
 	dir = 1;
@@ -10372,11 +10430,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/chair/bench/church/mid{
+/obj/structure/chair/wood/rogue{
 	dir = 1
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10432,13 +10490,6 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
-"fPi" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "fPm" = (
 /turf/open/floor/rogue/dirt/road{
@@ -10500,16 +10551,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10555,10 +10599,6 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"fRy" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "fRC" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/landmark/start/prince,
@@ -10592,12 +10632,25 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"fSv" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "fSH" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"fSU" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fTe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road{
@@ -10610,6 +10663,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"fTD" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "fTE" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -10627,14 +10687,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"fTV" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
+"fTO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "fUc" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10699,7 +10757,9 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/structure/closet/crate/chest,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "fVQ" = (
@@ -10707,24 +10767,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"fWa" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "fWh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"fWp" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "fWA" = (
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/blocks,
@@ -10759,6 +10807,16 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
+"fXz" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "fXL" = (
 /obj/structure/bars/pipe{
@@ -10846,9 +10904,12 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "gbN" = (
 /obj/structure/statue/saints/knight2,
 /turf/open/floor/rogue/blocks,
@@ -10864,13 +10925,6 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/church/chapel)
-"gcf" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "gch" = (
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/town/basement)
@@ -10894,10 +10948,6 @@
 "gdc" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/exposed)
-"gds" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gdv" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/under/cavewet/bogcaves)
@@ -10959,16 +11009,6 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves)
-"gff" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gfl" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
@@ -11026,14 +11066,9 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -11075,6 +11110,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"gjV" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "gke" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -11092,6 +11133,12 @@
 /obj/item/rogueweapon/pick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"gkI" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gkJ" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
@@ -11138,15 +11185,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"glV" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "gmc" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -11155,6 +11193,12 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"gmg" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "gmh" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/naturalstone,
@@ -11184,6 +11228,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"gnv" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gnG" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/concrete,
@@ -11209,17 +11257,20 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
-"gog" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "goK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -11240,10 +11291,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
-"gpA" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "gpP" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -11329,13 +11376,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"gtr" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gtx" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -11394,11 +11434,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "gvi" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11432,6 +11470,12 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
+"gws" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11509,6 +11553,12 @@
 /obj/item/chair/stool/bar/rogue/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"gyH" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gyP" = (
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/dirt/road{
@@ -11597,19 +11647,30 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"gBO" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "gBZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "gCr" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "gCA" = (
 /obj/effect/decal/cleanable/blood,
@@ -11659,6 +11720,23 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"gEr" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"gEw" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -11909,6 +11987,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"gMp" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "gMs" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -11917,6 +12002,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"gME" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gMO" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
@@ -12016,6 +12105,17 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"gQa" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "gQl" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/blocks/paving,
@@ -12024,6 +12124,15 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"gQF" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "gQM" = (
 /obj/structure/fluff/statue/small{
 	desc = "An expertly carved figure of an elven woman baring a warm yet flirtatious smile.";
@@ -12035,6 +12144,10 @@
 /obj/item/clothing/head/peaceflower,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/church/chapel)
+"gQV" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "gRd" = (
 /mob/living/carbon/human/species/human/northern/searaider/brute,
@@ -12064,6 +12177,18 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"gRv" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "gRz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -12121,13 +12246,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"gSA" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "gSG" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -12228,6 +12346,17 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"gWc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -12267,6 +12396,10 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"gXN" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "gXW" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -12290,6 +12423,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"gYG" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "gYI" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/c,
@@ -12380,17 +12521,11 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
-"hbi" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12474,14 +12609,6 @@
 /obj/structure/crabnest,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"hcT" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "hcU" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cobbleedge{
@@ -12573,6 +12700,10 @@
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"heJ" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -12696,14 +12827,14 @@
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/beach)
+"hhM" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hhR" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hhY" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "hiz" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -12725,6 +12856,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hiY" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "hji" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -12759,6 +12901,25 @@
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"hke" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "hkk" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -12794,6 +12955,15 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"hkW" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "hlo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -12937,17 +13107,6 @@
 /obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"hnL" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "hnN" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -12962,6 +13121,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"hor" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hox" = (
 /obj/structure/fluff/psycross,
 /obj/item/rogueweapon/woodstaff/aries,
@@ -12987,6 +13153,14 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"hpk" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hpp" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/bogguardsman{
@@ -13065,6 +13239,10 @@
 "hqI" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"hqS" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hqV" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13077,13 +13255,6 @@
 /obj/structure/statue/saints/knight,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"hqZ" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "hra" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -13092,28 +13263,14 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"hrf" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
+"hrS" = (
+/obj/structure/bars,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/church/chapel)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"hsd" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hsg" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/churchrough,
@@ -13125,18 +13282,6 @@
 "hsn" = (
 /turf/open/water/swamp,
 /area/rogue/indoors)
-"hsp" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "hsw" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/woodturned,
@@ -13153,9 +13298,10 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
@@ -13249,6 +13395,21 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"hxv" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"hxA" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hxN" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -13335,15 +13496,6 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"hAx" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
 "hAC" = (
 /obj/structure/bars,
 /turf/open/water/river{
@@ -13399,13 +13551,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"hCW" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "hDm" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
@@ -13437,6 +13582,13 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"hEw" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "hEG" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -13477,19 +13629,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hFp" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "hFM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/ravager,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13507,14 +13646,14 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
 /obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/area/rogue/indoors/town/garrison)
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "hGE" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13563,10 +13702,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"hIn" = (
-/obj/structure/fluff/wallclock/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "hIr" = (
 /obj/structure/stairs{
 	dir = 1
@@ -13604,6 +13739,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"hJH" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "hJJ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -13662,6 +13801,19 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"hLy" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"hLz" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "hLK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/rtfield)
@@ -13678,10 +13830,6 @@
 /obj/effect/rune,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
-"hMb" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "hMD" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -13711,12 +13859,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"hNE" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "hNF" = (
 /obj/structure/stairs{
 	dir = 1
@@ -13815,21 +13957,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"hQz" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
-"hQD" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hQE" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -13850,6 +13977,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hQZ" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "hRc" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -13863,6 +14002,11 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"hRj" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "hRl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -13987,15 +14131,6 @@
 /obj/item/dice,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"hWr" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "hWK" = (
 /obj/structure/fluff/statue/knight/interior,
 /obj/structure/spacevine,
@@ -14037,12 +14172,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cave)
-"hYo" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hYB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -14086,6 +14215,12 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"hZE" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "hZF" = (
 /obj/structure/mineral_door/wood{
 	dir = 4;
@@ -14144,6 +14279,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"ibL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "ibW" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -14179,10 +14324,6 @@
 "icO" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town)
-"icP" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "icU" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave)
@@ -14228,6 +14369,25 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"idW" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "idX" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt/road{
@@ -14278,6 +14438,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "ifq" = (
@@ -14302,18 +14464,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"ifS" = (
+"ign" = (
 /obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
-"igd" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "igq" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -14324,10 +14481,6 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"ihj" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "iho" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -14358,10 +14511,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"iie" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "iim" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -14424,16 +14573,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -14465,20 +14606,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"ilv" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"ilx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14525,13 +14652,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"inY" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14561,15 +14681,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
-"ips" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"ipr" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ipQ" = (
 /obj/structure/bars/pipe{
 	dir = 9;
@@ -14614,12 +14733,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"iqP" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "iqY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14630,6 +14743,12 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"irg" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "iri" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/ruinedwood{
@@ -14642,27 +14761,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"irE" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "irG" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"irI" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "irV" = (
 /turf/open/floor/rogue/twig{
 	dir = 8
@@ -14684,8 +14788,14 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -14693,11 +14803,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -14716,15 +14824,6 @@
 "iur" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"ius" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "iut" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -14762,12 +14861,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ivE" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -14812,14 +14905,6 @@
 "iwV" = (
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"ixk" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
 /area/rogue/indoors/town/church/chapel)
 "ixt" = (
 /obj/item/grown/log/tree/small,
@@ -14957,6 +15042,10 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"iAK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iAR" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -14986,6 +15075,12 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"iBX" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "iCj" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river{
@@ -15009,6 +15104,12 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"iDd" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "iDg" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/under/roguetown/trou,
@@ -15215,14 +15316,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"iKB" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iKR" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -15297,12 +15390,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"iMg" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "iMh" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles{
 	desc = "One of a trio that are joined hand-in-hand with the other nearby statues.";
@@ -15331,11 +15418,12 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -15382,19 +15470,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"iNA" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "iNE" = (
 /obj/machinery/anomalous_crystal,
 /turf/open/floor/rogue/grass,
@@ -15418,6 +15493,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"iOm" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iOq" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/rogue/cobble,
@@ -15426,6 +15505,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"iOL" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iPg" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
@@ -15474,15 +15559,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
-"iPO" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "iPY" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
@@ -15508,6 +15584,15 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"iQF" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "iRe" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
@@ -15519,10 +15604,7 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "iRR" = (
 /obj/structure/table/wood{
@@ -15556,15 +15638,13 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/indoors/town/church/chapel)
-"iSF" = (
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/town)
 "iSJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15587,10 +15667,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"iUn" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "iUY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/neck/roguetown/gorget,
@@ -15644,18 +15720,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/fluff/railing/border{
+/obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
-"iWn" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -15690,12 +15760,12 @@
 /obj/item/natural/bundle/cloth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"iXi" = (
-/obj/structure/flora/ausbushes/ppflowers,
+"iXl" = (
 /obj/structure/fluff/railing/border{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "iXn" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -15707,6 +15777,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"iXM" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "iXT" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -15714,12 +15794,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
-"iXU" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "iXZ" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood{
@@ -15768,16 +15842,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"iYS" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"iZb" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "iZl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -15819,10 +15883,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"jaA" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "jaF" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/purple,
@@ -15899,6 +15959,10 @@
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jcZ" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jde" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -15945,17 +16009,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
-"jeE" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "jeR" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16000,6 +16053,11 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"jfS" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16036,14 +16094,15 @@
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
-"jgQ" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+"jgV" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16088,24 +16147,12 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"jjE" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"jka" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "jkg" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16166,8 +16213,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
@@ -16189,6 +16239,10 @@
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
+"jmT" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jmZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16227,10 +16281,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"jpc" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "jpg" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -16262,9 +16312,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/structure/bars/cemetery,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16311,6 +16367,10 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"jrD" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jrZ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -16324,6 +16384,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"jsF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "jsN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -16381,12 +16447,14 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"juY" = (
-/obj/structure/stairs{
-	dir = 1
+"juR" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -16453,13 +16521,6 @@
 "jxy" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/manor)
-"jxE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
 "jxP" = (
 /obj/structure/table/wood,
 /obj/item/restraints/legcuffs/beartrap,
@@ -16542,10 +16603,6 @@
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"jAw" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "jAG" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
@@ -16563,6 +16620,10 @@
 "jAY" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"jBr" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "jBv" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -16573,21 +16634,30 @@
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"jCm" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
+"jCi" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jCq" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -16677,17 +16747,23 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"jEB" = (
+"jEc" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"jEf" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"jEB" = (
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -16725,10 +16801,12 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"jFP" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+"jGj" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "jGw" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -16796,11 +16874,19 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
+"jIR" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -16819,10 +16905,6 @@
 /obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"jJS" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
@@ -16922,10 +17004,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"jNk" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -17039,13 +17117,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jQk" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "jQo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -17067,11 +17138,6 @@
 "jQy" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
-"jQK" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "jRk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -17090,6 +17156,17 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"jRF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "jRP" = (
 /obj/effect/landmark/events/testportal{
 	aportalloc = "woodsman"
@@ -17132,6 +17209,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"jTw" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "jTy" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/bars/pipe{
@@ -17150,7 +17231,6 @@
 /area/rogue/outdoors/bog)
 "jUs" = (
 /obj/structure/stairs/stone,
-/obj/structure/mineral_door/secret/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
 "jUH" = (
@@ -17163,6 +17243,13 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
+"jUP" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -17171,6 +17258,19 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
+"jVK" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
+"jVO" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17217,6 +17317,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"jXx" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "jXy" = (
 /obj/effect/landmark/start/seelie,
 /turf/open/floor/rogue/grass,
@@ -17241,6 +17348,14 @@
 "jYm" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"jYu" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jYE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/tongs,
@@ -17249,14 +17364,6 @@
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"jYL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "jYR" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -17284,26 +17391,15 @@
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"jZp" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+"jZC" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"jZA" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "jZJ" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -17316,14 +17412,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"jZM" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kad" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "kan" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/mineral_door/bars{
@@ -17372,6 +17468,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"kbt" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "kbR" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
@@ -17422,15 +17527,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"kdN" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"kei" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "keq" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -17472,9 +17568,22 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kfm" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "kfr" = (
 /obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "kfv" = (
@@ -17497,10 +17606,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"kfI" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "kfT" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
@@ -17530,17 +17635,23 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
+"kgF" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "kha" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -17578,22 +17689,17 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"kiS" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
 "kiU" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"kja" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
+"kiX" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kjb" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -17667,6 +17773,10 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kmZ" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "kns" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/herringbone,
@@ -17695,6 +17805,13 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"kpg" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kpk" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -17749,6 +17866,20 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"kqV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "kra" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/rooftop{
@@ -17792,6 +17923,18 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"ksg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17830,14 +17973,21 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"ksN" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "ksO" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -17879,10 +18029,6 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"ktU" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "ktW" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/boss,
 /turf/open/floor/rogue/blocks,
@@ -17894,6 +18040,12 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kuf" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "kup" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/ruinedwood{
@@ -17928,16 +18080,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
-"kvp" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -17977,12 +18125,20 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"kwN" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
+"kwE" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"kwN" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18029,16 +18185,21 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/garrison)
+"kys" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "kyX" = (
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"kzs" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "kzv" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -18216,6 +18377,10 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kEk" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "kEn" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
@@ -18246,12 +18411,9 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18294,13 +18456,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"kGB" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "kGR" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
@@ -18367,6 +18522,21 @@
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kJb" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"kJf" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kJj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -18377,10 +18547,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
-"kJx" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kJJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -18420,13 +18586,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"kKG" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "kKS" = (
 /obj/structure/mineral_door/bars{
 	lockid = "dungeon"
@@ -18451,14 +18610,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"kLw" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+"kLE" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -18496,24 +18651,10 @@
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
-"kMO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "kMT" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"kMV" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "kNa" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -18552,10 +18693,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"kNR" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "kNY" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
@@ -18583,6 +18720,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kOA" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "kOB" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -18639,10 +18782,6 @@
 "kPC" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
-"kPK" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kPO" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
@@ -18691,6 +18830,16 @@
 /obj/structure/chair/bench/couch/r,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"kSe" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "kSh" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -18714,6 +18863,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kSC" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kSG" = (
 /obj/structure/bed/rogue/shit,
 /mob/living/carbon/human/species/halforc/orc_raider/savage_orc/ambush,
@@ -18756,6 +18915,16 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/garrison)
+"kUA" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "kUB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -18864,6 +19033,12 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement)
+"kYz" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kYS" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
@@ -18897,14 +19072,6 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town)
-"kZx" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "kZA" = (
 /obj/structure/mineral_door/bars{
@@ -18954,6 +19121,15 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"lbj" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lbB" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/scomstone,
@@ -18980,13 +19156,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lcF" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ldf" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -19006,10 +19175,11 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"lea" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+"ldQ" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lec" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt,
@@ -19051,13 +19221,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"lfG" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "lfI" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19096,6 +19259,22 @@
 "lgp" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/bog)
+"lgx" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"lgz" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "lgA" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road{
@@ -19126,13 +19305,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -19163,6 +19344,10 @@
 "lih" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/shop)
+"liq" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lis" = (
 /obj/structure/bed/rogue/shit,
 /obj/item/soap,
@@ -19188,14 +19373,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"liH" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "liM" = (
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/hexstone,
@@ -19212,12 +19389,6 @@
 "lji" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
-"ljG" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "ljM" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -19258,16 +19429,15 @@
 "lkM" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"lkT" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+"llg" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "lli" = (
 /obj/structure/rogue/trophy/deer,
 /obj/item/natural/rock,
@@ -19289,15 +19459,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"llV" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "lma" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -19322,16 +19483,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"lmT" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lmV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -19387,9 +19538,14 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -19403,6 +19559,10 @@
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"lpb" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lpe" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -19450,14 +19610,6 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"lpY" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -19476,60 +19628,15 @@
 "lqR" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
-"lqU" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"lqV" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"lrF" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "lsc" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lsg" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "lsD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19610,19 +19717,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"lvu" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"lvy" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lvA" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
@@ -19666,10 +19760,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"lya" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "lyh" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/large,
@@ -19688,6 +19778,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"lyQ" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -19777,12 +19876,6 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"lBJ" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "lBK" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -19799,14 +19892,6 @@
 /obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"lBY" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "lCn" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -19923,29 +20008,22 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"lFQ" = (
-/obj/structure/fluff/walldeco/stone{
+"lFV" = (
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/cavewet/bogcaves/chapel)
+"lFX" = (
+/obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"lFV" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/cavewet/bogcaves/chapel)
-"lGE" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lGI" = (
-/turf/open/floor/rogue/carpet,
+/obj/structure/chair/bench/church/mid{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
@@ -20015,6 +20093,13 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"lJh" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "lJp" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/railing/border{
@@ -20066,10 +20151,26 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"lKy" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lKP" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lKR" = (
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -20092,15 +20193,19 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"lLq" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "lLE" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/town/basement)
 "lLK" = (
-/obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
@@ -20111,6 +20216,14 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"lME" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lMF" = (
 /obj/structure/spider/stickyweb,
 /turf/open/water/sewer,
@@ -20124,27 +20237,28 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/rtfield)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/church/chapel)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lNY" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+"lNA" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
+"lNU" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "lOl" = (
 /obj/structure/mineral_door/wood,
@@ -20162,6 +20276,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"lOG" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lOH" = (
 /obj/item/rogue/instrument/harp,
 /obj/structure/flora/newleaf,
@@ -20192,15 +20314,12 @@
 "lPu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"lPI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"lPv" = (
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "lPQ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20230,12 +20349,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
-"lRd" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "lRJ" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
@@ -20270,12 +20383,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"lTy" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
 "lTz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/c,
@@ -20291,13 +20398,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"lUc" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "lUj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/churchrough,
@@ -20308,6 +20408,16 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
+"lUO" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lUQ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/church,
@@ -20332,25 +20442,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"lVF" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lVS" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks{
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors)
+"lVX" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lVZ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur,
 /turf/open/floor/rogue/dirt/road{
@@ -20362,10 +20463,12 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"lWI" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
+"lWz" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
@@ -20391,10 +20494,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lXv" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "lXJ" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
@@ -20450,13 +20549,6 @@
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"lYV" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "lYY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors/town/shop)
@@ -20464,13 +20556,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lZf" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "lZh" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
@@ -20486,6 +20571,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"lZE" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "mab" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
@@ -20515,33 +20607,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"maV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "mbm" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"mbx" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -20582,11 +20651,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mdm" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "mdo" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20604,8 +20668,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20666,12 +20737,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"meF" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "meV" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/structure/table/wood{
@@ -20709,30 +20774,6 @@
 "mfK" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician)
-"mgd" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "mgk" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/bog)
@@ -20746,10 +20787,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"mgR" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -20772,6 +20809,10 @@
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"mhE" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mhJ" = (
 /obj/item/chair/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20823,15 +20864,12 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -20866,12 +20904,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"mkS" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "mle" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -20893,6 +20925,17 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"mma" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "mmb" = (
 /obj/machinery/anvil,
 /turf/open/floor/rogue/blocks,
@@ -20912,14 +20955,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"mnG" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21021,6 +21056,10 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"mqI" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "mrl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21031,6 +21070,13 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town)
+"mrw" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "mrE" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -21095,12 +21141,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
-"mtO" = (
-/mob/living/simple_animal/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "mtR" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
@@ -21113,6 +21153,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"mup" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mus" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -21173,13 +21217,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"mwM" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "mwR" = (
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /obj/structure/rack/rogue,
@@ -21198,19 +21235,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"mxm" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
+"mxn" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mxx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"mxy" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "mxK" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21287,6 +21325,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"mBJ" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "mCz" = (
 /obj/effect/landmark/start/guardsman{
 	dir = 1
@@ -21377,6 +21425,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"mFA" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mFC" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -21412,12 +21467,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "mGn" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/stairs{
 	dir = 1
 	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
@@ -21450,27 +21504,38 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"mHK" = (
-/obj/structure/chair/wood/rogue/chair3{
+"mIn" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"mJt" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"mIR" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"mJI" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "mJL" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/woodturned,
@@ -21524,14 +21589,6 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"mLO" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21657,53 +21714,28 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"mQg" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "mQq" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"mQA" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
-"mQx" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"mQA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/outdoors/mountains)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"mRp" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mRr" = (
 /obj/structure/fluff/wallclock{
 	dir = 3
@@ -21761,6 +21793,13 @@
 	dir = 6
 	},
 /area/rogue/outdoors/bog)
+"mTP" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "mTT" = (
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/churchmarble,
@@ -21811,10 +21850,12 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -21876,6 +21917,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"mXk" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "mXn" = (
 /obj/structure/mineral_door/bars,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21910,16 +21955,20 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"mYD" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mYJ" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"mYZ" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "mZo" = (
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
@@ -21946,17 +21995,6 @@
 "nad" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/tribalfort)
-"nap" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "naI" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/manor)
@@ -22015,14 +22053,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"nbF" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"nca" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22063,6 +22093,18 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors/town/tavern)
+"ndA" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ndD" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora2";
@@ -22088,6 +22130,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"ndQ" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "ndT" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -22114,6 +22163,20 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
+"neE" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
+"neN" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "neP" = (
 /turf/open/water/river{
 	dir = 4;
@@ -22131,19 +22194,27 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"nfd" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
-"nfn" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
+"nfi" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nga" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22167,14 +22238,9 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22214,6 +22280,15 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nju" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "njv" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt/road,
@@ -22225,6 +22300,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"nkq" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22299,6 +22381,11 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"nnh" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nnk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
@@ -22343,6 +22430,17 @@
 	},
 /turf/closed,
 /area/rogue/indoors/town/manor)
+"npv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "npJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -22357,10 +22455,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"npZ" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "nqf" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/blocks,
@@ -22497,12 +22591,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/gate/bars{
-	gid = "viking1";
-	redstone_id = "viking1"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -22555,24 +22652,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"nwC" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "nwT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -22623,6 +22702,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"nxD" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "nxF" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -22710,10 +22793,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"nzI" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "nzO" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/naturalstone,
@@ -22749,9 +22828,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -22785,6 +22863,22 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"nCB" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"nCG" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nCN" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22941,6 +23035,12 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"nIw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nIy" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -22951,13 +23051,6 @@
 /obj/structure/plasticflaps,
 /turf/open/water/swamp,
 /area/rogue/indoors/town)
-"nIA" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nIH" = (
 /obj/structure/bars/tough,
 /turf/open/water/sewer,
@@ -22975,9 +23068,19 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"nIX" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "nJy" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -23055,12 +23158,23 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"nMg" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nMj" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors)
+"nMl" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nMz" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/twig,
@@ -23119,11 +23233,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"nPg" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "nPt" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/closet/crate/drawer,
@@ -23136,9 +23245,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23156,11 +23270,6 @@
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"nQh" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "nQi" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/shoes/roguetown/boots,
@@ -23192,6 +23301,15 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"nQP" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "nQU" = (
 /obj/structure/chair/wood,
 /turf/open/floor/rogue/woodturned,
@@ -23222,6 +23340,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"nRw" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nRx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -23249,10 +23373,8 @@
 /area/rogue/indoors/town)
 "nSr" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	dir = 8;
+	pixel_y = -1
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -23293,11 +23415,10 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23358,6 +23479,12 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"nVP" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nVU" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -23365,6 +23492,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"nWe" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nWj" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -23380,23 +23515,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"nWG" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"nWJ" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "nWM" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -23496,11 +23614,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"nYv" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "nYO" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -23553,34 +23666,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"oaN" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"oaV" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "obq" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23647,6 +23739,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"odd" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "odi" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
@@ -23713,15 +23813,6 @@
 "ofq" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
-"ofs" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ofB" = (
 /obj/item/needle/thorn,
 /obj/structure/table/wood{
@@ -23739,13 +23830,6 @@
 /obj/structure/flora/newtree,
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
-"ogj" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ogo" = (
 /obj/structure/statue/saints/acolyte_alt,
 /turf/open/floor/rogue/cobble,
@@ -23764,9 +23848,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -23780,6 +23865,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"ohr" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ohs" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -23829,18 +23921,6 @@
 "ohU" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"ohY" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -23913,13 +23993,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"olC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "olD" = (
 /turf/open/floor/grass/snow{
 	icon_state = "ice"
@@ -23939,12 +24012,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"olZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "oma" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
@@ -23959,6 +24026,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"omi" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "oml" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 10
@@ -23975,6 +24048,11 @@
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
+"omQ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "one" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -23998,10 +24076,6 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"onS" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "onT" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -24129,19 +24203,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"otk" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "ots" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
@@ -24190,6 +24251,23 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"oul" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
+"oun" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "ous" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -24202,12 +24280,21 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ovd" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "ovj" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -24243,6 +24330,18 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"owa" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24342,10 +24441,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"oza" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "oze" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/grass,
@@ -24373,6 +24468,12 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"ozP" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "oAf" = (
 /obj/structure/bars/cemetery,
 /obj/effect/decal/cobbleedge,
@@ -24444,6 +24545,13 @@
 	icon_state = "knightstatue_r"
 	},
 /turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
+"oBO" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "oBU" = (
 /obj/effect/landmark/start/priest,
@@ -24527,6 +24635,11 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"oEy" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "oEL" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/tile{
@@ -24571,6 +24684,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oFV" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oGv" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/effect/landmark/start/tribalcook,
@@ -24616,13 +24733,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"oHu" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "oHA" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 10
@@ -24645,9 +24755,18 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"oIG" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oIY" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -24675,8 +24794,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "oJO" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -24698,11 +24820,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"oKL" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oLb" = (
 /obj/structure/stairs{
 	dir = 1
@@ -24723,10 +24840,20 @@
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
-"oMa" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+"oLS" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"oMa" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -24824,6 +24951,11 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
+"oOW" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "oPi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
@@ -24869,10 +25001,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/rtfield)
-"oRb" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "oRc" = (
 /obj/structure/lever/wall{
 	pixel_x = 12;
@@ -24895,10 +25023,11 @@
 /obj/structure/fermenting_barrel/random,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"oRi" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "oRp" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "oRs" = (
@@ -24908,12 +25037,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"oRB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "oRF" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/father,
@@ -25041,6 +25164,12 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"oVC" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oVD" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/twig,
@@ -25129,6 +25258,13 @@
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"oXz" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oXE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -25184,14 +25320,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"oZA" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "oZC" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -25305,13 +25433,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"pcr" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+"pcs" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pct" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -25349,9 +25474,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -25364,23 +25495,9 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"pdl" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "pdm" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -25391,9 +25508,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"pdP" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
 "pel" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -25402,13 +25516,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"pes" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "peN" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -25431,12 +25538,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"peX" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "peZ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25450,6 +25551,13 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"pfi" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pfp" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -25543,6 +25651,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"piN" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "piV" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
@@ -25623,6 +25741,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"pkX" = (
+/obj/structure/closet/crate/chest/reward,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "plb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/fluff/railing/wood{
@@ -25633,16 +25755,38 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"pmd" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"pmt" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pmF" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/mince,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"pmK" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "pnl" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/bog,
@@ -25756,6 +25900,16 @@
 /obj/structure/fluff/walldeco/rpainting/forest,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
+"pqp" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "pqr" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -25821,10 +25975,6 @@
 "prZ" = (
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
-"psj" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "psz" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/roguekey/mason,
@@ -25855,14 +26005,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"ptu" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "pty" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8;
@@ -25879,6 +26021,15 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors)
+"ptP" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "ptT" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -26007,12 +26158,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"pxY" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "pyh" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -26094,13 +26239,6 @@
 "pAa" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
-"pAb" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "pAg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -26143,12 +26281,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"pBp" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "pBx" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/roguebin/water,
@@ -26163,26 +26295,10 @@
 	icon_state = "stonewindow"
 	},
 /area/rogue/indoors)
-"pBQ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "pBS" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"pCk" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "pCl" = (
 /obj/structure/handcart,
 /obj/item/grown/log/tree,
@@ -26270,15 +26386,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"pEw" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "pEC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -26286,6 +26393,11 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pFt" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26296,6 +26408,10 @@
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"pGo" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pGz" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26308,6 +26424,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"pGM" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "pHa" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -26347,6 +26470,10 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"pIn" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "pIq" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -26380,23 +26507,6 @@
 /obj/item/storage/belt/rogue/leather/black,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"pJP" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "pKb" = (
 /obj/structure/winch{
 	gid = "townin2";
@@ -26421,12 +26531,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -26458,6 +26565,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
+"pLq" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "pLs" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -26481,13 +26592,14 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -26555,6 +26667,10 @@
 "pOf" = (
 /turf/open/water/river,
 /area/rogue/under/town/sewer)
+"pOq" = (
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "pOs" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -26580,6 +26696,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"pOT" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "pPq" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "nobleguest"
@@ -26596,6 +26720,14 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"pPt" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "pPy" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road{
@@ -26614,13 +26746,6 @@
 /area/rogue/indoors/town/tavern)
 "pPO" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/outdoors/mountains)
-"pPY" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "pQd" = (
 /turf/closed/mineral/rogue,
@@ -26646,16 +26771,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"pRt" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "pRE" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -26726,10 +26841,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"pTC" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "pTE" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -26805,13 +26916,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"pWw" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -26970,16 +27074,6 @@
 /obj/item/clothing/cloak/stabard/guardhood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"qbA" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qbC" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -27009,6 +27103,22 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qcb" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"qcc" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qcm" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -27047,15 +27157,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"qdg" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "qdn" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -27083,6 +27184,16 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"qdN" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qee" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -27101,23 +27212,13 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qeH" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "qeY" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -27163,14 +27264,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cave)
-"qgD" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qgH" = (
 /obj/structure/winch{
 	gid = "forestgate2";
@@ -27178,25 +27271,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"qgS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
+"qgY" = (
+/obj/structure/stairs{
+	dir = 4
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/closed,
+/area/rogue/indoors/town)
 "qhg" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -27243,21 +27323,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qif" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "qil" = (
 /obj/structure/bars/passage{
 	redstone_id = "tourneytop"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"qip" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -27313,6 +27384,13 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qjY" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qkl" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27387,25 +27465,13 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qmp" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "qmx" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qmC" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
+"qmA" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "qne" = (
 /obj/effect/decal/cobbleedge,
@@ -27475,18 +27541,17 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"qor" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "qoE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"qoR" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27533,8 +27598,23 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"qpY" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -27556,6 +27636,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"qqq" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "qqA" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -27572,13 +27658,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"qqE" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qqV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -27620,6 +27699,12 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors)
+"qrv" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "qrA" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -27698,6 +27783,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qua" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qub" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile{
@@ -27708,12 +27797,12 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"quy" = (
-/obj/structure/chair/wood{
-	dir = 4
+"quv" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -27728,9 +27817,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -27773,6 +27864,13 @@
 "qvB" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/manor)
+"qvL" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qvR" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
@@ -27787,19 +27885,15 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -27874,20 +27968,23 @@
 	},
 /area/rogue/outdoors/bog)
 "qzy" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
 	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -27914,6 +28011,14 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qAB" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "qBk" = (
 /obj/structure/stairs{
 	dir = 4
@@ -27932,13 +28037,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"qBH" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qBX" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -27961,32 +28059,24 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"qDm" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "qDn" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"qDq" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -27994,12 +28084,6 @@
 "qDI" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/vikingarea)
-"qDL" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qDP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -28015,31 +28099,10 @@
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
-"qEO" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qEY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
-"qFp" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qFu" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -28048,16 +28111,6 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
-"qFF" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qFK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/churchbrick,
@@ -28072,16 +28125,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
-	},
-/area/rogue/under/cave)
-"qGy" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -28153,6 +28199,10 @@
 /obj/item/soap,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"qJh" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qJp" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -28179,6 +28229,10 @@
 /obj/structure/mineral_door/wood,
 /turf/open/water/swamp,
 /area/rogue/indoors)
+"qKg" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "qKo" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood,
@@ -28192,20 +28246,8 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
-"qKD" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "qKU" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
@@ -28234,9 +28276,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
 "qLF" = (
-/obj/structure/roguewindow/stained/silver,
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
 /obj/structure/bars,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "qLP" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -28256,23 +28302,23 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"qMB" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
-"qMF" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+"qMk" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"qNU" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -28315,16 +28361,6 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"qPF" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "qPH" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
@@ -28358,13 +28394,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"qQo" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
+"qQD" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -28384,26 +28421,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qRp" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -28466,15 +28492,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"qUg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "qUE" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -28498,6 +28515,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"qVq" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "qVD" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -28576,15 +28597,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -28624,6 +28641,13 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"rac" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
@@ -28633,15 +28657,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"rba" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rbk" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -28691,10 +28706,6 @@
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
-"rbZ" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
 "rcg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -28702,9 +28713,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"rcm" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -28712,9 +28720,8 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -28825,11 +28832,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -28858,14 +28862,9 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"rgw" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "rgO" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -28931,6 +28930,25 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"riW" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
+"rja" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "rjg" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -28981,6 +28999,12 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"rlo" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29055,13 +29079,20 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"rnq" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"rnn" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "rns" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/globe,
@@ -29146,6 +29177,10 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"rqu" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "rqP" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29288,10 +29323,6 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"rvU" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29415,10 +29446,6 @@
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
-"rzb" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "rzq" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -29520,9 +29547,6 @@
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"rDR" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -29609,6 +29633,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"rGp" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rGQ" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -29617,36 +29649,44 @@
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
-"rGS" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "rGY" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"rHa" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/area/rogue/indoors/town/church/chapel)
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "rHM" = (
 /obj/structure/fluff/railing/border{
@@ -29654,27 +29694,31 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"rHO" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rHW" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"rIc" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rIl" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 8
 	},
 /area/rogue/indoors/town)
-"rIm" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
-"rIE" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
+"rIp" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
 "rIP" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -29715,6 +29759,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"rJI" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rJX" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road{
@@ -29742,6 +29790,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"rKD" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "rKQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -29796,6 +29854,15 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
+"rMX" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "rNg" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -29856,6 +29923,12 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
+"rPa" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "rPE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -29873,6 +29946,11 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"rPO" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "rPR" = (
 /obj/structure/crabnest,
 /turf/open/water/sewer,
@@ -29907,6 +29985,12 @@
 "rQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
+"rQT" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rRb" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/sewer)
@@ -29922,9 +30006,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -29938,24 +30022,21 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -30009,6 +30090,12 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
+"rTo" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rTv" = (
 /obj/structure/fluff/traveltile/vampire{
 	aportalgoesto = "vampin";
@@ -30047,22 +30134,28 @@
 	},
 /area/rogue/indoors/town/manor)
 "rTT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"rTZ" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
@@ -30113,6 +30206,10 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"rWd" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rWj" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -30166,10 +30263,6 @@
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"rXY" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "rXZ" = (
 /obj/item/rogueweapon/mace/wsword,
 /obj/item/rogueweapon/mace/wsword,
@@ -30184,14 +30277,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"rYq" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "rYt" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -30229,10 +30314,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"rYO" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+"rZg" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "rZk" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30305,11 +30394,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/wood/rogue{
+	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30390,10 +30479,6 @@
 /obj/structure/statue/saints/magelady2_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"sdD" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
 "sdR" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair/wood/rogue{
@@ -30424,9 +30509,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -30450,12 +30537,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"sgf" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "sgi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -30471,6 +30552,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"sgt" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "sgx" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -30510,14 +30595,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"sgY" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "shd" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -30570,6 +30647,26 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"siT" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"siV" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sjc" = (
 /obj/structure/bars/tough,
 /turf/open/water/cleanshallow,
@@ -30618,6 +30715,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"skp" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "skx" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/grass/snow,
@@ -30884,6 +30985,16 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"ssP" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "ssY" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -30894,6 +31005,10 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/outdoors/beach)
+"stj" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "stv" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -30916,12 +31031,6 @@
 "sue" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors)
-"suf" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sux" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -31008,10 +31117,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/obj/structure/bars,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "sxR" = (
@@ -31039,10 +31145,6 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"syi" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sym" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
@@ -31065,6 +31167,10 @@
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"szi" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "szp" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -31139,10 +31245,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"sCf" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
 "sCg" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -31156,11 +31258,27 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town)
 "sDa" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -31232,12 +31350,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"sFM" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "sGj" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -31308,6 +31420,13 @@
 "sIl" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"sIx" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "sIy" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
@@ -31316,8 +31435,8 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
@@ -31334,26 +31453,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"sIT" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"sJd" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"sJt" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "sJZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -31400,12 +31499,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"sLs" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31417,14 +31510,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"sLY" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "sMb" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/wood,
@@ -31437,12 +31522,16 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"sNj" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+"sNm" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "sNp" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -31457,22 +31546,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
-"sNS" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "sNY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -31497,15 +31570,6 @@
 "sPu" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"sPx" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "sPH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -31519,6 +31583,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"sPK" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "sPP" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/naturalstone,
@@ -31537,16 +31607,36 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"sQN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
+"sRe" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "sRD" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -31554,6 +31644,13 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sRO" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"sRT" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -31618,10 +31715,9 @@
 "sTr" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter)
-"sTN" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"sTG" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "sTW" = (
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt/road{
@@ -31679,6 +31775,10 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"sVh" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sVB" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -31695,27 +31795,12 @@
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sWs" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"sWy" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "sWL" = (
 /obj/effect/landmark/start/squire{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"sWT" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "sWU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31733,16 +31818,6 @@
 /area/rogue/indoors/town/manor)
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town)
-"sXO" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "sXU" = (
 /obj/structure/fermenting_barrel/random,
@@ -31795,10 +31870,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"sZB" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -31835,6 +31906,12 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"taz" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "taK" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -31960,6 +32037,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"tex" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "teE" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -31990,7 +32071,8 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/turf/open/floor/carpet/inn,
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -32014,6 +32096,18 @@
 "tgZ" = (
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"thr" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "thM" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -32029,14 +32123,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"tig" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "til" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/tile,
@@ -32058,8 +32144,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -32110,13 +32197,6 @@
 	dir = 1;
 	icon_state = "wooden_floor2"
 	},
-/area/rogue/indoors/town/church/chapel)
-"tks" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "tkB" = (
 /obj/structure/fluff/railing/border{
@@ -32169,6 +32249,10 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"tlG" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -32176,14 +32260,20 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5"
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"tlS" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32194,13 +32284,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"tmj" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+"tmu" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "tmE" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -32269,18 +32356,6 @@
 "tou" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"toI" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"toM" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
@@ -32293,9 +32368,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"tpO" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
+"tpY" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "tqq" = (
 /obj/structure/table/wood{
@@ -32371,13 +32449,6 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"tsJ" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32391,14 +32462,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"ttB" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "ttC" = (
 /obj/structure/lever/wall{
 	pixel_x = 32;
@@ -32481,14 +32544,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"twz" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "twA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32501,10 +32556,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
-"twL" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "twP" = (
 /obj/item/rogueweapon/spear{
 	color = gold;
@@ -32618,18 +32669,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tzj" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tzy" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -32663,16 +32702,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"tAb" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tAf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -32784,10 +32813,6 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
-"tCF" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
@@ -32820,10 +32845,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"tDB" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
 "tDJ" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -32882,6 +32903,23 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"tFA" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "tFH" = (
 /obj/item/dice,
 /obj/structure/table/wood{
@@ -32978,6 +33016,13 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
+"tJl" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tJp" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -32996,12 +33041,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -33020,13 +33066,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tKO" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "tKW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -33044,12 +33083,6 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"tLZ" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "tMb" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/item/clothing/cloak/tabard/crusader/astrata,
@@ -33086,6 +33119,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"tNe" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tNj" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -33100,15 +33138,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
-"tNp" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "tNr" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -33160,18 +33189,15 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"tOk" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
+"tOB" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "tOM" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -33201,6 +33227,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"tQT" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33240,6 +33274,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"tTv" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tTF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -33273,10 +33317,6 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
 "tUw" = (
@@ -33290,8 +33330,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -33305,13 +33343,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"tUZ" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
 "tVd" = (
 /obj/structure/gate{
 	gid = "gatemanor2";
@@ -33320,6 +33351,12 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
+"tVo" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "tVp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -33328,11 +33365,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"tVB" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tVG" = (
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -33383,6 +33415,16 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"tXh" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tXC" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /obj/structure/flora/roguetree,
@@ -33391,6 +33433,14 @@
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"tYB" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "tYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -33415,6 +33465,17 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"tZx" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "tZJ" = (
 /obj/structure/fluff/walldeco/bigpainting/lake,
 /turf/open/floor/carpet/royalblack,
@@ -33455,6 +33516,24 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"uaQ" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uaX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -33468,6 +33547,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"ubr" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ubv" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -33621,10 +33707,6 @@
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"uhn" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "uhw" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -33687,14 +33769,6 @@
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"uka" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "ukb" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -33746,45 +33820,10 @@
 /obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"ulR" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
-"ulU" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ulY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"umi" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
-"umz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "umH" = (
 /obj/structure/bars/pipe{
 	dir = 5
@@ -33859,6 +33898,21 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"upu" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "upx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -33866,6 +33920,17 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"upC" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"upI" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "upU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/asteroid/elite/broodmother,
 /turf/open/floor/rogue/blocks,
@@ -33914,9 +33979,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34071,13 +34136,8 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "uvu" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34093,13 +34153,14 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
 "uwa" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"uwf" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34126,6 +34187,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"uwX" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uxf" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/structure/fluff/railing/border{
@@ -34148,13 +34216,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -34194,6 +34258,14 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"uyO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "uyU" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/transparent/openspace,
@@ -34214,9 +34286,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34304,13 +34379,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"uCD" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "uCF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -34342,8 +34410,13 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -34364,32 +34437,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"uEA" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
-"uEB" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "uEG" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34404,19 +34451,22 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -34426,6 +34476,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uFY" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uGc" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -34437,9 +34496,12 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uGo" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -34459,6 +34521,14 @@
 /obj/structure/closet/crate/drawer/inn,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"uGE" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "uGI" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/tile,
@@ -34495,19 +34565,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"uHk" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
-"uHk" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -34531,11 +34594,6 @@
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
-"uKf" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -34637,10 +34695,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"uMB" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "uMO" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -34666,12 +34720,12 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"uNW" = (
-/obj/structure/stairs/stone{
-	dir = 1
+"uNH" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -34704,10 +34758,13 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/obj/structure/flora/ausbushes/brflowers,
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
+"uPi" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -34728,10 +34785,6 @@
 	dir = 4
 	},
 /area/rogue/indoors)
-"uPD" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "uPE" = (
 /obj/structure/mineral_door/wood{
 	lockid = "townroom2"
@@ -34747,12 +34800,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"uQb" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "uQp" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -34791,12 +34838,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"uRt" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -34818,16 +34859,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"uSP" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "uSS" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
@@ -34926,6 +34957,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"uVS" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "uVU" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
@@ -35047,9 +35082,13 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -35063,6 +35102,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"uZN" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uZY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -35137,30 +35180,22 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"vcN" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
+"vdd" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "vdg" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -35188,6 +35223,13 @@
 "veg" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
+"veu" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vey" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/oat,
@@ -35235,8 +35277,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35269,16 +35312,23 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vfW" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
+"vgh" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/blocks/stonered,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"vgv" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "vgz" = (
 /obj/structure/table/wood{
@@ -35341,9 +35391,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"vhV" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
 "vib" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 1
@@ -35362,17 +35409,16 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"viP" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "vjs" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -35392,21 +35438,19 @@
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"vjV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
+"vjL" = (
+/obj/structure/fluff/railing/wood{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vka" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/tavern)
@@ -35414,13 +35458,16 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vkB" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"vkk" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/rtfield)
 "vkI" = (
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35499,9 +35546,22 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"vnw" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
+"vnG" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "vnK" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/grown/log/tree/stick,
@@ -35516,18 +35576,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"voc" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "vof" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road{
@@ -35553,12 +35601,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -35638,6 +35686,13 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"vrS" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "vse" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/iron/messer,
@@ -35656,10 +35711,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35703,13 +35757,6 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"vtF" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "vtZ" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/ruinedwood{
@@ -35781,24 +35828,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"vvo" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "vvJ" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"vvU" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "vvV" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -35872,6 +35905,12 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"vyS" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -35929,6 +35968,15 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"vzO" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vzR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -35988,6 +36036,14 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"vBy" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
@@ -36067,6 +36123,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"vDr" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vDz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36087,6 +36150,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vDQ" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "vDS" = (
 /obj/structure/bars/pipe,
 /obj/item/roguegem/random,
@@ -36147,24 +36214,17 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/wood,
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
-"vFL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -36186,14 +36246,17 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "vGQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "vGT" = (
 /obj/structure/spacevine,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -36204,12 +36267,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
-	},
+/obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36248,15 +36308,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
-"vJz" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "vJU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -36283,14 +36334,13 @@
 /obj/structure/fluff/walldeco/maidendrape,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"vLy" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "vLA" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -36326,15 +36376,24 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"vMj" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "vMQ" = (
 /obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/town)
 "vMT" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -36372,23 +36431,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"vOe" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vOy" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vOH" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "vOU" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/effect/decal/cleanable/cobweb,
@@ -36410,13 +36458,13 @@
 /area/rogue/indoors)
 "vPA" = (
 /obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/church/chapel)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -36458,11 +36506,10 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36474,13 +36521,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"vRA" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "vRF" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
@@ -36570,10 +36610,10 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/carbon/human/species/skeleton/no_equipment,
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -36601,17 +36641,6 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"vVP" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "vWa" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -36660,7 +36689,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/turf/open/floor/rogue/wood,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -36693,10 +36728,6 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
-"vYa" = (
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "vYw" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -36760,6 +36791,12 @@
 "wan" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
+"waB" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "waE" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36827,6 +36864,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"wdv" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wdJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
@@ -36866,6 +36907,7 @@
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
 	},
+/obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "weB" = (
@@ -36895,18 +36937,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"wfJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"wfP" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "wfY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper/scroll,
@@ -36914,14 +36944,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "wgn" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36967,6 +36993,17 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
+"wjl" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -36990,6 +37027,10 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
+"wke" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "wkg" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
@@ -37033,6 +37074,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"wmH" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wmK" = (
 /obj/structure/stairs{
 	dir = 1
@@ -37081,26 +37126,16 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
-	},
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "wou" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"woJ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37111,16 +37146,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"wpc" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "wpe" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -37138,9 +37163,14 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -37157,26 +37187,24 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"wqv" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
+	icon_state = "tablewood1"
 	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"wqB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "wqE" = (
 /obj/structure/fluff/traveltile{
@@ -37199,23 +37227,45 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"wra" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+"wqV" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4"
 	},
-/turf/open/floor/rogue/grass,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"wra" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
 /area/rogue/indoors/town/church/chapel)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
+"wsg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"wsx" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "wsR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -37232,7 +37282,6 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "wte" = (
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
 	dir = 4;
 	layer = 2.8;
@@ -37248,6 +37297,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"wtx" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wty" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -37286,13 +37339,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"wvn" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
+"wvp" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "wvy" = (
 /obj/structure/flora/roguetree,
@@ -37343,10 +37396,6 @@
 "wxd" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"wxi" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "wxy" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -37373,11 +37422,8 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
@@ -37415,6 +37461,14 @@
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
+"wAp" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "wAr" = (
 /obj/item/bait,
 /obj/item/bait,
@@ -37424,13 +37478,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"wAJ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "wAP" = (
 /obj/structure/rack/rogue,
 /obj/item/flint,
@@ -37548,24 +37595,19 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37590,19 +37632,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"wFa" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "wFc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -37619,13 +37648,19 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"wFp" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+"wFn" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
 	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"wFp" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -37667,12 +37702,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"wGR" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "wHa" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/cobble,
@@ -37686,18 +37715,6 @@
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
-"wIc" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -37884,6 +37901,20 @@
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"wOr" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
@@ -37950,9 +37981,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"wPR" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town)
 "wPU" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/woodturned,
@@ -38012,10 +38040,6 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wRw" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wRy" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -38034,12 +38058,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
 /area/rogue/indoors/town)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
@@ -38056,13 +38081,18 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"wSY" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wTs" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/obj/structure/bars,
+/turf/closed,
 /area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
@@ -38086,13 +38116,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
+/obj/structure/fluff/railing/wood{
+	dir = 8
 	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38106,6 +38134,10 @@
 /obj/structure/statue/saints/acolyte_alt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"wVi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wVs" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/churchrough,
@@ -38138,13 +38170,6 @@
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/bog)
-"wXi" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "wXj" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -38153,6 +38178,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"wXp" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "wXz" = (
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -38176,6 +38207,10 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wYa" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "wYk" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -38190,10 +38225,13 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38221,10 +38259,6 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
-"wZA" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "wZJ" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword,
@@ -38236,9 +38270,15 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38279,10 +38319,18 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38295,29 +38343,6 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"xcm" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"xct" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "xcF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -38354,26 +38379,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"xdQ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
@@ -38508,6 +38518,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"xhZ" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "xif" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -38603,7 +38623,14 @@
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
 /area/rogue/outdoors/mountains)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -38646,6 +38673,12 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"xlY" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xmn" = (
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/wood,
@@ -38660,10 +38693,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"xmZ" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "xna" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -38683,6 +38712,11 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"xng" = (
+/turf/open/lava{
+	name = "an actual pit of lava"
+	},
+/area/rogue/under/cave)
 "xnp" = (
 /obj/structure/stairs,
 /obj/structure/stairs{
@@ -38798,22 +38832,13 @@
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"xpF" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xpM" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -38825,12 +38850,6 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"xqD" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xqH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -38873,6 +38892,10 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"xrs" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "xrH" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
@@ -38882,6 +38905,23 @@
 "xrI" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/shop)
+"xrO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"xrW" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "xse" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -38902,14 +38942,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"xsL" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "xtc" = (
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
@@ -38959,6 +38991,16 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"xtW" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
+"xud" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "xuh" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -39040,24 +39082,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"xwo" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39139,16 +39165,6 @@
 	dir = 9
 	},
 /area/rogue/outdoors/mountains)
-"xyB" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "xyC" = (
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/ruinedwood,
@@ -39172,18 +39188,19 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"xyU" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "xzi" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"xzx" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "xzN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road{
@@ -39206,11 +39223,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -39221,6 +39238,18 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town)
+"xAw" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"xAz" = (
+/obj/structure/fluff/wallclock/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "xAL" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border{
@@ -39394,41 +39423,24 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xEF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
+"xEI" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
 	},
-/turf/closed,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"xEK" = (
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "xET" = (
-/obj/structure/stairs{
-	dir = 4
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
-"xFb" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
-"xFi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39469,6 +39481,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"xGq" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "xGz" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/dirt/road{
@@ -39510,11 +39531,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xHe" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39552,6 +39574,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"xIg" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "xIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -39559,23 +39589,6 @@
 /obj/item/rope,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"xIq" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"xIr" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "xID" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -39587,9 +39600,21 @@
 /obj/effect/landmark/start/guardsman,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"xIQ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xJe" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39688,22 +39713,27 @@
 "xMr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
-"xMs" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
+"xMP" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
+"xMR" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "xMZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -39717,6 +39747,10 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town/roofs)
+"xNf" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "xNo" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -39735,6 +39769,10 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"xOd" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "xOt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -39817,6 +39855,13 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/garrison)
+"xQc" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "xQK" = (
 /obj/structure/bed/rogue/shit,
@@ -39998,14 +40043,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"xVB" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "xVJ" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
@@ -40105,6 +40142,16 @@
 "xYz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"xYB" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xYM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -40117,6 +40164,16 @@
 /obj/item/natural/poo/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"xZg" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xZs" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -40200,6 +40257,11 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"ybB" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ybH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/border{
@@ -40221,45 +40283,26 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"ych" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
-"ycs" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "ycv" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 8
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"ycX" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ydb" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -40280,6 +40323,10 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
+"yeq" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "yer" = (
 /obj/structure/bars/passage/shutter,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -40331,11 +40378,14 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"yfe" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"yff" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "yfj" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -40372,12 +40422,34 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"yfN" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
+"yfQ" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "yfY" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "ygF" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"ygS" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ygW" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
@@ -40402,6 +40474,12 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
+/area/rogue/indoors/town/church/chapel)
+"yhL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "yhO" = (
 /obj/structure/spider/stickyweb,
@@ -40432,20 +40510,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"yir" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "yiw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/mountains)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -40473,11 +40543,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -40529,9 +40600,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"yll" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "ylC" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/basement)
@@ -184128,13 +184196,13 @@ bpD
 bpD
 bpD
 bpD
-nJy
-nJy
-nJy
-nJy
-nJy
-nJy
-nJy
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -184530,13 +184598,13 @@ bpD
 bpD
 bpD
 bpD
-nJy
-bKE
-goz
-goz
-vQV
-bKE
-nJy
+dbt
+pkX
+tUp
+tUp
+xlY
+pkX
+dbt
 bpD
 bpD
 bpD
@@ -184932,17 +185000,17 @@ bpD
 bpD
 bpD
 bpD
-nJy
-goz
-goz
-vQV
-goz
-jNk
-nJy
-nJy
-nJy
-nJy
-nJy
+dbt
+tUp
+tUp
+xlY
+tUp
+pLq
+dbt
+dbt
+dbt
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -185334,17 +185402,17 @@ bpD
 bpD
 bpD
 bpD
-nJy
+dbt
+lZE
+adK
 tUp
-nIA
-goz
-goz
-goz
-goz
-goz
-hMb
-nJy
-nJy
+tUp
+tUp
+tUp
+tUp
+uPi
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -185736,17 +185804,17 @@ bpD
 bpD
 bpD
 bpD
-nJy
-qGh
-qGh
-aBW
-sIT
-loE
-goz
-vQV
-hMb
-nJy
-nJy
+dbt
+xng
+xng
+xrO
+pmd
+rRA
+tUp
+xlY
+uPi
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -186138,17 +186206,17 @@ bpD
 bpD
 bpD
 bpD
-nJy
-lRd
-qGh
-qGh
-uwa
-qif
-goz
-goz
-goz
-uNW
-nJy
+dbt
+nRw
+xng
+xng
+yff
+jrD
+tUp
+tUp
+tUp
+rIc
+dbt
 bpD
 bpD
 bpD
@@ -186540,17 +186608,17 @@ bpD
 bpD
 bpD
 bpD
-nJy
-bmk
-qGh
-qGh
-adK
-qif
-goz
-goz
-goz
-uNW
-nJy
+dbt
+wFn
+xng
+xng
+dNo
+jrD
+tUp
+tUp
+tUp
+rIc
+dbt
 bpD
 bpD
 bpD
@@ -186942,17 +187010,17 @@ sSS
 sSS
 sSS
 sSS
-nJy
-qGh
-qGh
-oaV
-goz
-loE
-goz
-vQV
-hMb
-nJy
-nJy
+dbt
+xng
+xng
+nCG
+tUp
+rRA
+tUp
+xlY
+uPi
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -187344,17 +187412,17 @@ sSS
 sSS
 sSS
 sSS
-nJy
-oaN
-eza
-goz
-goz
-goz
-goz
-goz
-hMb
-nJy
-nJy
+dbt
+eoz
+lJh
+tUp
+tUp
+tUp
+tUp
+tUp
+uPi
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -187746,17 +187814,17 @@ sSS
 sSS
 sSS
 sSS
-nJy
-goz
-goz
-goz
-goz
-jNk
-nJy
-nJy
-nJy
-nJy
-nJy
+dbt
+tUp
+tUp
+tUp
+tUp
+pLq
+dbt
+dbt
+dbt
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -188148,13 +188216,13 @@ sSS
 sSS
 sSS
 sSS
-nJy
-bKE
-goz
-vQV
-vQV
-bKE
-nJy
+dbt
+pkX
+tUp
+xlY
+xlY
+pkX
+dbt
 bpD
 bpD
 bpD
@@ -188550,13 +188618,13 @@ sSS
 sSS
 sSS
 sSS
-nJy
-nJy
-nJy
-nJy
-nJy
-nJy
-nJy
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 bpD
 bpD
 bpD
@@ -202588,15 +202656,15 @@ vRu
 vRu
 vRu
 fjw
-cEK
-ylC
-cEK
-ylC
-ylC
-ylC
-ylC
-cBf
-cBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
 vup
 iTw
 iTw
@@ -202990,7 +203058,7 @@ vRu
 vRu
 fjw
 fjw
-ylC
+nBf
 txa
 txa
 txa
@@ -203392,7 +203460,7 @@ vRu
 vRu
 vRu
 fjw
-vRu
+sYw
 txa
 rpo
 opv
@@ -203794,7 +203862,7 @@ vRu
 vRu
 vRu
 fjw
-vRu
+sYw
 txa
 iML
 opv
@@ -204196,7 +204264,7 @@ vRu
 vRu
 fjw
 fjw
-vRu
+sYw
 txa
 yeM
 cGw
@@ -204598,7 +204666,7 @@ vRu
 fjw
 fjw
 vRu
-vRu
+sYw
 txa
 nhC
 lHK
@@ -205000,7 +205068,7 @@ vRu
 fjw
 fjw
 vRu
-vRu
+sYw
 txa
 aaI
 icc
@@ -205402,7 +205470,7 @@ vRu
 fjw
 fjw
 fjw
-vRu
+sYw
 txa
 rpo
 opv
@@ -205804,7 +205872,7 @@ vRu
 vRu
 fjw
 fjw
-fjw
+sYw
 txa
 uKD
 rpo
@@ -206206,7 +206274,7 @@ vRu
 vRu
 vRu
 vRu
-vuH
+sYw
 txa
 txa
 txa
@@ -206602,13 +206670,13 @@ fyc
 (159,1,2) = {"
 sYw
 sYw
-vRu
-vRu
-vRu
-vRu
-vRu
-txa
-iTw
+sYw
+sYw
+sYw
+sYw
+sYw
+nBf
+nBf
 txa
 cFQ
 cBf
@@ -227515,7 +227583,7 @@ acD
 acD
 fhw
 acD
-dol
+ibL
 acD
 acD
 acD
@@ -227918,8 +227986,8 @@ acD
 acD
 acD
 vuH
-bVa
-qzy
+mIR
+xpM
 acD
 azH
 azH
@@ -228317,7 +228385,7 @@ vRu
 vRu
 acD
 qgC
-qzy
+xpM
 qgC
 vuH
 qgC
@@ -228718,12 +228786,12 @@ vRu
 vRu
 vRu
 acD
-qzy
+xpM
 qgC
-bVa
+mIR
 vuH
-bVa
-qzy
+mIR
+xpM
 acD
 qgC
 qgC
@@ -229121,11 +229189,11 @@ vRu
 vRu
 acD
 qgC
-qzy
+xpM
 qgC
 vuH
-bVa
-qzy
+mIR
+xpM
 acD
 qgC
 qgC
@@ -229522,12 +229590,12 @@ vRu
 vRu
 vRu
 acD
-qzy
+xpM
 qgC
 qgC
 vuH
-bVa
-qzy
+mIR
+xpM
 acD
 qgC
 qgC
@@ -229926,9 +229994,9 @@ vRu
 acD
 qgC
 qgC
-jaA
+kFh
 vuH
-bVa
+mIR
 qgC
 acD
 vRu
@@ -230329,7 +230397,7 @@ acD
 acD
 acD
 acD
-nhR
+xGq
 acD
 acD
 acD
@@ -231130,12 +231198,12 @@ vRu
 vRu
 acD
 qgC
-qzy
-dSi
+xpM
+gWc
 vuH
 ffw
 qgC
-qzy
+xpM
 acD
 vRu
 vRu
@@ -231533,7 +231601,7 @@ vRu
 acD
 qgC
 qgC
-dSi
+gWc
 qgC
 vuH
 vuH
@@ -231934,9 +232002,9 @@ vRu
 vRu
 acD
 qgC
-qzy
+xpM
 qgC
-dSi
+gWc
 vuH
 vuH
 qgC
@@ -232738,9 +232806,9 @@ vRu
 vRu
 acD
 qgC
-kja
+gBO
 qgC
-kja
+gBO
 ffw
 vuH
 qgC
@@ -233141,11 +233209,11 @@ vRu
 acD
 qgC
 vRu
-dSi
+gWc
 vuH
 vuH
 vuH
-qzy
+xpM
 acD
 vRu
 vRu
@@ -233545,8 +233613,8 @@ acD
 acD
 acD
 acD
-mdm
-atE
+rPO
+jVK
 acD
 acD
 vRu
@@ -280614,12 +280682,12 @@ hcW
 hcW
 hcW
 cWT
-qeY
-qeY
-qeY
-qeY
-qeY
-qeY
+rfO
+rfO
+rfO
+rfO
+rfO
+rfO
 uSw
 uSw
 uSw
@@ -280639,35 +280707,35 @@ uSw
 uSw
 uSw
 uSw
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 cWT
 hcW
 hcW
@@ -281015,12 +281083,12 @@ uaL
 uaL
 uaL
 uaL
-veW
-itC
-rcr
+dAf
+eSt
+wdv
 mwq
 mwq
-aok
+neE
 nrw
 nrw
 nrw
@@ -281050,26 +281118,26 @@ ykt
 ykt
 ykt
 ykt
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
+dAf
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 cWT
 hcW
 hcW
@@ -281417,61 +281485,61 @@ wSn
 wSn
 uaL
 uaL
-veW
-itC
-rYO
+dAf
+eSt
+aem
 mwq
 mwq
 mwq
 nrw
 nrw
-qbA
-bPv
-bPv
-vOe
-vOe
-qEO
+aPE
+oRp
+oRp
+pKQ
+pKQ
+nnh
 nrw
 kzQ
-mdB
-mdB
-mdB
+obq
+obq
+obq
 kzQ
-hnL
-mVz
-mVz
-gCr
-ewu
+kys
+ogC
+ogC
+nju
+gQa
 nrw
 mwq
 mwq
-htf
+qRp
 uaL
-mtO
+bGe
 paf
 qvR
 qvR
-jpw
+auL
 uaL
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
-veW
-kVc
-kVc
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 cWT
 hcW
 hcW
@@ -281819,62 +281887,62 @@ wSn
 wSn
 tzK
 uaL
-veW
-itC
-ebb
+dAf
+eSt
+dIP
 mwq
 mwq
-cGQ
+qJh
 nrw
 nrw
-kvp
-bPv
-aNG
-bPz
-bPz
-bPz
+qDn
+oRp
+iOm
+pGo
+pGo
+pGo
 nrw
 jlO
-mdB
-hbi
-mdB
+obq
+uzT
+obq
 jlO
-hnL
-mVz
-mVz
-bBc
-pRt
+kys
+ogC
+ogC
+kSe
+pcQ
 nrw
 mwq
 mwq
-htf
+qRp
 uaL
-mtO
+bGe
 paf
 qvR
 qvR
-jpw
+auL
 uaL
 uaL
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 cWT
 cWT
 cWT
@@ -282221,65 +282289,65 @@ wSn
 uaL
 uaL
 uaL
-veW
-itC
-iZb
+dAf
+eSt
+mqI
 mwq
 mwq
-cGQ
+qJh
 nrw
 nrw
-vHd
-bPv
-bPv
-bPv
-bPv
-bPv
-jZA
+mFA
+oRp
+oRp
+oRp
+oRp
+oRp
+qMk
 jlO
-mdB
-wUw
-hhY
+obq
+rZg
+edP
 jlO
 evo
-wTs
-mVz
-qmp
-mVz
+tJC
+ogC
+wSl
+ogC
 nrw
 mwq
 mwq
-htf
+qRp
 uaL
 uaL
 paf
 qvR
 qvR
-jpw
+auL
 fxx
 aJj
 wSn
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 cWT
 hcW
 hcW
@@ -282623,66 +282691,66 @@ wSn
 uaL
 uaL
 uaL
-veW
-itC
-itC
-jlY
-jlY
-exq
-itC
+dAf
+eSt
+eSt
+uvu
+uvu
+dEW
+eSt
 nrw
-peX
-xqD
-aNG
-bPv
-aNG
-bPv
-jZA
+rTT
+sbF
+iOm
+oRp
+iOm
+oRp
+qMk
 jlO
-mdB
-glV
-mdB
+obq
+pMn
+obq
 jlO
 nrw
-xFb
-mVz
-mVz
-mVz
-qmC
+gCr
+ogC
+ogC
+ogC
+dsP
 mwq
 mwq
-htf
+qRp
 uaL
 uaL
-aPR
+iBX
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 wSn
 wSn
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 hcW
 hcW
 hcW
@@ -283025,68 +283093,68 @@ wSn
 wSn
 uaL
 uaL
-veW
-itC
-iZb
-jlY
-jlY
-exq
-itC
+dAf
+eSt
+mqI
+uvu
+uvu
+dEW
+eSt
 nrw
-ogj
-bPv
-bPv
-fVM
-fVM
-fVM
+pfi
+oRp
+oRp
+liq
+liq
+liq
 nrw
 jlO
-mdB
-hsp
-mdB
+obq
+etF
+obq
 jlO
 nrw
-cuh
-mVz
-uFp
+wXp
+ogC
+oRi
 mwq
-qmC
+dsP
 mwq
 mwq
-htf
+qRp
 ykt
 ykt
 ykt
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 wSn
 aJj
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 hcW
 hcW
 uaL
@@ -283388,7 +283456,7 @@ cWT
 hcW
 hcW
 hcW
-xwo
+gRv
 wSn
 wSn
 wSn
@@ -283427,69 +283495,69 @@ uaL
 uaL
 uaL
 uaL
-veW
-itC
-rcr
-jlY
-jlY
-jlY
-lMZ
-bPv
-bPv
-aNG
-iUn
-bPz
-bPz
-nPg
+dAf
+eSt
+wdv
+uvu
+uvu
+uvu
+vkk
+oRp
+oRp
+iOm
+gME
+pGo
+pGo
+tNe
 nrw
-ycs
-mdB
-mdB
-mdB
-oRb
+pOT
+obq
+obq
+obq
+nfi
 nrw
-wTs
-mVz
-uFp
+tJC
+ogC
+oRi
 mwq
-qmC
-nBf
+dsP
+qDq
 mwq
-htf
+qRp
 uaL
 uaL
-aPR
+iBX
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 wSn
 uaL
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 uaL
 uaL
 wSn
@@ -283829,68 +283897,68 @@ hcW
 hcW
 uaL
 uaL
-veW
-itC
-rYO
-jlY
-jlY
-jlY
-itC
+dAf
+eSt
+aem
+uvu
+uvu
+uvu
+eSt
 nrw
-jZA
-nrw
-nrw
+qMk
 nrw
 nrw
 nrw
 nrw
 nrw
-oRb
-cWS
+nrw
+nrw
+nfi
+uVS
 jlO
 jlO
 nrw
-lBJ
-mVz
+ozP
+ogC
 mwq
-qqE
+veu
 nrw
-eoz
+jmT
 mwq
-htf
-pxY
+qRp
+tVo
 uaL
 paf
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
 wSn
 uaL
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 wSn
@@ -284231,67 +284299,67 @@ hcW
 hcW
 uaL
 uaL
-veW
-itC
-ebb
-jQk
-jlY
-jlY
-umi
+dAf
+eSt
+dIP
+fSv
+uvu
+uvu
+fdG
 mwq
 mwq
-hIn
+xEK
 mwq
 mwq
 mwq
 mwq
 mwq
 nrw
-jZp
+kUA
 nrw
 jlO
 jlO
 nrw
-vJz
-cOS
+ptP
+wou
 mwq
-qBH
+dmf
 nrw
-nBf
+qDq
 mwq
-htf
-sFM
+qRp
+rIp
 uaL
 paf
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
 uaL
 wSn
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 qvR
@@ -284633,65 +284701,65 @@ hcW
 hcW
 hcW
 uaL
-veW
-itC
-itC
-itC
-itC
+dAf
+eSt
+eSt
+eSt
+eSt
 nrw
 nrw
 mwq
 mwq
 mwq
 mwq
-uFp
+oRi
 mwq
 mwq
 mwq
 mwq
 mwq
 nrw
-cMs
+kwN
 nrw
 nrw
 nrw
 nrw
-tUZ
+wTs
 nrw
 nrw
 mwq
 mwq
-htf
+qRp
 lsD
 lsD
-dFa
+fbB
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
 fxx
 wSn
-veW
+dAf
 kVc
-veW
-kVc
-kVc
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
@@ -285035,65 +285103,65 @@ hcW
 hcW
 uaL
 uaL
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
 evo
 nrw
 nrw
-mYZ
-mYZ
-uCD
-jAw
-mxy
-mxy
-mxy
-rcm
+qgY
+qgY
+eMZ
+mXk
+qeY
+qeY
+qeY
+nMl
 mwq
 nrw
-bPv
-qDL
-pBp
-sJt
-fcf
-nBf
-eoz
-nBf
+oRp
+oVC
+aJC
+ubr
+xtW
+qDq
+jmT
+qDq
 mwq
 mwq
-htf
+qRp
 rhD
 rhD
 rhD
 rhD
 rhD
-jpw
+auL
 fxx
 fxx
 fxx
 fxx
 uaL
-veW
+dAf
 kVc
-veW
-kVc
-kVc
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 uaL
 uaL
@@ -285441,31 +285509,31 @@ uaL
 uaL
 qvR
 qvR
-veW
+dAf
 evo
-uEA
-eoz
+gXN
+jmT
 cbG
 cbG
-maV
-rcm
-ilv
-hCW
-kZx
-rcm
-uFp
+idW
+nMl
+lME
+fBK
+qAB
+nMl
+oRi
 nrw
-bPv
 oRp
-bPv
-cMs
+bVV
+oRp
+kwN
 mwq
 mwq
-nBf
+qDq
 mwq
 mwq
 mwq
-ulR
+dwO
 fxx
 fxx
 fxx
@@ -285478,24 +285546,24 @@ fxx
 fxx
 aJj
 wSn
-veW
-veW
+dAf
+dAf
 kVc
 kVc
-veW
+dAf
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 uaL
 uaL
@@ -285843,34 +285911,34 @@ uaL
 uaL
 qvR
 qvR
-wPR
+cdn
 evo
-sWT
-eoz
+upI
+jmT
 cbG
 cbG
-uCD
-rcm
-uka
-wqq
-kKG
-rcm
+eMZ
+nMl
+lOG
+hxA
+kwE
+nMl
 mwq
-gff
-bPv
-aNG
-bPv
+vjs
+oRp
+iOm
+oRp
+kwN
+mwq
+mwq
+mwq
+mwq
+mwq
+mwq
+dwO
+fxx
+fxx
 cMs
-mwq
-mwq
-mwq
-mwq
-mwq
-mwq
-ulR
-fxx
-fxx
-meF
 fxx
 fxx
 fxx
@@ -285880,24 +285948,24 @@ fxx
 fxx
 uaL
 wSn
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 uaL
 wSn
@@ -286245,31 +286313,31 @@ uaL
 uaL
 qvR
 qvR
-wPR
+cdn
 evo
-qzH
-eoz
+qNU
+jmT
 cbG
 cbG
-uCD
-rcm
-lhd
-kFh
-bEJ
-rcm
+eMZ
+nMl
+ksN
+jXx
+tJl
+nMl
 mwq
 nrw
-olZ
-gtr
-bPv
-cMs
+nVP
+aFJ
+oRp
+kwN
 mwq
 mwq
 mwq
 mwq
 mwq
 mwq
-ulR
+dwO
 fxx
 fxx
 fxx
@@ -286283,23 +286351,23 @@ fxx
 uaL
 uaL
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 uaL
@@ -286611,7 +286679,7 @@ uaL
 uaL
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -286647,37 +286715,37 @@ uaL
 uaL
 qvR
 qvR
-wPR
+cdn
 evo
 nrw
 nrw
-frp
-frp
-uCD
-rcm
-avO
-avO
-avO
-rcm
-uFp
+bUc
+bUc
+eMZ
+nMl
+fIs
+fIs
+fIs
+nMl
+oRi
 nrw
-eYG
-aac
-bPv
-sJt
+iOL
+ohr
+oRp
+ubr
 mwq
 mwq
-nBf
+qDq
 mwq
 mwq
 mwq
-htf
+qRp
 rhD
 rhD
 rhD
 rhD
 rhD
-jpw
+auL
 fxx
 fxx
 fxx
@@ -286685,23 +286753,23 @@ fxx
 fxx
 aJj
 kVc
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 uaL
@@ -287049,14 +287117,14 @@ uaL
 uaL
 qvR
 qvR
-veW
+dAf
 evo
 nrw
 mwq
 mwq
 mwq
 mwq
-uFp
+oRi
 mwq
 mwq
 mwq
@@ -287065,21 +287133,21 @@ mwq
 nrw
 nrw
 nrw
-dQi
+bty
 nrw
-fcf
-nBf
-eoz
-nBf
+xtW
+qDq
+jmT
+qDq
 mwq
 mwq
-htf
-eKb
+qRp
+bHX
 qvR
 qvR
 qvR
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -287087,23 +287155,23 @@ fxx
 fxx
 uaL
 aJj
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
-veW
+dAf
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
-veW
+dAf
 kVc
 qvR
 qvR
@@ -287451,37 +287519,37 @@ uaL
 uaL
 uaL
 qvR
-veW
+dAf
 evo
 nrw
-tmj
+cRP
 mwq
-vYa
-mwq
-mwq
+xAz
 mwq
 mwq
 mwq
-nrw
-nrw
-nrw
-nrw
-uZC
-bPv
-nrw
-nrw
-wGR
-nrw
-nrw
-nBf
 mwq
-htf
+mwq
+nrw
+nrw
+nrw
+nrw
+uxV
+oRp
+nrw
+nrw
+fxX
+nrw
+nrw
+qDq
+mwq
+qRp
 uaL
 uaL
 uaL
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -287489,23 +287557,23 @@ fxx
 fxx
 wSn
 aJj
-veW
-veW
-veW
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 uaL
 wSn
@@ -287822,7 +287890,7 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -287851,9 +287919,9 @@ uaL
 uaL
 uaL
 hcW
-veW
-veW
-veW
+dAf
+dAf
+dAf
 evo
 nrw
 nrw
@@ -287865,25 +287933,25 @@ nrw
 nrw
 nrw
 nrw
-cCS
-cCS
+khc
+khc
 nrw
-uZC
-bPv
-uZC
-wRw
-dcU
-vOe
+uxV
+oRp
+uxV
+cag
+qmA
+pKQ
 nrw
-eoz
+jmT
 mwq
-htf
+qRp
 uaL
 uaL
 uaL
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -287892,20 +287960,20 @@ fxx
 wSn
 aJj
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-sdD
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dbN
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
@@ -288255,37 +288323,37 @@ hcW
 hcW
 hcW
 cWT
-qeY
-qeY
-qeY
-qeY
-uZC
-uZC
-uZC
-cCS
-cCS
-uZC
-uZC
-uZC
-bPv
-bVe
-nrw
-sLs
-bPv
-aNG
-bPv
+rfO
+rfO
+rfO
+rfO
+uxV
+uxV
+uxV
+khc
+khc
+uxV
+uxV
+uxV
 oRp
-bPv
-inY
-nBf
+wVi
+nrw
+wSY
+oRp
+iOm
+oRp
+bVV
+oRp
+oIG
+qDq
 mwq
-htf
+qRp
 qvR
 qvR
 qvR
 qvR
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -288294,20 +288362,20 @@ fxx
 wSn
 wSn
 kVc
-veW
+dAf
 kVc
-veW
+dAf
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 kVc
@@ -288654,40 +288722,40 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 cWT
-qeY
+rfO
 iJR
-sCf
-kMO
-bPv
-xFi
-bVe
-bVe
-xFi
-xFi
-bVe
-xFi
-xFi
-bPv
-sWT
-dcU
-bPv
-bPv
-bPv
-aNG
-bPv
-sJt
+cMj
+rRD
+oRp
+fIG
+wVi
+wVi
+fIG
+fIG
+wVi
+fIG
+fIG
+oRp
+upI
+qmA
+oRp
+oRp
+oRp
+iOm
+oRp
+ubr
 mwq
 mwq
-htf
+qRp
 uaL
 uaL
 uaL
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -288702,15 +288770,15 @@ kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 lyL
@@ -289020,25 +289088,22 @@ uaL
 uaL
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
-qRm
-hcW
-hcW
-hcW
-hcW
-qRm
+pdm
 hcW
 hcW
 hcW
+hcW
+pdm
 hcW
 hcW
 hcW
@@ -289047,11 +289112,14 @@ hcW
 hcW
 hcW
 hcW
-qRm
 hcW
 hcW
 hcW
-qRm
+pdm
+hcW
+hcW
+hcW
+pdm
 hcW
 hcW
 hcW
@@ -289059,37 +289127,37 @@ hcW
 hcW
 hcW
 cWT
-qeY
+rfO
 iJR
-nzI
-kMO
-bPv
-xFi
-vUf
-ilx
-xFi
-bVe
-vUf
-bVe
-bVe
-aNG
+nxD
+rRD
+oRp
+fIG
+rGY
+fVM
+fIG
+wVi
+rGY
+wVi
+wVi
+iOm
 nrw
-bPv
-bPv
-fVM
-fVM
-bPv
-bPv
-sJt
+oRp
+oRp
+liq
+liq
+oRp
+oRp
+ubr
 mwq
 mwq
-htf
+qRp
 uaL
 uaL
 uaL
 uaL
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -289097,22 +289165,22 @@ fxx
 fxx
 uaL
 wSn
-veW
+dAf
 kVc
 kVc
 kVc
-veW
+dAf
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 qvR
@@ -289456,42 +289524,42 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 cWT
-qeY
-qeY
-qeY
-qeY
-uZC
-uZC
-uZC
-wSl
-wSl
-uZC
-uZC
-uZC
-bVe
-bPv
-ius
-bPv
-bPv
-lpY
-nbF
-kNR
-uZC
+rfO
+rfO
+rfO
+rfO
+uxV
+uxV
+uxV
+tYB
+tYB
+uxV
+uxV
+uxV
+wVi
+oRp
+bjN
+oRp
+oRp
+jYu
+rJI
+pcs
+uxV
 nrw
 mwq
 mwq
-htf
-iPO
+qRp
+jgV
 qvR
 qvR
 qvR
 qvR
-jpw
+auL
 fxx
 fxx
 fxx
@@ -289499,22 +289567,22 @@ fxx
 fxx
 fxx
 wSn
-veW
+dAf
 kVc
-veW
-kVc
-kVc
+dAf
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 qvR
@@ -289851,7 +289919,7 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -289866,7 +289934,7 @@ cWT
 cWT
 cWT
 cWT
-qeY
+rfO
 nrw
 nrw
 nrw
@@ -289903,20 +289971,20 @@ fxx
 uaL
 kVc
 kVc
-veW
+dAf
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 uaL
@@ -290235,7 +290303,7 @@ qvR
 uaL
 uaL
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -290253,14 +290321,14 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -290269,10 +290337,10 @@ hcW
 hcW
 hcW
 cWT
-wPR
-wPR
-iSF
-iSF
+cdn
+cdn
+sTG
+sTG
 evo
 ykt
 ykt
@@ -290307,17 +290375,17 @@ aJj
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 kVc
 qvR
@@ -290638,7 +290706,7 @@ qvR
 qvR
 hcW
 hcW
-qRm
+pdm
 hcW
 kYc
 kYS
@@ -290647,7 +290715,7 @@ mzx
 kYc
 mzx
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -290671,8 +290739,8 @@ hcW
 hcW
 hcW
 hcW
-iSF
-wPR
+sTG
+cdn
 evo
 evo
 evo
@@ -290707,19 +290775,19 @@ fxx
 uaL
 uaL
 uaL
-veW
+dAf
 uaL
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
 kVc
 qvR
 qvR
@@ -291052,16 +291120,16 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -291452,18 +291520,18 @@ msk
 ntQ
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -291516,13 +291584,13 @@ uaL
 uaL
 fxx
 fxx
-vox
-vjs
-vjs
-vjs
-vjs
-vjs
-vox
+qvL
+oJO
+oJO
+oJO
+oJO
+oJO
+qvL
 wSn
 uaL
 uaL
@@ -291843,7 +291911,7 @@ sJZ
 sJZ
 qvR
 hcW
-qRm
+pdm
 hcW
 hcW
 ldI
@@ -291918,13 +291986,13 @@ fxx
 fxx
 fxx
 fxx
-qQo
+hLz
 peN
 peN
 peN
 peN
 peN
-vOH
+aQx
 fxx
 fxx
 fxx
@@ -292233,7 +292301,7 @@ uaL
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 qvR
@@ -292265,13 +292333,13 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -292320,13 +292388,13 @@ fxx
 fxx
 fxx
 fxx
-vjs
+oJO
 peN
 peN
 peN
-twL
+bZw
 peN
-vjs
+oJO
 fxx
 fxx
 fxx
@@ -292670,10 +292738,10 @@ hcW
 hcW
 hcW
 hcW
-qRm
-qRm
+pdm
+pdm
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -292694,14 +292762,14 @@ wSn
 wSn
 wSn
 xKz
-rTT
-hGr
+fmp
+nPQ
 lLa
 xKz
 xKz
-nap
-jCm
-rHj
+dNI
+qzy
+hkW
 xKz
 jeb
 jeb
@@ -293067,8 +293135,8 @@ hcW
 hcW
 hcW
 hcW
-qRm
-qRm
+pdm
+pdm
 hcW
 hcW
 hcW
@@ -293096,18 +293164,18 @@ wSn
 wSn
 wSn
 xKz
-sQN
+wke
 iYQ
 fVQ
-mQr
+edb
 qpt
-sDa
+wgn
 peN
 kIf
-wgn
-mQr
+xZg
+edb
 fVQ
-bmO
+ycz
 xKz
 qvR
 qvR
@@ -293124,13 +293192,13 @@ wSn
 uaL
 fTe
 wSn
-rUr
-bay
-oRB
-oRB
-oRB
-bay
-rUr
+iWj
+qYw
+jlY
+jlY
+jlY
+qYw
+iWj
 uaL
 uaL
 uaL
@@ -293471,7 +293539,7 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -293498,18 +293566,18 @@ wSn
 wSn
 wSn
 xKz
-nYv
-hGr
+ybB
+nPQ
 fVQ
 lLa
 qpt
-sDa
+wgn
 peN
 kIf
-wgn
+xZg
 lLa
 fVQ
-pWw
+aok
 xKz
 qvR
 qvR
@@ -293529,7 +293597,7 @@ uaL
 xKz
 bOK
 jeb
-bYy
+cjJ
 jeb
 bOK
 xKz
@@ -293866,14 +293934,14 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -293900,18 +293968,18 @@ wSn
 wSn
 wSn
 xKz
-sQN
+wke
 iYQ
 fVQ
-qRp
+uaQ
 qpt
-sDa
+wgn
 peN
 kIf
-wgn
+xZg
 hmU
 fVQ
-pWw
+aok
 xKz
 qvR
 qvR
@@ -293931,7 +293999,7 @@ uaL
 bOK
 tYP
 tYP
-uQb
+lPv
 tYP
 tYP
 xKz
@@ -294244,7 +294312,7 @@ uaL
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 qvR
 qvR
@@ -294266,7 +294334,7 @@ ndD
 kYc
 msk
 nxV
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -294302,18 +294370,18 @@ wSn
 wSn
 wSn
 xKz
-nYv
-hGr
+ybB
+nPQ
 fVQ
 jeb
 jeb
-sDa
+wgn
 peN
 kIf
 jeb
 jeb
 fVQ
-pWw
+aok
 xKz
 qvR
 qvR
@@ -294330,11 +294398,11 @@ uaL
 qvR
 qvR
 uaL
-fKy
+eyN
 tYP
-tsJ
+kvj
 tYP
-oHu
+uwX
 tYP
 xKz
 qvR
@@ -294704,18 +294772,18 @@ wSn
 wSn
 wSn
 xKz
-eSt
+kfm
 iYQ
 fVQ
 fVQ
 jeb
-mGn
+pGM
 peN
 kIf
 jeb
 fVQ
 tYP
-vGQ
+doi
 xKz
 qvR
 qvR
@@ -294733,7 +294801,7 @@ qvR
 uaL
 wSn
 xKz
-sWs
+kpg
 tYP
 tYP
 tYP
@@ -295058,7 +295126,7 @@ uaL
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -295106,18 +295174,18 @@ wSn
 wSn
 wSn
 xKz
-gvi
+fSU
 lLa
 fVQ
 fVQ
 hZF
-sDa
+wgn
 peN
 kIf
 hZF
 fVQ
 sCg
-dTa
+jfS
 xKz
 qvR
 uaL
@@ -295136,10 +295204,10 @@ uaL
 wSn
 bOK
 tYP
-iie
+erP
 tYP
 sCg
-sZB
+heJ
 xKz
 qvR
 qvR
@@ -295467,7 +295535,7 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -295508,18 +295576,18 @@ xKz
 xKz
 xKz
 xKz
-gvi
+fSU
 lLa
 kMi
-fKs
+hEw
 jeb
-mGn
+pGM
 peN
 kIf
 jeb
 fVQ
 sCg
-dTa
+jfS
 xKz
 qvR
 uaL
@@ -295539,9 +295607,9 @@ wSn
 xKz
 xKz
 xKz
-uhn
+eza
 sCg
-dTa
+jfS
 xKz
 qvR
 qvR
@@ -295913,15 +295981,15 @@ fVQ
 fVQ
 fVQ
 kMi
-eSt
+kfm
 jeb
-sDa
+wgn
 peN
 kIf
 jeb
 fVQ
 tYP
-dTa
+jfS
 xKz
 qvR
 qvR
@@ -295943,7 +296011,7 @@ xKz
 xKz
 tYP
 sCg
-dTa
+jfS
 xKz
 qvR
 qvR
@@ -296253,7 +296321,7 @@ hcW
 wSn
 uaL
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -296317,13 +296385,13 @@ fIB
 fVQ
 fVQ
 qpt
-sDa
+wgn
 peN
 kIf
-wgn
+xZg
 lLa
 fVQ
-eGy
+waB
 xKz
 qvR
 uaL
@@ -296343,9 +296411,9 @@ wSn
 xKz
 xKz
 xKz
-uhn
+eza
 sCg
-sZB
+heJ
 xKz
 qvR
 uaL
@@ -296655,7 +296723,7 @@ wSn
 wSn
 uaL
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
@@ -296664,7 +296732,7 @@ hcW
 hcW
 hcW
 hcW
-qRm
+pdm
 wSn
 wSn
 qvR
@@ -296711,7 +296779,7 @@ xqL
 wSn
 wSn
 xKz
-fKs
+hEw
 gqa
 fVQ
 fVQ
@@ -296719,10 +296787,10 @@ fVQ
 fVQ
 fVQ
 qpt
-sDa
+wgn
 peN
 kIf
-wgn
+xZg
 lLa
 fVQ
 uxZ
@@ -296745,7 +296813,7 @@ uaL
 xKz
 xKz
 xKz
-uHk
+kSC
 xKz
 xKz
 xKz
@@ -297054,19 +297122,19 @@ fyc
 cWT
 cWT
 wSn
-qRm
-qRm
-qRm
-qRm
+pdm
+pdm
+pdm
+pdm
 hcW
-qRm
+pdm
 hcW
 hcW
 hcW
-qRm
-qRm
-qRm
-qRm
+pdm
+pdm
+pdm
+pdm
 wSn
 wSn
 qvR
@@ -297113,7 +297181,7 @@ aJj
 uaL
 qvR
 xKz
-sQN
+wke
 iYQ
 lLa
 fVQ
@@ -297121,13 +297189,13 @@ fIB
 fVQ
 fVQ
 qpt
-sDa
+wgn
 peN
 kIf
-wgn
-qgS
+xZg
+rHj
 fVQ
-vkB
+xJe
 xKz
 uaL
 uaL
@@ -297456,9 +297524,9 @@ fyc
 cWT
 cWT
 uaL
-qRm
-qRm
-qRm
+pdm
+pdm
+pdm
 hcW
 hcW
 hcW
@@ -297515,18 +297583,18 @@ evo
 evo
 evo
 xKz
-eSt
-hGr
+kfm
+nPQ
 kds
-sJd
+aSD
 xKz
-qRp
+uaQ
 fVQ
 xKz
-vFL
-jgQ
-tNp
-xAh
+npv
+dCr
+gQF
+bIP
 xKz
 xKz
 xKz
@@ -297926,29 +297994,29 @@ xKz
 xKz
 xKz
 uWL
-xET
-xET
+mJI
+mJI
 xKz
 xKz
-dAf
-dAf
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-vhV
-vhV
-bqt
-bqt
-dAf
-dAf
-dAf
-dAf
-bqt
-bqt
-bqt
+csH
+csH
+rUr
+rUr
+rUr
+rUr
+rUr
+rUr
+ikM
+ikM
+rUr
+rUr
+csH
+csH
+csH
+csH
+rUr
+rUr
+rUr
 axq
 dnx
 axl
@@ -305163,7 +305231,7 @@ xKz
 wVI
 wbg
 wbg
-lea
+bqL
 wbg
 wbg
 wbg
@@ -305519,7 +305587,7 @@ mcK
 nBW
 mOY
 nBW
-igd
+tlG
 nBW
 wtF
 wbg
@@ -307133,7 +307201,7 @@ wtF
 wbg
 wbg
 wbg
-lea
+bqL
 wbg
 wbg
 wbg
@@ -309140,7 +309208,7 @@ jDm
 uOL
 lbC
 hOh
-aev
+hOh
 aHx
 aHx
 lbC
@@ -309256,9 +309324,9 @@ bwS
 lVe
 bwS
 lVe
-hHF
+kuf
 goK
-uPD
+veW
 sux
 pYf
 pYf
@@ -310393,12 +310461,12 @@ wbg
 wbg
 wVI
 wVI
-kdN
+fnL
 nHz
 wVI
 wVI
 wVI
-xyB
+rKD
 wVI
 wVI
 tUw
@@ -310435,7 +310503,7 @@ fxx
 fxx
 fxx
 fxx
-bmL
+oMa
 fxx
 boU
 fxx
@@ -310453,13 +310521,13 @@ qvR
 wSn
 cyr
 hHF
-wFp
+wsg
 wlD
 sIG
 wlD
 wlD
 wlD
-uPD
+veW
 wlD
 sIG
 wlD
@@ -310760,7 +310828,7 @@ wbg
 xXq
 yhZ
 yhZ
-kMV
+yfN
 yhZ
 yhZ
 xXq
@@ -311173,13 +311241,13 @@ xez
 wbg
 wbg
 wbg
-lea
+bqL
 wbg
 wbg
 wbg
 wbg
 wbg
-lea
+bqL
 wbg
 wbg
 wbg
@@ -311227,7 +311295,7 @@ fxx
 fxx
 fxx
 fxx
-bmL
+oMa
 fxx
 fxx
 fxx
@@ -311552,7 +311620,7 @@ uYE
 sHm
 mwE
 mwE
-nPQ
+mwE
 mwE
 lpq
 mwE
@@ -311595,7 +311663,7 @@ wbg
 wbg
 wbg
 wbg
-lea
+bqL
 wbg
 wbg
 wbg
@@ -311603,7 +311671,7 @@ wbg
 wbg
 wbg
 wbg
-lea
+bqL
 wbg
 wbg
 wbg
@@ -312802,16 +312870,16 @@ wbg
 wbg
 wbg
 wbg
-rfO
+qzH
 hUt
 vFj
-rfO
+qzH
 wbg
 wbg
 wbg
-rfO
+qzH
 xGM
-rfO
+qzH
 wsR
 ukb
 wvE
@@ -312853,7 +312921,7 @@ trG
 ryI
 fZw
 fxx
-bmL
+oMa
 rhD
 qvR
 qvR
@@ -313211,9 +313279,9 @@ wew
 wxZ
 nRo
 bQf
-mQA
+nuH
 iPY
-eEp
+bPz
 wsR
 ukb
 wvE
@@ -313568,7 +313636,7 @@ aOn
 aOn
 lpa
 nCh
-lea
+bqL
 wbg
 wbg
 hOh
@@ -313601,21 +313669,21 @@ pUl
 rJX
 tCr
 guP
-bZX
+xhZ
 guP
-olC
+csJ
 wbg
 qtV
 iPY
 iPY
 iPY
-wew
+quL
 wVI
 weX
 wVI
-mQA
-iPY
-eEp
+bwO
+hRv
+bPz
 wsR
 xMr
 yho
@@ -314003,7 +314071,7 @@ rJX
 eai
 tCr
 guP
-otk
+ams
 guP
 iGf
 viq
@@ -314011,13 +314079,13 @@ qtV
 iPY
 iPY
 iPY
-wew
+quL
 wxZ
 wVI
 bQf
-bzl
+vjL
 nXd
-uSP
+lhd
 wsR
 dHZ
 xww
@@ -314407,13 +314475,13 @@ fQm
 guP
 guP
 guP
-tCF
+kLE
 uTQ
 qtV
 nXd
-nXd
-nXd
-hrf
+hor
+hor
+vMQ
 wVI
 wVI
 wVI
@@ -314477,7 +314545,7 @@ lVe
 uxL
 sZI
 xlx
-rbZ
+skp
 iTv
 cXU
 iTv
@@ -314755,7 +314823,7 @@ uOL
 jxy
 vbO
 oif
-oza
+bmM
 oif
 uJk
 tOz
@@ -314812,16 +314880,16 @@ sxR
 sxR
 abh
 wbg
-woq
-woq
+qRm
+qRm
 aSH
-woq
+qRm
 wVI
 wVI
 wVI
 wVI
 wVI
-iYS
+sPK
 oUn
 xMr
 vwQ
@@ -314864,7 +314932,7 @@ hLK
 nht
 fxx
 fxx
-nuH
+aIp
 wxd
 wSn
 wSn
@@ -315203,7 +315271,7 @@ tYm
 oAn
 wbg
 wbg
-xVB
+oul
 dTB
 tVP
 tVP
@@ -315212,7 +315280,7 @@ tCG
 tVP
 tVP
 tCG
-qdg
+jVO
 wbg
 wVI
 wVI
@@ -315614,9 +315682,9 @@ tVP
 tVP
 tVP
 tVP
-pEw
+iQF
 qtV
-pKQ
+mrw
 rZY
 wVI
 wxZ
@@ -316004,21 +316072,21 @@ pAS
 sZN
 sZN
 xdq
-jIP
+iDd
 wbg
 wbg
-xVB
+oul
 rJC
 tVP
-yjP
-tVP
+qrv
+oOW
 tVP
 tZZ
 tVP
 tVP
-pEw
+iQF
 qtV
-pKQ
+mrw
 rZY
 wVI
 wxZ
@@ -316028,7 +316096,7 @@ wVI
 bQf
 wVI
 rZY
-pAb
+vrS
 kjH
 kjH
 kjH
@@ -316058,7 +316126,7 @@ vLS
 uaL
 sjP
 wSn
-bmL
+oMa
 fxx
 lcg
 fQg
@@ -316406,23 +316474,23 @@ sZN
 sZN
 sZN
 xdq
-wew
+quL
 wbg
 wbg
 wKT
 kFS
 tVP
-wZA
-hWr
-uEB
-aWQ
+ovd
+mBJ
+sDa
+ldQ
 tVP
 tCG
-pEw
+iQF
 wbg
 wbg
 wVI
-jJS
+woq
 wVI
 wVI
 wVI
@@ -316758,7 +316826,7 @@ oif
 oif
 oif
 oif
-mbx
+qVq
 eUJ
 eUJ
 jxy
@@ -316808,7 +316876,7 @@ sZN
 sZN
 lzC
 xdq
-jIP
+iDd
 wbg
 wbg
 wKT
@@ -316816,7 +316884,7 @@ eWj
 yfY
 ijS
 mmb
-xcm
+wmH
 uaj
 yfY
 yfY
@@ -316826,8 +316894,8 @@ qEa
 vXm
 vXm
 vXm
-abZ
-vPA
+kqV
+ssP
 wVI
 wVI
 wVI
@@ -317228,12 +317296,12 @@ wbg
 uqe
 ewM
 uqe
-xct
-wew
+hke
+quL
 wVI
 wVI
 rZY
-qDm
+bTg
 rZY
 jXw
 xgi
@@ -317612,7 +317680,7 @@ pDy
 sZN
 sZN
 xdq
-jIP
+iDd
 wbg
 wbg
 cCQ
@@ -317624,18 +317692,18 @@ yfY
 yfY
 yfY
 yfY
-hAx
+hGr
 wbg
-lya
+vDQ
 uqe
 uqe
 uqe
-yir
+xHe
 wew
 weX
 wVI
 rZY
-lqU
+fDF
 rZY
 jXw
 xgi
@@ -317677,7 +317745,7 @@ gkv
 hLK
 njv
 fxx
-bmL
+oMa
 wxd
 wxd
 wSn
@@ -317983,7 +318051,7 @@ wrj
 jDm
 jDm
 mwE
-cHY
+nIX
 mwE
 wbg
 wbg
@@ -318014,25 +318082,25 @@ pAS
 sZN
 sZN
 xdq
-wew
+quL
 wbg
 wbg
 cJz
 yfY
-cye
-kfr
-cZx
+fQq
+ijS
+dNL
 uaj
-xcm
-jEB
-lsg
+wmH
+kfr
+vGQ
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-yir
+xHe
 wew
 wVI
 wVI
@@ -318416,7 +318484,7 @@ ygF
 ygF
 uDv
 xdq
-jIP
+iDd
 wbg
 wbg
 wKT
@@ -318434,13 +318502,13 @@ qEa
 gGZ
 gGZ
 gGZ
-mgd
-hrf
-xdw
-xdw
-xdw
-xdw
-xdw
+sRe
+xaD
+wqq
+wqq
+wqq
+wqq
+wqq
 kjH
 kjH
 kjH
@@ -318822,14 +318890,14 @@ qls
 wbg
 wbg
 wKT
-iMg
-ewf
-urF
-xbW
-urF
-xbW
-urF
-xbW
+qqq
+biQ
+ksK
+vQV
+ksK
+vQV
+ksK
+vQV
 wKT
 wbg
 wbg
@@ -319622,7 +319690,7 @@ pMj
 pPI
 xdq
 xdq
-jIP
+iDd
 wbg
 wbg
 wKT
@@ -319640,13 +319708,13 @@ wbg
 usR
 ncb
 ncb
-ifS
+uyO
 wbg
 wVI
 wVI
 wVI
 wVI
-cld
+iAK
 wVI
 wVI
 wbg
@@ -320024,18 +320092,18 @@ pOs
 pRW
 xdq
 qls
-mJt
+gjV
 wbg
 wbg
 wKT
 wKT
 jCs
-urF
-xwi
-urF
-xwi
-urF
-xwi
+ksK
+wFp
+ksK
+wFp
+ksK
+wFp
 wKT
 wbg
 wbg
@@ -320425,7 +320493,7 @@ xdq
 xdq
 xdq
 xdq
-uEX
+kiX
 wbg
 wbg
 wbg
@@ -320443,7 +320511,7 @@ wbg
 wbg
 vAB
 bnQ
-oZA
+eLR
 nWM
 wbg
 kjH
@@ -320827,7 +320895,7 @@ xMr
 xMr
 xMr
 xMr
-wew
+quL
 wbg
 wbg
 wbg
@@ -321229,7 +321297,7 @@ dCV
 csA
 dCV
 hXf
-jIP
+iDd
 wbg
 wbg
 wbg
@@ -321631,7 +321699,7 @@ dCV
 dCV
 dCV
 qee
-mJt
+gjV
 wbg
 wbg
 wbg
@@ -322437,11 +322505,11 @@ xMr
 xMr
 gGZ
 qCy
-hcT
+gEr
 wVI
 weX
 wVI
-sXO
+mdB
 wbg
 ekQ
 qDx
@@ -322838,7 +322906,7 @@ bmi
 mgx
 xMr
 xAt
-vvo
+chw
 wbg
 wVI
 wVI
@@ -323241,11 +323309,11 @@ oVp
 xMr
 qnO
 oZC
-uxV
+xAw
 wVI
 xbo
 wVI
-sXO
+mdB
 wbg
 hOh
 qDx
@@ -323643,11 +323711,11 @@ nTe
 qhC
 wbg
 wbg
-uxV
+xAw
 wVI
 wVI
 wVI
-sXO
+mdB
 wbg
 hOh
 qDx
@@ -324043,7 +324111,7 @@ oXn
 oXn
 oXn
 xMr
-bUi
+tXh
 wbg
 wbg
 wVI
@@ -324445,13 +324513,13 @@ paz
 bmi
 bmi
 xMr
-uEX
+kiX
 wbg
-hcT
+gEr
 wVI
 weX
 wVI
-sXO
+mdB
 wbg
 lHf
 rfx
@@ -324847,7 +324915,7 @@ gVS
 gVS
 bmi
 xMr
-jIP
+iDd
 wbg
 wbg
 wbg
@@ -325249,7 +325317,7 @@ poR
 pPs
 bmi
 qhR
-uEX
+kiX
 wbg
 wbg
 wbg
@@ -326053,7 +326121,7 @@ orY
 orY
 bmi
 xMr
-jIP
+iDd
 wbg
 wbg
 wbg
@@ -326076,7 +326144,7 @@ ewt
 cEF
 wbg
 xll
-ksK
+nTR
 aOn
 jHc
 mwE
@@ -326455,7 +326523,7 @@ bmi
 mou
 bmi
 xMr
-jIP
+iDd
 wbg
 wbg
 wbg
@@ -326857,7 +326925,7 @@ xMr
 xMr
 xMr
 xMr
-wew
+quL
 wbg
 wbg
 wbg
@@ -328143,7 +328211,7 @@ kVc
 kVc
 hcW
 cWT
-veW
+dAf
 hcW
 hcW
 hcW
@@ -328544,8 +328612,8 @@ kVc
 kVc
 kVc
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -328946,8 +329014,8 @@ wxd
 kVc
 kVc
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -329348,8 +329416,8 @@ wxd
 kVc
 kVc
 kVc
-veW
-veW
+dAf
+dAf
 hcW
 hcW
 hcW
@@ -329662,9 +329730,9 @@ xKF
 xKF
 xKF
 xKF
-tks
-tpO
-uMB
+vLA
+oFV
+hhM
 xKF
 xKF
 xKF
@@ -329750,8 +329818,8 @@ xqL
 kVc
 kVc
 kVc
-veW
-veW
+dAf
+dAf
 hcW
 hcW
 hcW
@@ -330058,21 +330126,21 @@ uaL
 xAt
 xAt
 xKF
-wvn
-lGI
-lGI
-ebt
+diR
+dTa
+dTa
+qKg
 xKF
 xKF
 eBN
 eBN
 eBN
-iug
-iug
-vcN
+mGn
+mGn
+bVT
 trI
-aem
-aem
+wDz
+wDz
 hcp
 tkZ
 xKF
@@ -330152,8 +330220,8 @@ wxd
 kVc
 kVc
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -330460,22 +330528,22 @@ paf
 xAt
 xAt
 xKF
-lXv
-lGI
-lGI
-ebt
+bPF
+dTa
+dTa
+qKg
 xKF
 xKF
 ejY
 eBN
 eBN
-iug
-iug
+mGn
+mGn
 ejY
 trI
-aem
+wDz
 rTm
-aem
+wDz
 obL
 xKF
 vtw
@@ -330554,8 +330622,8 @@ sJZ
 wxd
 wxd
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -330862,10 +330930,10 @@ afX
 xAt
 xAt
 xKF
-rgO
-lGI
-lGI
-ebt
+szi
+dTa
+dTa
+qKg
 xKF
 xKF
 xKF
@@ -330875,9 +330943,9 @@ xKF
 xKF
 xKF
 xKF
-aem
-aem
-aem
+wDz
+wDz
+wDz
 oiC
 xKF
 vtw
@@ -330956,8 +331024,8 @@ sJZ
 sJZ
 feP
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -331264,22 +331332,22 @@ paf
 xAt
 xAt
 xKF
-eIr
-lGI
-lGI
-xpM
+bLu
+dTa
+dTa
+rTo
 xKF
 xKF
 xKF
 xKF
-lTy
+exW
 ofq
 eBN
-aem
+wDz
 suN
-aem
+wDz
 bok
-aem
+wDz
 tkZ
 xKF
 vtw
@@ -331358,8 +331426,8 @@ sJZ
 sJZ
 wxd
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -331666,10 +331734,10 @@ paf
 xAt
 xAt
 xKF
-nfd
-lGI
-lGI
-wIc
+aky
+dTa
+dTa
+hQZ
 xKF
 xKF
 iuo
@@ -331679,7 +331747,7 @@ ofq
 eBN
 bok
 suN
-aem
+wDz
 nrx
 idG
 obL
@@ -331760,8 +331828,8 @@ qet
 sJZ
 wxd
 kVc
-veW
-veW
+dAf
+dAf
 kVc
 hcW
 hcW
@@ -332068,10 +332136,10 @@ paf
 xAt
 xAt
 xKF
-jFP
-lGI
-cSR
-jjE
+kmZ
+dTa
+cEJ
+bfD
 xKF
 xKF
 iuo
@@ -332079,9 +332147,9 @@ wVy
 ofq
 ofq
 eBN
-aem
+wDz
 suN
-aem
+wDz
 iIl
 xKF
 xKF
@@ -332162,8 +332230,8 @@ qet
 qet
 wxd
 kVc
-veW
-veW
+dAf
+dAf
 hcW
 hcW
 hcW
@@ -332470,10 +332538,10 @@ paf
 xAt
 xAt
 xKF
-mwM
-vRA
+byw
+iME
 xKF
-fDD
+yhL
 xKF
 xKF
 xKF
@@ -332483,7 +332551,7 @@ ofq
 eBN
 bok
 suN
-aem
+wDz
 tkZ
 xKF
 vtw
@@ -332564,8 +332632,8 @@ qet
 qet
 wxd
 kVc
-veW
-veW
+dAf
+dAf
 hcW
 hcW
 hcW
@@ -332871,21 +332939,21 @@ uaL
 afX
 xAt
 xAt
-seC
+jTw
 fCM
 fCM
 cNo
 twX
 cNo
-ohY
+jCi
 eeO
-qUg
+bPv
 xKF
 eBN
 eBN
-aem
+wDz
 suN
-aem
+wDz
 vCr
 xKF
 vtw
@@ -333273,20 +333341,20 @@ uaL
 paf
 xAt
 xAt
-seC
+jTw
 fCM
 fCM
 fCM
 fCM
-nca
-fvl
+stj
+xrW
 dsW
 sKd
 xgL
-aem
-aem
-aem
-aem
+wDz
+wDz
+wDz
+wDz
 nrx
 obL
 xKF
@@ -333676,21 +333744,21 @@ uaL
 xAt
 xAt
 xKF
-tiH
+wYa
 iuo
 iuo
 iuo
-nca
+stj
 wPC
 dsW
 sKd
 xgL
-oIv
-aem
-aem
-aem
-aem
-aem
+jBr
+wDz
+wDz
+wDz
+wDz
+wDz
 xKF
 vtw
 vWe
@@ -334078,21 +334146,21 @@ paf
 xAt
 xAt
 xKF
-aiZ
-aiZ
-aiZ
+xAh
+xAh
+xAh
 iuo
 fCM
 sKd
 sKd
 vSM
-fQq
-aem
-aem
+mma
+wDz
+wDz
 wIl
 dXw
 uHg
-aem
+wDz
 xKF
 vtw
 vWe
@@ -334103,7 +334171,7 @@ vtw
 qZh
 ltk
 mwE
-cHY
+nIX
 mwE
 mwE
 aOv
@@ -334480,11 +334548,11 @@ paf
 xAt
 xAt
 xKF
-dJz
-ych
-vtF
+cUS
+tZx
+jUP
 iuo
-kzs
+oIv
 sKd
 sKd
 xKF
@@ -334890,7 +334958,7 @@ xKF
 xKF
 xKF
 xKF
-uvu
+juR
 eCn
 eCn
 xKF
@@ -336507,7 +336575,7 @@ oOU
 smO
 buj
 smO
-xEF
+uGE
 kSh
 sKd
 uHb
@@ -383527,31 +383595,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-ifg
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
+uHk
+uHk
+uHk
+uHk
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
 erZ
 erZ
 erZ
@@ -383565,8 +383633,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -383929,31 +383997,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-ifg
-qDn
+uHk
+uHk
+uHk
+uHk
+yiI
 rST
-juY
-wou
-wou
-qDn
-wou
-wou
-qDn
-toI
-ifg
-qip
-ifg
-eHv
-ifg
-ifg
-tJC
-ifg
-ifg
-psj
-xHe
+dyt
+jEB
+jEB
+yiI
+jEB
+jEB
+yiI
+cwd
+uHk
+lNU
+uHk
+ygS
+uHk
+uHk
+aev
+uHk
+uHk
+yeq
+xET
 erZ
 erZ
 erZ
@@ -383967,8 +384035,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -384331,31 +384399,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-ifg
-qDn
+uHk
+uHk
+uHk
+uHk
+yiI
 rST
-kiS
-wou
-wou
-qDn
-wou
-wou
-qDn
-uzT
-ifg
-ifg
-uzT
-qDn
-ifg
-ifg
-qDn
-quL
-ifg
-rvU
-xHe
+tQT
+jEB
+jEB
+yiI
+jEB
+jEB
+yiI
+qpX
+uHk
+uHk
+qpX
+yiI
+uHk
+uHk
+yiI
+rHO
+uHk
+vHd
+xET
 erZ
 erZ
 erZ
@@ -384370,8 +384438,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -384733,31 +384801,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-ifg
-qDn
-qDn
-qDn
+uHk
+uHk
+uHk
+uHk
+yiI
+yiI
+yiI
+mup
+jEB
+yiI
+jEB
+jEB
+yiI
+jpw
+iXl
+uHk
+cKp
+yiI
 sIE
-wou
-qDn
-wou
-wou
-qDn
-bCb
-pes
-ifg
-hFp
-qDn
-uHj
-ifg
-qDn
-lcF
-dwu
-vLA
-xHe
+uHk
+yiI
+oXz
+uGf
+wtx
+xET
 erZ
 erZ
 erZ
@@ -384772,8 +384840,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -385135,31 +385203,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-ifg
-qDn
-qDn
-qDn
-sIE
-wou
-qDn
-wou
-wou
-qDn
-vsg
-ifg
-ifg
+uHk
+uHk
+uHk
+uHk
 yiI
-qDn
-ifg
-ifg
-qDn
-qDn
-qDn
-qDn
-qDn
+yiI
+yiI
+mup
+jEB
+yiI
+jEB
+jEB
+yiI
+htf
+uHk
+uHk
+ebe
+yiI
+uHk
+uHk
+yiI
+yiI
+yiI
+yiI
+yiI
 erZ
 erZ
 erZ
@@ -385174,8 +385242,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -385537,31 +385605,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-ifg
-qDn
-qDn
-qDn
-exJ
-wou
-qDn
-wou
-wou
-qDn
-vsg
-ifg
-uHj
+uHk
+uHk
+uHk
+uHk
 yiI
-qDn
-ifg
-uHj
-qDn
-qDn
-qDn
-qDn
-qDn
+yiI
+yiI
+cPx
+jEB
+yiI
+jEB
+jEB
+yiI
+htf
+uHk
+sIE
+ebe
+yiI
+uHk
+sIE
+yiI
+yiI
+yiI
+yiI
+yiI
 erZ
 erZ
 erZ
@@ -385576,8 +385644,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -385596,8 +385664,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 aUc
 vIa
 erZ
@@ -385939,31 +386007,31 @@ erZ
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-qDn
-qDn
-qDn
-qDn
-qDn
-qFF
-qDn
-qDn
-qDn
-qDn
-aZg
-iSJ
-ifg
-rRD
-qDn
-ifg
-uHj
-tJC
-ifg
-rvU
-psj
-xHe
+uHk
+uHk
+uHk
+yiI
+yiI
+yiI
+yiI
+yiI
+piN
+yiI
+yiI
+yiI
+yiI
+goz
+hLy
+uHk
+mIn
+yiI
+uHk
+sIE
+aev
+uHk
+vHd
+yeq
+xET
 erZ
 erZ
 erZ
@@ -385978,8 +386046,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -385998,9 +386066,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386341,31 +386409,31 @@ vIa
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-qDn
-wXi
-wou
-wou
-wou
-wou
-vLy
-qDn
-tVB
-ifg
-ifg
-uHj
-ifg
-uzT
-qDn
-ifg
-ifg
-qDn
-ifg
-ifg
-ifg
-xHe
+uHk
+uHk
+uHk
+yiI
+vDr
+jEB
+jEB
+jEB
+jEB
+cBG
+yiI
+xMR
+uHk
+uHk
+sIE
+uHk
+qpX
+yiI
+uHk
+uHk
+yiI
+uHk
+uHk
+uHk
+xET
 erZ
 erZ
 erZ
@@ -386380,8 +386448,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386399,10 +386467,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386743,31 +386811,31 @@ vIa
 erZ
 erZ
 erZ
-ifg
-ifg
-ifg
-qDn
-eUt
-wou
-wou
-wou
-wou
-dtf
-qDn
-tVB
-ifg
-cwd
-ifg
-wsx
-uzT
-qDn
-ifg
-ifg
-qDn
-oKL
-nWG
-vLA
-xHe
+uHk
+uHk
+uHk
+yiI
+lgx
+jEB
+jEB
+jEB
+jEB
+rWd
+yiI
+xMR
+uHk
+wqV
+uHk
+lpb
+qpX
+yiI
+uHk
+uHk
+yiI
+pFt
+pmt
+wtx
+xET
 erZ
 erZ
 erZ
@@ -386782,8 +386850,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386800,11 +386868,11 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -387145,31 +387213,31 @@ vIa
 vIa
 erZ
 erZ
-ifg
-ifg
-ifg
-qDn
-lvu
-wou
-wou
-wou
-wou
-dtf
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-xdQ
-xdQ
-qDn
-qDn
-qDn
-qDn
-qDn
+uHk
+uHk
+uHk
+yiI
+gnv
+jEB
+jEB
+jEB
+jEB
+rWd
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+qwp
+qwp
+yiI
+yiI
+yiI
+yiI
+yiI
 erZ
 erZ
 erZ
@@ -387185,7 +387253,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -387202,10 +387270,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -387550,24 +387618,24 @@ erZ
 erZ
 erZ
 erZ
-qDn
-mgR
-wou
-wou
-wou
-wou
-vLy
-qDn
-npZ
-wYv
-pcQ
-fvW
-pcQ
-wYv
-hQD
-wou
-wou
-ycz
+yiI
+sgt
+jEB
+jEB
+jEB
+jEB
+cBG
+yiI
+jcZ
+fqo
+uZN
+asr
+uZN
+fqo
+fLK
+jEB
+jEB
+gvi
 erZ
 erZ
 erZ
@@ -387587,7 +387655,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -387603,9 +387671,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -387952,24 +388020,24 @@ erZ
 erZ
 erZ
 erZ
-qDn
-eAP
-wou
-wou
-wou
-wou
-enF
-qDn
-wou
-iRN
-iRN
-wou
-lfG
-lfG
-wou
-rRA
-wou
-ycz
+yiI
+fkp
+jEB
+jEB
+jEB
+jEB
+pIn
+yiI
+jEB
+rlo
+rlo
+jEB
+bmL
+bmL
+jEB
+vdg
+jEB
+gvi
 erZ
 erZ
 erZ
@@ -387989,7 +388057,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -388005,9 +388073,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -388354,24 +388422,24 @@ erZ
 erZ
 erZ
 erZ
-qDn
-jQK
-wou
-wou
-wou
-wou
-yll
-ttB
-wou
-wou
-wou
-rRA
-wou
-wou
-rRA
-wou
-wou
-ycz
+yiI
+kgF
+jEB
+jEB
+jEB
+jEB
+uwa
+fkq
+jEB
+jEB
+jEB
+vdg
+jEB
+jEB
+vdg
+jEB
+jEB
+gvi
 erZ
 erZ
 erZ
@@ -388391,7 +388459,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -388407,9 +388475,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -388756,24 +388824,24 @@ erZ
 erZ
 erZ
 erZ
-qDn
-bFX
-wou
-wou
-wou
-wou
-enF
-qDn
-wou
-uRt
-uRt
-wou
-wou
-hYo
-hYo
-rRA
-wou
-ycz
+yiI
+jZM
+jEB
+jEB
+jEB
+jEB
+pIn
+yiI
+jEB
+cld
+cld
+jEB
+jEB
+rQT
+rQT
+vdg
+jEB
+gvi
 erZ
 erZ
 erZ
@@ -388793,7 +388861,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -388809,9 +388877,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389158,24 +389226,24 @@ erZ
 erZ
 erZ
 erZ
-qDn
-fxA
-wou
-wou
-wou
-wou
-xmZ
-qDn
-npZ
-pcQ
-pcQ
-hQD
-wou
-wou
-juY
-suf
-wou
-ycz
+yiI
+jIR
+jEB
+jEB
+jEB
+jEB
+dKU
+yiI
+jcZ
+uZN
+uZN
+fLK
+jEB
+jEB
+dyt
+taz
+jEB
+gvi
 erZ
 erZ
 erZ
@@ -389195,8 +389263,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389210,10 +389278,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389560,24 +389628,24 @@ erZ
 erZ
 erZ
 erZ
-qDn
-vvU
-wou
-wou
-wou
-wou
-xmZ
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-pBQ
-pBQ
-qDn
+yiI
+sRO
+jEB
+jEB
+jEB
+jEB
+dKU
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+siV
+siV
+yiI
 erZ
 erZ
 erZ
@@ -389597,8 +389665,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389612,10 +389680,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389962,28 +390030,28 @@ erZ
 erZ
 erZ
 erZ
-qDn
-bFX
-wou
-wou
-wou
-wou
-yfe
-qDn
-lPI
-pdl
-sgY
+yiI
+jZM
+jEB
+jEB
+jEB
+jEB
+hRj
+yiI
+oun
+rMX
 tUR
-sgY
-pdl
+xkF
 tUR
-suf
-wou
-qDn
-qDn
-qDn
-qDn
-qDn
+rMX
+xkF
+taz
+jEB
+yiI
+yiI
+yiI
+yiI
+yiI
 erZ
 erZ
 erZ
@@ -390000,7 +390068,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -390014,10 +390082,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -390363,29 +390431,29 @@ erZ
 erZ
 aUc
 erZ
-qDn
-qDn
-sIE
-wou
-wou
-wou
-wou
-bHX
-qDn
-wou
-rRA
-wou
-wou
-wou
-wou
-rRA
-wou
-wou
-tJC
-ifg
-ifg
-psj
-xHe
+yiI
+yiI
+mup
+jEB
+jEB
+jEB
+jEB
+mxn
+yiI
+jEB
+vdg
+jEB
+jEB
+jEB
+jEB
+vdg
+jEB
+jEB
+aev
+uHk
+uHk
+yeq
+xET
 erZ
 erZ
 erZ
@@ -390402,7 +390470,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -390416,10 +390484,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -390765,29 +390833,29 @@ vIa
 vIa
 aUc
 aUc
-qDn
-qDn
-sIE
-wou
-wou
-wou
-wou
-yll
-qDn
-rzb
-wou
-wou
-rRA
-rRA
-wou
-wou
-wou
-wou
-qDn
-quy
-ifg
-ifg
-xHe
+yiI
+yiI
+mup
+jEB
+jEB
+jEB
+jEB
+uwa
+yiI
+mhE
+jEB
+jEB
+vdg
+vdg
+jEB
+jEB
+jEB
+jEB
+yiI
+gkI
+uHk
+uHk
+xET
 erZ
 erZ
 erZ
@@ -390804,7 +390872,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -390818,10 +390886,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -391167,29 +391235,29 @@ vIa
 vIa
 aUc
 aUc
-uDi
-uDi
-sIE
-toM
-yll
-wou
-wou
-wou
-wpc
-wou
-wou
-wou
-rRA
-rRA
-wou
-wou
-wou
-wou
-qDn
-quL
-ifg
-ifg
-xHe
+rcr
+rcr
+mup
+ahX
+uwa
+jEB
+jEB
+jEB
+vnw
+jEB
+jEB
+jEB
+vdg
+vdg
+jEB
+jEB
+jEB
+jEB
+yiI
+rHO
+uHk
+uHk
+xET
 erZ
 erZ
 erZ
@@ -391206,7 +391274,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -391220,9 +391288,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -391570,28 +391638,28 @@ vIa
 vIa
 vIa
 aUc
-uDi
-uDi
-uDi
-yll
-yll
-wou
-wou
-aiu
-iWn
-rRA
-wou
-wou
-wou
-wou
-rRA
-wou
-wou
-qDn
-oMa
-ifg
-ifg
-xHe
+rcr
+rcr
+rcr
+uwa
+uwa
+jEB
+jEB
+dSY
+tlQ
+vdg
+jEB
+jEB
+jEB
+jEB
+vdg
+jEB
+jEB
+yiI
+lVX
+uHk
+uHk
+xET
 erZ
 erZ
 erZ
@@ -391608,7 +391676,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -391622,9 +391690,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -391974,26 +392042,26 @@ vIa
 vIa
 aUc
 aUc
-uDi
-uDi
-yll
-yll
-yll
-qDn
-qDn
-ffN
-ffN
-dNL
-ffN
-suf
-wou
-wou
-wou
-qDn
-kJx
-vLA
-uKf
-xHe
+rcr
+rcr
+uwa
+uwa
+uwa
+yiI
+yiI
+lgz
+lgz
+nQP
+lgz
+taz
+jEB
+jEB
+jEB
+yiI
+gip
+wtx
+ifg
+xET
 erZ
 erZ
 erZ
@@ -392010,7 +392078,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -392024,9 +392092,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -392377,25 +392445,25 @@ vIa
 vIa
 aUc
 aUc
-uDi
-uDi
-uDi
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-gds
-gds
-gds
-gds
-qDn
-qDn
-qDn
-qDn
-qDn
+rcr
+rcr
+rcr
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+sxM
+sxM
+sxM
+sxM
+yiI
+yiI
+yiI
+yiI
+yiI
 erZ
 erZ
 erZ
@@ -392412,8 +392480,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -392426,9 +392494,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -392783,7 +392851,7 @@ aUc
 aUc
 aUc
 aUc
-oJO
+bqt
 erZ
 erZ
 erZ
@@ -392814,9 +392882,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -392827,10 +392895,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -393218,20 +393286,20 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -393624,15 +393692,15 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -394027,13 +394095,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-dbt
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+lLK
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -394429,13 +394497,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-khc
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+mVz
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -394807,12 +394875,12 @@ xKz
 xKz
 xKz
 xKz
-aym
-kLw
-cjy
-tAb
-eSj
-foQ
+kJb
+tlS
+siT
+xYB
+xIQ
+nWe
 xKz
 erZ
 erZ
@@ -394831,13 +394899,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-dbt
-kvj
-dbt
-tDB
-kvj
-obq
+iug
+lLK
+iRN
+lLK
+cNj
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -395204,10 +395272,10 @@ erZ
 fVQ
 fVQ
 xKz
-lGE
-hsd
-hsd
-ayc
+bCb
+llg
+llg
+nga
 xKz
 fVQ
 fVQ
@@ -395233,13 +395301,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-kvj
-kvj
-khc
-dbt
-kvj
-obq
+iug
+iRN
+iRN
+mVz
+lLK
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -395614,14 +395682,14 @@ xKz
 fVQ
 fVQ
 jeb
-mnG
+lFX
 fVQ
-qgD
+fjB
 xKz
 fVQ
 bvN
 tYP
-xaD
+hJH
 jeb
 erZ
 erZ
@@ -395635,13 +395703,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-kvj
-kvj
-dbt
-tDB
-kvj
-obq
+iug
+iRN
+iRN
+lLK
+cNj
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -396012,18 +396080,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-gip
+lKP
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-gip
+lKP
 fVQ
 bvN
 tYP
-rGS
+iSJ
 jeb
 erZ
 erZ
@@ -396037,13 +396105,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-dbt
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+lLK
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -396408,24 +396476,24 @@ erZ
 erZ
 erZ
 xKz
-qPF
-sbF
+rTZ
+uNH
 fVQ
 fVQ
 lLa
-vdg
+ndA
 jeb
-ips
-xpF
-rba
-lvy
+lbj
+mYD
+jZC
+gEw
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-ycX
+aym
 jeb
 erZ
 erZ
@@ -396439,13 +396507,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-khc
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+mVz
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -396810,12 +396878,12 @@ erZ
 erZ
 erZ
 xKz
-tKO
-sbF
+xQc
+uNH
 fVQ
 fVQ
 lLa
-vdg
+ndA
 jeb
 xKz
 xKz
@@ -396827,7 +396895,7 @@ xKz
 fVQ
 tYP
 tYP
-pMn
+odd
 jeb
 erZ
 erZ
@@ -396841,13 +396909,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-dbt
-kvj
-dbt
-tDB
-kvj
-obq
+iug
+lLK
+iRN
+lLK
+cNj
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -397212,24 +397280,24 @@ erZ
 erZ
 erZ
 xKz
-bmc
-sbF
+vyS
+uNH
 fVQ
 fVQ
 fVQ
 fVQ
-gip
+lKP
 fVQ
-sLY
-wDz
-ulU
+cKL
+jEf
+wYv
 fVQ
-iKB
+cHt
 xKz
 fVQ
 bvN
 tYP
-xaD
+hJH
 jeb
 erZ
 erZ
@@ -397243,13 +397311,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-kvj
-kvj
-khc
-dbt
-kvj
-obq
+iug
+iRN
+iRN
+mVz
+lLK
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -397614,24 +397682,24 @@ erZ
 erZ
 erZ
 xKz
-lBY
-sbF
+pmK
+uNH
 fVQ
-fzR
+nIw
 fVQ
 fVQ
 jeb
-dGv
+rGp
 fVQ
 fVQ
 fVQ
 fVQ
-cmQ
+gws
 xKz
 fVQ
 bvN
 tYP
-rGS
+iSJ
 jeb
 erZ
 erZ
@@ -397645,13 +397713,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-dbt
-kvj
-dbt
-tDB
-kvj
-obq
+iug
+lLK
+iRN
+lLK
+cNj
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -398020,20 +398088,20 @@ xKz
 xKz
 xKz
 xKz
-qYw
+ovj
 xKz
 xKz
-qGy
+eiG
 fVQ
 jeb
-mnG
+lFX
 fVQ
-dNz
+lyQ
 xKz
 fVQ
 tYP
 tYP
-ycX
+aym
 jeb
 erZ
 erZ
@@ -398047,13 +398115,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-khc
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+mVz
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -398425,7 +398493,7 @@ fVQ
 fVQ
 fVQ
 xKz
-lFQ
+eFt
 fVQ
 fVQ
 fVQ
@@ -398435,7 +398503,7 @@ xKz
 fVQ
 tYP
 tYP
-pMn
+odd
 jeb
 erZ
 erZ
@@ -398449,13 +398517,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-dbt
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+lLK
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -398827,17 +398895,17 @@ vZP
 lLa
 fVQ
 xKz
-lqV
-mRp
-tzj
-qFp
+pqp
+tTv
+owa
+xMP
 fVQ
-ftE
+rHa
 xKz
 fVQ
 fIB
 tYP
-xaD
+hJH
 jeb
 erZ
 erZ
@@ -398851,13 +398919,13 @@ erZ
 erZ
 erZ
 erZ
-wpm
-kvj
-kvj
-kvj
-kvj
-kvj
-obq
+iug
+iRN
+iRN
+iRN
+iRN
+iRN
+gbA
 erZ
 erZ
 erZ
@@ -399227,7 +399295,7 @@ fVQ
 lLa
 noC
 lLa
-qgD
+fjB
 xKz
 xKz
 xKz
@@ -399253,10 +399321,10 @@ erZ
 erZ
 erZ
 erZ
-wpm
-kvj
+iug
+iRN
 xKz
-lmT
+fgh
 bOK
 jeb
 xKz
@@ -399638,7 +399706,7 @@ fVQ
 fVQ
 xKz
 xKz
-qYw
+ovj
 xKz
 xKz
 xKz
@@ -399655,8 +399723,8 @@ erZ
 erZ
 erZ
 erZ
-wpm
-kvj
+iug
+iRN
 jeb
 fVQ
 ugK
@@ -418911,7 +418979,7 @@ ygF
 ygF
 ygF
 ygF
-rIm
+tmu
 jYR
 lHe
 lHe
@@ -431771,8 +431839,8 @@ wAm
 wAm
 wAm
 wAm
-xIr
-xIr
+qLF
+qLF
 wAm
 wAm
 wAm
@@ -432173,18 +432241,18 @@ rwH
 uSx
 teW
 kqc
-woJ
+vFz
 jjS
-sNS
-vMQ
+abZ
+wte
 vsf
 rwH
 nKu
 jiv
 rwH
 teW
-vVP
-qeH
+fDB
+rja
 wte
 enq
 fZJ
@@ -432572,10 +432640,10 @@ teW
 dvD
 jiv
 jiv
-ixk
+vgv
 teW
-cdn
-ikM
+sIx
+jRF
 jiv
 jiv
 jiv
@@ -432586,8 +432654,8 @@ jiv
 jjS
 teW
 hqI
-rDR
-uGf
+aPR
+hqI
 enq
 fZJ
 fZJ
@@ -432976,8 +433044,8 @@ jiv
 jiv
 teW
 teW
-vMQ
-ikM
+wte
+jRF
 jiv
 jiv
 jiv
@@ -432988,11 +433056,11 @@ jiv
 vIX
 teW
 hqI
-rDR
-uGf
-enq
-fZJ
-fZJ
+aPR
+hqI
+wUw
+wUw
+bzl
 fZJ
 fZJ
 fZJ
@@ -433383,18 +433451,18 @@ jiv
 jiv
 jiv
 qfh
-wra
+nSr
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-rDR
-uGf
-enq
-fZJ
-fZJ
+aPR
+hqI
+jFM
+jFM
+oEy
 fZJ
 fZJ
 fZJ
@@ -433784,19 +433852,19 @@ jiv
 xSI
 jiv
 jiv
-nSr
-icP
+vPA
+lLq
 htU
 teW
 ael
 hqI
 hqI
 hqI
-rDR
-uGf
-enq
-fZJ
-fZJ
+aPR
+hqI
+jFM
+jFM
+jIP
 fZJ
 fZJ
 fZJ
@@ -434183,8 +434251,8 @@ xSI
 tML
 tML
 tML
-tOk
-tOk
+vWY
+vWY
 tML
 aGb
 tML
@@ -434194,11 +434262,11 @@ pDA
 hqI
 hqI
 hqI
-rDR
-uGf
-enq
-fZJ
-fZJ
+aPR
+hqI
+jFM
+jFM
+jIP
 fZJ
 fZJ
 fZJ
@@ -434589,18 +434657,18 @@ nyc
 ntK
 ntK
 cAe
-nWJ
-rSg
+wpm
+wDZ
 teW
 ulu
 hqI
 fVE
-rDR
-rDR
-uGf
-enq
-fZJ
-fZJ
+aPR
+uPa
+hqI
+fTO
+fTO
+lNA
 fZJ
 fZJ
 fZJ
@@ -434991,14 +435059,14 @@ nyc
 ntK
 ntK
 tak
-fLK
-fLK
+lGI
+lGI
 teW
 uNz
 hqI
 hqI
-rDR
-xMs
+aPR
+btY
 ojc
 enq
 fZJ
@@ -435382,7 +435450,7 @@ erZ
 erZ
 fZJ
 fZJ
-qLF
+cWM
 gys
 tsB
 aur
@@ -435392,13 +435460,13 @@ swm
 nyc
 ntK
 ntK
-mjP
-iqP
-iqP
+iXM
+rSg
+rSg
 teW
 ajj
-lLK
-lLK
+uPa
+uPa
 uPa
 tML
 tML
@@ -436594,11 +436662,11 @@ uKB
 aur
 uZa
 cPw
-fEa
+tOB
 ntK
 ntK
 ntK
-dwO
+vgh
 ybm
 ybm
 ohA
@@ -436990,7 +437058,7 @@ erZ
 erZ
 fZJ
 fZJ
-qLF
+cWM
 pfp
 sUb
 aur
@@ -437001,8 +437069,8 @@ nyc
 ntK
 ntK
 cAe
-rSg
-rSg
+wDZ
+wDZ
 teW
 eYI
 vGN
@@ -437403,12 +437471,12 @@ nyc
 ntK
 ntK
 tak
-fLK
-fLK
+lGI
+lGI
 tML
-vfW
-vfW
-vfW
+wjl
+wjl
+wjl
 wAm
 tML
 tML
@@ -437804,13 +437872,13 @@ aXE
 nyc
 ntK
 ntK
-iNA
-lkT
-qMF
+eTL
+sNm
+fXz
 tML
-rgw
-rgw
-rgw
+ewS
+ewS
+ewS
 wAm
 hKU
 hKU
@@ -437827,7 +437895,7 @@ squ
 squ
 squ
 rTC
-aIl
+vnG
 squ
 squ
 squ
@@ -438203,7 +438271,7 @@ tML
 teW
 tML
 tML
-aNu
+aKc
 fnF
 tML
 aGb
@@ -438217,7 +438285,7 @@ wpe
 fQd
 eCn
 sNY
-aSo
+lWz
 teW
 teW
 teW
@@ -438229,7 +438297,7 @@ squ
 squ
 squ
 rTC
-aIl
+vnG
 rTC
 rTC
 rTC
@@ -438623,7 +438691,7 @@ eCn
 teW
 aor
 xfh
-rGY
+ksg
 teW
 squ
 squ
@@ -439019,8 +439087,8 @@ cfY
 cfY
 teW
 aTF
-jeE
-fPi
+cXK
+nkq
 eCn
 mYi
 gbX
@@ -439421,8 +439489,8 @@ uZy
 cfY
 alk
 eCn
-qor
-gSA
+nMg
+fTD
 eCn
 mYi
 gbX
@@ -439805,14 +439873,14 @@ erZ
 fZJ
 fZJ
 rxp
-fJl
+vdd
 uKB
 uBv
 tML
 tML
 tML
 xnv
-tig
+pPt
 tML
 rMM
 cfY
@@ -439827,9 +439895,9 @@ eCn
 eCn
 eCn
 teW
-nwC
-sPx
-tlQ
+wra
+kbt
+nJy
 teW
 squ
 squ
@@ -440611,8 +440679,8 @@ fZJ
 rxp
 uKB
 uKB
-ktU
-gbA
+fsD
+xOd
 uKB
 nIr
 swm
@@ -440631,8 +440699,8 @@ eCn
 teW
 mYi
 teW
-xJe
-xJe
+lMZ
+lMZ
 teW
 squ
 squ
@@ -441033,8 +441101,8 @@ teW
 teW
 eCn
 teW
-xJe
-xJe
+lMZ
+lMZ
 teW
 squ
 squ
@@ -441410,14 +441478,14 @@ vIa
 vIa
 aUc
 teW
-xIq
+vBy
 teW
 uKB
 uKB
-jpc
-diu
-gpA
-kfI
+gQV
+tfp
+rqu
+qua
 tML
 swm
 swm
@@ -441435,8 +441503,8 @@ eCn
 fQd
 eCn
 teW
-xJe
-xJe
+lMZ
+lMZ
 teW
 eQa
 rTC
@@ -441812,10 +441880,10 @@ vIa
 vIa
 aUc
 teW
-ihj
+hrS
 teW
-ptu
-rIE
+aYP
+cZz
 tML
 tML
 ydR
@@ -441831,15 +441899,15 @@ idu
 sct
 sNp
 cfY
-twz
-mQx
-xsL
-wfJ
+wvp
+gMp
+uZC
+jCr
 eCn
 teW
-xJe
-xJe
-xJe
+lMZ
+lMZ
+lMZ
 aUc
 aUc
 aUc
@@ -442226,20 +442294,20 @@ pjB
 swm
 swm
 tML
-ivE
+irg
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-twz
-aiR
-kei
-hqZ
+wvp
+hqS
+cjZ
+qjY
 eCn
 teW
-xJe
+lMZ
 lAs
 lAs
 vIa
@@ -442630,18 +442698,18 @@ swm
 tML
 rMM
 eVa
-qKD
+loE
 tcW
 tcW
 tcW
 eVa
-xzx
-pcr
-liH
-rYq
+yfQ
+aXs
+gYG
+xEI
 eCn
 teW
-xJe
+lMZ
 lAs
 lAs
 vIa
@@ -443018,7 +443086,7 @@ vIa
 vIa
 aUc
 teW
-rXY
+sVh
 nMd
 uKB
 uKB
@@ -443027,7 +443095,7 @@ tML
 tML
 tML
 wAm
-tig
+pPt
 wAm
 wAm
 teW
@@ -443043,7 +443111,7 @@ eCn
 grk
 eCn
 teW
-xJe
+lMZ
 lAs
 lAs
 vIa
@@ -443422,22 +443490,22 @@ aUc
 teW
 teW
 teW
-gbA
+xOd
 uKB
 uKB
-rnq
+lKy
 iYx
-cLL
-vWY
-vWY
+omi
+xwi
+xwi
 teW
-iYx
-iYx
 iYx
 iYx
-xJe
-xJe
-xJe
+iYx
+iYx
+lMZ
+lMZ
+lMZ
 teW
 teW
 teW
@@ -443445,7 +443513,7 @@ teW
 teW
 teW
 teW
-xJe
+lMZ
 lAs
 lAs
 vIa
@@ -443821,33 +443889,33 @@ vIa
 vIa
 vIa
 aUc
-xJe
-xJe
+lMZ
+lMZ
 teW
-gbA
+xOd
 uKB
 uKB
-bmj
+tpY
 iYx
 vaa
-vWY
-fWa
+xwi
+quv
 teW
-llV
-ljG
-ogC
+itC
+aac
+uHj
 iYx
-xJe
-xJe
-xJe
-xJe
-xJe
-xJe
-xJe
-xJe
-xJe
-xJe
-xJe
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
 lAs
 lAs
 vIa
@@ -444224,22 +444292,22 @@ vIa
 vIa
 vIa
 lAs
-xJe
+lMZ
 teW
-gbA
+xOd
 uKB
 uKB
-kGB
+hxv
 iYx
-ePv
-vWY
-vWY
+als
+xwi
+xwi
 teW
-ebe
-vWY
-vWY
+uwf
+xwi
+xwi
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -444626,22 +444694,22 @@ vIa
 vIa
 vIa
 lAs
-xJe
+lMZ
 teW
-viP
+dFV
 uKB
 uKB
-pJP
+tFA
 iYx
-nQh
-vWY
-vWY
-vFz
-vWY
-vWY
-mLO
+bUi
+xwi
+xwi
+hpk
+xwi
+xwi
+wAp
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -445028,22 +445096,22 @@ vIa
 vIa
 vIa
 lAs
-xJe
+lMZ
 teW
 teW
 teW
 teW
 teW
 iYx
-hbc
-vWY
-eil
+omQ
+xwi
+vsg
 iYx
-lWI
-sTN
-cdQ
+cXg
+aNU
+tiH
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -445430,22 +445498,22 @@ vIa
 vIa
 vIa
 lAs
-xJe
-xJe
-xJe
+lMZ
+lMZ
+lMZ
 iYx
 iYx
 iYx
 iYx
-cLL
-vWY
-pCk
+omi
+xwi
+nCB
 iYx
 iYx
 iYx
 iYx
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -445834,20 +445902,20 @@ vIa
 lAs
 lAs
 lAs
-xJe
+lMZ
 iYx
-pCk
-lYV
+nCB
+oBO
 iYx
 iYx
-vWY
-eil
+xwi
+vsg
 iYx
-llV
-ljG
-ogC
+itC
+aac
+uHj
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -446236,20 +446304,20 @@ vIa
 lAs
 lAs
 lAs
-xJe
+lMZ
 iYx
-ebe
-vWY
-aNu
-vWY
-vWY
-vWY
+uwf
+xwi
+aKc
+xwi
+xwi
+xwi
 iYx
-ebe
-vWY
-vWY
+uwf
+xwi
+xwi
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -446638,20 +446706,20 @@ vIa
 lAs
 lAs
 lAs
-xJe
+lMZ
 iYx
-vWY
-vWY
+xwi
+xwi
 iYx
-vWY
-vWY
-vWY
-vFz
-vWY
-vWY
-mLO
+xwi
+xwi
+xwi
+hpk
+xwi
+xwi
+wAp
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -447040,20 +447108,20 @@ vIa
 lAs
 lAs
 lAs
-xJe
+lMZ
 iYx
-cQP
-cdQ
+neN
+tiH
 iYx
-vWY
-fRy
-qwp
+xwi
+mQr
+wOr
 iYx
-lWI
-sTN
-cdQ
+cXg
+aNU
+tiH
 iYx
-xJe
+lMZ
 lAs
 lAs
 lAs
@@ -447443,18 +447511,18 @@ vIa
 vIa
 vIa
 aUc
-pdP
+qCT
 iYx
 iYx
 iYx
-eZX
+uEX
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-pdP
+qCT
 aUc
 vIa
 vIa
@@ -447848,14 +447916,14 @@ aUc
 aUc
 iYx
 iYx
-qMB
+mxm
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-xJe
+lMZ
 aUc
 aUc
 vIa
@@ -448249,15 +448317,15 @@ vIa
 vIa
 aUc
 iYx
-dUD
-tfp
+xNf
+dbH
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-xJe
+lMZ
 vIa
 vIa
 vIa
@@ -448651,15 +448719,15 @@ vIa
 vIa
 aUc
 iYx
-wxi
-tfp
+jEc
+dbH
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-xJe
+lMZ
 vIa
 vIa
 vIa
@@ -449053,15 +449121,15 @@ vIa
 vIa
 aUc
 iYx
-fWp
-onS
+gmg
+xrs
 vGN
 vGN
 vGN
 iYx
 iYx
 iYx
-xJe
+lMZ
 vIa
 vIa
 vIa
@@ -449457,13 +449525,13 @@ aUc
 iYx
 iYx
 iYx
-mQg
-mQg
-sWy
+kEk
+kEk
+bsB
 iYx
-xJe
-xJe
-xJe
+lMZ
+lMZ
+lMZ
 vIa
 vIa
 vIa
@@ -486033,36 +486101,36 @@ vIa
 aUc
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-dbH
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+nhR
 erZ
 erZ
 erZ
@@ -486432,39 +486500,39 @@ vIa
 vIa
 vIa
 vIa
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-ifg
-iXU
-qDn
-qDn
-qDn
-ifg
-ifg
-ifg
-ifg
-ifg
-tJC
-ifg
-qDn
-irI
-jYL
-mHK
-sgf
-aSD
-sgf
-cUj
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+uHk
+ckv
+yiI
+yiI
+yiI
+uHk
+uHk
+uHk
+uHk
+uHk
+aev
+uHk
+yiI
+eqI
+wqv
+fpz
+gyH
+bVa
+gyH
+xyU
 erZ
 erZ
 erZ
@@ -486834,39 +486902,39 @@ vIa
 erZ
 erZ
 erZ
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-ifg
-iWj
-qDn
-qDn
-qDn
-ifg
-ifg
-bzU
-iXi
-iXi
-qDn
-ifg
-lNY
-aSD
-aSD
-aSD
-aSD
-aSD
-aSD
-aXv
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+uHk
+jGj
+yiI
+yiI
+yiI
+uHk
+uHk
+qdN
+qoR
+qoR
+yiI
+uHk
+uFY
+bVa
+bVa
+bVa
+bVa
+bVa
+bVa
+lUO
 erZ
 erZ
 erZ
@@ -487236,39 +487304,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-ifg
-ifg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 yiI
-qDn
-bCb
-sxM
-wDZ
-dkw
-qDn
-qDn
-qDn
-tJC
-qDn
-mkS
-aSD
-aSD
-aSD
-aSD
-aSD
-ofs
+uHk
+uHk
+ebe
+yiI
+jpw
+upC
+qGh
+qcc
+yiI
+yiI
+yiI
+aev
+yiI
+cLL
+bVa
+bVa
+bVa
+bVa
+bVa
+vzO
 erZ
 erZ
 erZ
@@ -487638,39 +487706,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-ifg
-ifg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 yiI
-qDn
-cRP
-ifg
-ifg
-syi
-qDn
-oMa
-ifg
-ifg
-qDn
-csm
-pdm
-irE
-aSD
-aSD
-aSD
-cUj
+uHk
+uHk
+ebe
+yiI
+vUf
+uHk
+uHk
+fnf
+yiI
+lVX
+uHk
+uHk
+yiI
+mQA
+uDi
+qQD
+bVa
+bVa
+bVa
+xyU
 erZ
 erZ
 erZ
@@ -488040,39 +488108,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-tJC
-qDn
-qDn
-qDn
-cRP
-ifg
-ifg
-syi
-qDn
-far
-ifg
-ifg
-dbH
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+aev
+yiI
+yiI
+yiI
+vUf
+uHk
+uHk
+fnf
+yiI
 wyA
-wAJ
-hQz
-vjV
-aSD
-aSD
-aXv
+uHk
+uHk
+nhR
+cjf
+xdw
+vMj
+upu
+bVa
+bVa
+lUO
 erZ
 erZ
 erZ
@@ -488442,39 +488510,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-qDn
-qpX
-qpX
-auL
-qDn
-bCb
-iSJ
-ifg
-hFp
-qDn
-ifg
-wDZ
-ifg
-dbH
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+yiI
+urF
+urF
+xIg
+yiI
+jpw
+hLy
+uHk
+cKp
+yiI
+uHk
+qGh
+uHk
+nhR
 wQI
-sNj
+hbc
 wQI
-umz
-aSD
-aSD
-ofs
+qpY
+bVa
+bVa
+vzO
 erZ
 erZ
 erZ
@@ -488844,39 +488912,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+bqt
 fIL
 wQD
 aUc
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-bCb
-iSJ
-ifg
-dkw
-qDn
-cRP
-wDZ
-wDZ
-syi
-qDn
-ifg
-ifg
-ifg
-dbH
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+jpw
+hLy
+uHk
+qcc
+yiI
+vUf
+qGh
+qGh
+fnf
+yiI
+uHk
+uHk
+uHk
+nhR
 wQI
 wQI
 wQI
-lVF
-aSD
-aSD
-cUj
+xbW
+bVa
+bVa
+xyU
 erZ
 erZ
 erZ
@@ -489251,34 +489319,34 @@ eNY
 hby
 aUc
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-cRP
-ifg
-ifg
-syi
-qDn
-cRP
-ifg
-ifg
-syi
-qDn
-far
-ifg
-far
-dbH
-wfP
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+vUf
+uHk
+uHk
+fnf
+yiI
+vUf
+uHk
+uHk
+fnf
+yiI
+wyA
+uHk
+wyA
+nhR
+tex
 wQI
-wfP
-fhK
-aSD
-aSD
-aXv
+tex
+fAd
+bVa
+bVa
+lUO
 erZ
 erZ
 erZ
@@ -489654,33 +489722,33 @@ twI
 aUc
 aUc
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-vsg
-ifg
-qpX
+bqt
+bqt
+bqt
+bqt
+bqt
 yiI
-qDn
-bCb
-iSJ
-ifg
-hFp
-qDn
-oMa
-ifg
-wDZ
-qDn
-qDn
-qDn
-qDn
-pdm
-pdm
-pdm
-voc
+htf
+uHk
+urF
+ebe
+yiI
+jpw
+hLy
+uHk
+cKp
+yiI
+lVX
+uHk
+qGh
+yiI
+yiI
+yiI
+yiI
+uDi
+uDi
+uDi
+thr
 erZ
 erZ
 erZ
@@ -490055,30 +490123,30 @@ twI
 twI
 twI
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-lZf
-iSJ
-ifg
-bzU
-qDn
-vsg
-ifg
-ifg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 yiI
-qDn
-ifg
-wDZ
-ifg
-qKU
-ifg
-far
-kPK
+yjP
+hLy
+uHk
+qdN
+yiI
+htf
+uHk
+uHk
+ebe
+yiI
+uHk
+qGh
+uHk
+eJE
+uHk
+wyA
+bBR
 erZ
 erZ
 erZ
@@ -490456,31 +490524,31 @@ aUc
 aUc
 xGC
 oWI
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-eIC
-iSJ
-ifg
-dkw
-qDn
-cRP
-ifg
-ifg
-syi
-qDn
-qKU
-ifg
-ifg
-ifg
-fnD
-iME
-lrF
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+vox
+hLy
+uHk
+qcc
+yiI
+vUf
+uHk
+uHk
+fnf
+yiI
+eJE
+uHk
+uHk
+uHk
+oLS
+kYz
+kJf
 erZ
 erZ
 erZ
@@ -490858,31 +490926,31 @@ vIa
 aUc
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-vsg
-qpX
-ifg
-syi
-qDn
-bCb
-iSJ
-ifg
-hFp
-qDn
-far
-ifg
-wDZ
-ifg
-fDB
-kwN
-lUc
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+htf
+urF
+uHk
+fnf
+yiI
+jpw
+hLy
+uHk
+cKp
+yiI
+wyA
+uHk
+qGh
+uHk
+mTP
+seC
+dEf
 erZ
 erZ
 erZ
@@ -491257,34 +491325,34 @@ erZ
 erZ
 erZ
 bQB
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-cRP
-ifg
-ifg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 yiI
-qDn
+vUf
+uHk
+uHk
+ebe
 yiI
-wDZ
-wDZ
-syi
-qDn
-oMa
-qKU
-ifg
-ifg
-fDB
-xkF
-kad
+ebe
+qGh
+qGh
+fnf
+yiI
+lVX
+eJE
+uHk
+uHk
+mTP
+sRT
+fEZ
 erZ
 erZ
 erZ
@@ -491659,34 +491727,34 @@ erZ
 erZ
 erZ
 bQB
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-bCb
-iSJ
-ifg
-nTR
-nTR
-nTR
-ifg
-ifg
-nTR
-nTR
-wDZ
-ifg
-qKU
-qKU
-fDB
-xkF
-kad
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+jpw
+hLy
+uHk
+xud
+xud
+xud
+uHk
+uHk
+xud
+xud
+qGh
+uHk
+eJE
+eJE
+mTP
+sRT
+fEZ
 erZ
 erZ
 erZ
@@ -492061,34 +492129,34 @@ erZ
 erZ
 erZ
 bQB
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-cRP
-qpX
-ifg
-wFa
-qDn
-aZg
-iSJ
-ifg
-rRD
-qDn
-oMa
-wDZ
-ifg
-far
-ovj
-ovj
-fTV
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+vUf
+urF
+uHk
+dEk
+yiI
+goz
+hLy
+uHk
+mIn
+yiI
+lVX
+qGh
+uHk
+wyA
+qcb
+qcb
+ipr
 erZ
 erZ
 erZ
@@ -492463,37 +492531,37 @@ erZ
 erZ
 erZ
 bQB
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-cRP
-ifg
-qpX
-ifg
-tJC
-ifg
-ifg
-ifg
-qDn
-qDn
-qDn
-qDn
-qDn
-oMa
-ifg
-ifg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+vUf
+uHk
+urF
+uHk
+aev
+uHk
+uHk
+uHk
+yiI
+yiI
+yiI
+yiI
+yiI
+lVX
+uHk
+uHk
 uLh
 uLh
-nfn
-bBo
+riW
+pOq
 uLh
 erZ
 erZ
@@ -492865,39 +492933,39 @@ erZ
 erZ
 erZ
 bQB
-oJO
+bqt
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-aDD
-iSJ
-ifg
-wqB
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-oJO
-oJO
-qDn
-ifg
-ifg
-far
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+hiY
+hLy
+uHk
+rnn
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+bqt
+bqt
+yiI
+uHk
+uHk
+wyA
 uLh
-tLZ
-jCr
-dsq
+kOA
+rgO
+mjP
 uLh
-pTC
+diq
 erZ
 erZ
 erZ
@@ -493261,46 +493329,46 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 hqA
 pCW
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-qDn
-qDn
-qDn
-qDn
-qDn
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-far
-ifg
-ifg
-gcf
-jCr
-jCr
-jka
-bBo
-jCr
-jCr
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+yiI
+yiI
+yiI
+yiI
+yiI
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+wyA
+uHk
+uHk
+ndQ
+rgO
+rgO
+rPa
+pOq
+rgO
+rgO
 erZ
 erZ
 erZ
@@ -493658,13 +493726,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 lgg
 lgg
 lgg
@@ -493676,33 +493744,33 @@ lgg
 lgg
 lgg
 lgg
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-qDn
-qDn
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-far
-ifg
-ifg
-gcf
-jCr
-jCr
-jCr
-gcf
-jCr
-jCr
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+yiI
+yiI
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+wyA
+uHk
+uHk
+ndQ
+rgO
+rgO
+rgO
+ndQ
+rgO
+rgO
 erZ
 erZ
 erZ
@@ -494056,13 +494124,13 @@ vIa
 vIa
 vIa
 vIa
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 lgg
 lgg
 lgg
@@ -494082,29 +494150,29 @@ lgg
 lgg
 vIa
 vIa
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-oMa
-ifg
-ifg
-gcf
-jCr
-jCr
-jCr
-bBo
-jCr
-jCr
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+lVX
+uHk
+uHk
+ndQ
+rgO
+rgO
+rgO
+pOq
+rgO
+rgO
 erZ
 erZ
 erZ
@@ -494487,25 +494555,25 @@ vIa
 vIa
 vIa
 vIa
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-qDn
-pPY
-ifg
-ifg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+yiI
+rac
+uHk
+uHk
 uLh
-gog
-jCr
-jCr
+ebb
+rgO
+rgO
 uLh
-pTC
+diq
 erZ
 erZ
 erZ
@@ -494891,22 +494959,22 @@ vIa
 vIa
 vIa
 aUc
-oJO
-qDn
-qCT
-qCT
-qCT
-qCT
-qCT
-qCT
-qCT
-bLa
-bLa
+bqt
+yiI
+jsF
+jsF
+jsF
+jsF
+jsF
+jsF
+jsF
+uFp
+uFp
 uLh
 uLh
-hNE
-hNE
-jxE
+hZE
+hZE
+ign
 erZ
 erZ
 erZ
@@ -495293,8 +495361,8 @@ vIa
 vIa
 vIa
 vIa
-oJO
-oJO
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -496915,14 +496983,14 @@ erZ
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -497312,19 +497380,19 @@ erZ
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -497714,24 +497782,24 @@ erZ
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -498116,24 +498184,24 @@ erZ
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -498516,26 +498584,26 @@ sri
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -498918,26 +498986,26 @@ sri
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -499320,26 +499388,26 @@ sri
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -499722,26 +499790,26 @@ erZ
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -500124,26 +500192,26 @@ erZ
 erZ
 erZ
 erZ
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -500526,7 +500594,7 @@ erZ
 erZ
 erZ
 erZ
-cBG
+qKU
 iJC
 bOK
 nEd
@@ -500534,18 +500602,18 @@ nEd
 nEd
 bOK
 iJC
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -500928,7 +500996,7 @@ erZ
 erZ
 erZ
 erZ
-cBG
+qKU
 bOK
 fVQ
 fVQ
@@ -500936,18 +501004,18 @@ bmG
 fVQ
 fVQ
 bOK
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -501330,7 +501398,7 @@ erZ
 erZ
 erZ
 erZ
-cBG
+qKU
 nEd
 fVQ
 lgN
@@ -501338,18 +501406,18 @@ jJC
 lgN
 fVQ
 nEd
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -501732,7 +501800,7 @@ erZ
 erZ
 erZ
 erZ
-cBG
+qKU
 nEd
 fVQ
 qxZ
@@ -501746,12 +501814,12 @@ vxC
 vxC
 vxC
 ppx
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -502134,7 +502202,7 @@ erZ
 erZ
 erZ
 erZ
-cBG
+qKU
 nEd
 fVQ
 fVQ
@@ -502148,12 +502216,12 @@ fZJ
 fZJ
 fZJ
 kZS
-cBG
-cBG
-cBG
-cBG
-cBG
-cBG
+qKU
+qKU
+qKU
+qKU
+qKU
+qKU
 erZ
 erZ
 erZ
@@ -543519,8 +543587,8 @@ vIa
 vIa
 vIa
 vIa
-cjJ
-cjJ
+cCS
+cCS
 lAs
 woj
 qPA
@@ -543921,8 +543989,8 @@ vIa
 vIa
 vIa
 vIa
-cjJ
-cjJ
+cCS
+cCS
 lAs
 woj
 qPA
@@ -544323,8 +544391,8 @@ vIa
 vIa
 vIa
 vIa
-cjJ
-cjJ
+cCS
+cCS
 lAs
 woj
 qPA
@@ -544725,8 +544793,8 @@ vIa
 vIa
 vIa
 vIa
-cjJ
-cjJ
+cCS
+cCS
 lAs
 eJN
 bHY
@@ -545127,8 +545195,8 @@ vIa
 vIa
 vIa
 vIa
-cjJ
-cjJ
+cCS
+cCS
 lAs
 lAs
 lAs
@@ -545529,7 +545597,7 @@ vIa
 vIa
 vIa
 vIa
-cjJ
+cCS
 vIa
 vIa
 vIa
@@ -545931,7 +545999,7 @@ vIa
 vIa
 vIa
 vIa
-cjJ
+cCS
 vIa
 vIa
 vIa
@@ -546333,7 +546401,7 @@ vIa
 vIa
 vIa
 vIa
-cjJ
+cCS
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,16 +7,14 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -503,13 +501,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -987,9 +981,11 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "adK" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "adL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -1147,34 +1143,26 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
-"aet" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"aeu" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
-"aev" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
+"aen" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
+"aev" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1197,13 +1185,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"afy" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "afz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -1266,6 +1247,10 @@
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"agV" = (
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ahH" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -1283,15 +1268,6 @@
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"ahS" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
@@ -1335,6 +1311,16 @@
 	icon_state = "ice"
 	},
 /area/rogue/indoors/shelter/mountains)
+"ajD" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ajF" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe{
 	color = '#87CEFA';
@@ -1372,6 +1358,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"alQ" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "alU" = (
 /turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/under/town/basement)
@@ -1419,13 +1413,32 @@
 /obj/structure/statue/saints/knight_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"aok" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+"anO" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"anS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"aok" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1489,19 +1502,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"arp" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
-"art" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1579,8 +1579,10 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "auQ" = (
 /obj/structure/bookcase/random,
@@ -1594,24 +1596,18 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"ava" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "avh" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town)
+"avN" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "avQ" = (
 /obj/structure/bars/grille,
@@ -1704,14 +1700,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
@@ -1765,6 +1755,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"azR" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "aAe" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/guard,
@@ -1774,6 +1774,24 @@
 /obj/item/clothing/cloak/stabard/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"aAo" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "aAs" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
@@ -1795,32 +1813,6 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
-"aBn" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"aBq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"aCr" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1845,15 +1837,6 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"aDw" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1894,6 +1877,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"aEG" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aEN" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/angle,
@@ -1919,10 +1908,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"aFh" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -1931,11 +1916,6 @@
 /obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"aFX" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "aFY" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
@@ -1978,11 +1958,6 @@
 /obj/effect/landmark/map_load_mark/sewers_bottom,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"aHl" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aHo" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
@@ -2010,6 +1985,12 @@
 /obj/item/clothing/neck/roguetown/psicross/pestra,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"aIb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "aIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/kitchen/spoon/plastic,
@@ -2059,12 +2040,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak/fried,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"aIK" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "aIQ" = (
 /obj/item/clothing/ring/psydon{
 	max_integrity = 99999999
@@ -2073,6 +2048,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"aIT" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aIV" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
@@ -2140,14 +2121,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"aLg" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5";
-	pixel_x = 17
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "aLo" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -2185,6 +2158,13 @@
 "aMH" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/tribalfort)
+"aMK" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aMV" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = 32
@@ -2232,15 +2212,6 @@
 "aOv" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"aOJ" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "aOT" = (
 /obj/structure/roguemachine/stockpile{
 	pixel_x = 32;
@@ -2252,20 +2223,6 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"aPg" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "aPn" = (
 /obj/structure/bars/pipe,
 /obj/structure/mineral_door/wood{
@@ -2293,9 +2250,14 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2370,9 +2332,10 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2399,10 +2362,12 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"aTq" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"aTn" = (
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "aTE" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2480,15 +2445,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"aVK" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
+"aVU" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
@@ -2500,17 +2461,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"aWS" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "aXa" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
@@ -2546,10 +2496,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs)
-"aXQ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "aXR" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
@@ -2577,6 +2523,10 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
+"aZu" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "aZG" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/blocks,
@@ -2590,10 +2540,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"aZS" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "aZZ" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/leather,
@@ -2608,6 +2554,11 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"baG" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "baO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -2615,6 +2566,16 @@
 "baS" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
+"baV" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "bbm" = (
 /obj/structure/flora/wildplant/wild_poppy,
 /turf/open/floor/rogue/grass,
@@ -2624,11 +2585,6 @@
 	dir = 10
 	},
 /area/rogue/indoors/town/manor)
-"bbA" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "bbO" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
@@ -2645,6 +2601,13 @@
 "bcN" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/church/chapel)
+"bcO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bdu" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -2668,12 +2631,6 @@
 "bdN" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
-"bea" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "bee" = (
 /obj/structure/glowshroom,
 /turf/open/water/swamp,
@@ -2689,6 +2646,16 @@
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"bez" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "beA" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -2725,6 +2692,14 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"bfE" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "bfK" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2761,12 +2736,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"bhe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bhg" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2794,6 +2763,12 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"bhR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2877,6 +2852,14 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bkF" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -2900,6 +2883,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"blT" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "blW" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -2923,10 +2910,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"bmF" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "bmG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood{
@@ -2934,7 +2917,10 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/turf/open/floor/rogue/tile/checker,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "bmV" = (
 /obj/item/burial_shroud,
@@ -3003,12 +2989,6 @@
 "bok" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
-"bor" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "bow" = (
 /obj/structure/mineral_door/wood{
@@ -3104,8 +3084,19 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"bqu" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3147,15 +3138,16 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"brz" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
+"brt" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "brP" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
@@ -3180,6 +3172,10 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"bsh" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "bsm" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -3207,6 +3203,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"bsS" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3268,6 +3268,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"buB" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "buL" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -3325,12 +3334,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"bvV" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "bwc" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/cobble,
@@ -3384,14 +3387,6 @@
 /obj/item/roguegem/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"bxo" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "bxC" = (
 /obj/structure/stairs{
 	dir = 8
@@ -3408,7 +3403,8 @@
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "shop"
+	lockid = "shop";
+	max_integrity = 99999
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -3464,14 +3460,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/structure/rack/rogue,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3521,10 +3512,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"bAU" = (
-/obj/structure/composter/full,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3542,7 +3529,7 @@
 /area/rogue/indoors/town/tavern)
 "bCb" = (
 /turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/under/town/basement)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3566,6 +3553,14 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"bDf" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bDh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "bDl" = (
 /obj/structure/stairs{
 	dir = 1
@@ -3576,17 +3571,18 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"bDN" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16;
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "bEe" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
-"bEn" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "bEo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -3625,18 +3621,6 @@
 /obj/structure/fluff/littlebanners,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bFu" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3";
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
-"bFx" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "bFC" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -3678,6 +3662,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bHe" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bHt" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -3694,15 +3686,6 @@
 /obj/item/rogueweapon/stoneaxe/woodcut,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"bHT" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "bHV" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb,
@@ -3710,8 +3693,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town)
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3748,10 +3735,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"bIM" = (
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "bIZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -3778,12 +3761,6 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"bJC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bJE" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -3819,14 +3796,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"bLl" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "bLD" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
@@ -3877,10 +3846,6 @@
 "bOu" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
-"bOC" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bOK" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/garrison)
@@ -3891,20 +3856,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "bON" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
 	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "bOP" = (
 /obj/structure/mineral_door/wood/window{
@@ -3935,15 +3895,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"bPz" = (
-/obj/structure/roguewindow/openclose{
+/obj/structure/chair/bench/church{
 	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"bPz" = (
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors/town/garrison)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -4009,13 +3970,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"bRy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "bRF" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks/stonered,
@@ -4091,15 +4045,28 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bUr" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bVa" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"bVk" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "bVw" = (
 /turf/open/water/river{
@@ -4194,6 +4161,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"bYH" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "bYM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -4237,10 +4213,6 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"caL" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4250,6 +4222,22 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cbo" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cbE" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "sheriff"
@@ -4260,11 +4248,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "cbQ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "cca" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4315,20 +4300,6 @@
 /obj/structure/statue/saints/magelady2_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"ccT" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH";
-	pixel_x = 19
-	},
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh2";
-	aportalid = "wh1";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = 18
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "ccX" = (
 /obj/structure/well,
 /turf/open/floor/rogue/dirt/road,
@@ -4340,12 +4311,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4378,16 +4346,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"cfm" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "cfw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4545,9 +4503,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "cjJ" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4599,9 +4557,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
+/obj/structure/bed/rogue/inn/double,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "clr" = (
@@ -4619,12 +4575,6 @@
 /obj/item/roguekey/nightmaiden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"clR" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "clY" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/poo,
@@ -4702,10 +4652,6 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
-"coy" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "coE" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/carpet/royalblack,
@@ -4786,6 +4732,14 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cqU" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "crx" = (
 /obj/structure/statue/saints/noble3_l,
 /turf/open/floor/rogue/grass,
@@ -4825,13 +4779,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
-"csH" = (
-/obj/structure/stairs{
-	dir = 1
-	},
+"csE" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4902,6 +4853,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"cvC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cvN" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road{
@@ -4909,9 +4867,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4932,14 +4889,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"cwo" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "cwq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5023,19 +4972,13 @@
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"cxZ" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"cyy" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "czb" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
@@ -5123,6 +5066,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"cAj" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cAo" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -5178,9 +5127,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/storage/backpack/rogue/backpack/surgery,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/tribalfort)
@@ -5193,6 +5148,10 @@
 "cCz" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"cCC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "cCF" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/grass,
@@ -5216,8 +5175,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5242,11 +5202,6 @@
 /obj/item/roguekey/garrison,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"cDG" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "cDM" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/bog)
@@ -5307,16 +5262,6 @@
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"cGa" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cGc" = (
 /obj/structure/chair/wood/rogue,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -5477,27 +5422,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"cLX" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "cMh" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -5509,21 +5440,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"cMm" = (
-/obj/structure/mineral_door/wood{
-	dir = 4;
-	locked = 1;
-	lockid = "garrison"
+"cMs" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/obj/effect/decal/cobbleedge{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
-"cMs" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5532,10 +5458,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"cMR" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "cMU" = (
 /obj/structure/roguewindow,
 /turf/open/transparent/openspace,
@@ -5571,12 +5493,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"cNM" = (
-/obj/structure/stairs{
-	dir = 1
+"cND" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "cNN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf{
 	faction = list("undead")
@@ -5588,13 +5511,6 @@
 "cNY" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
-"cOb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "cOz" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -5607,10 +5523,23 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"cOL" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"cPd" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "cPe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -5636,6 +5565,20 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"cPT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/hexstone,
@@ -5653,11 +5596,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"cQs" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "cQz" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5697,9 +5635,12 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5723,14 +5664,9 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
-"cSb" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+"cSi" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "cSk" = (
 /obj/structure/flora/junglebush/large,
@@ -5763,12 +5699,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"cTc" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
+"cTb" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cTr" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -5784,12 +5721,6 @@
 /obj/item/clothing/suit/roguetown/armor/silkcoat,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"cTP" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "cTQ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/rogue/decowood,
@@ -5846,11 +5777,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"cVn" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "cVo" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -5863,6 +5789,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"cVu" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cVK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -5924,12 +5855,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
-"cXu" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "cXy" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -6007,12 +5932,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"cZi" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "cZu" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -6021,10 +5940,6 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"cZU" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -6065,15 +5980,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dbH" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -6200,6 +6112,10 @@
 /obj/effect/landmark/start/nightman,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"dey" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "deT" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -6214,6 +6130,22 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"dfz" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"dfH" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "dfK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -6314,6 +6246,10 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"diG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "diP" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -6332,10 +6268,17 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"diV" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+"djd" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "djA" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -6390,15 +6333,6 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"dkx" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4";
-	pixel_x = 13
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dkI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -6469,6 +6403,12 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dmH" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "dmI" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -6510,6 +6450,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"doN" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "doW" = (
 /obj/structure/stairs{
 	dir = 4
@@ -6532,6 +6479,15 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"dpr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dpw" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -6607,30 +6563,20 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"drL" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"dsg" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
 	},
-/area/rogue/indoors/town/garrison)
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "dsk" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/roguetown/shirt/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"dso" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "dsr" = (
 /obj/structure/statue/saints/cephine{
 	desc = "Her radiant angel that shall serve as our guiding light during end times."
@@ -6653,6 +6599,14 @@
 "dsB" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
+"dsR" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "dsW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -6674,14 +6628,15 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
-"duo" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
+"dua" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "duu" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -6728,13 +6683,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"dvG" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "dwa" = (
 /obj/structure/bars,
 /obj/machinery/light/rogue/torchholder{
@@ -6762,9 +6710,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6804,19 +6754,6 @@
 "dyF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/vikingarea)
-"dyH" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dyK" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -6840,24 +6777,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"dzB" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dzI" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur{
 	faction = list("undead")
@@ -6866,19 +6785,8 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dzV" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "dAf" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "dAk" = (
 /obj/structure/bars/pipe{
@@ -6908,6 +6816,20 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"dBO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6915,23 +6837,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"dCd" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
-"dCl" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6939,15 +6844,6 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"dCO" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dCP" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -7015,23 +6911,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"dFv" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
-"dFx" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dFz" = (
 /obj/item/reagent_containers/glass/cup/golden,
 /obj/structure/table/wood,
@@ -7046,12 +6925,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"dFS" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -7098,18 +6971,17 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"dHw" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dHC" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "dHZ" = (
 /turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
-"dIl" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "dIo" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
@@ -7232,13 +7104,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"dNp" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "dNu" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
@@ -7246,16 +7111,8 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"dOj" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7288,17 +7145,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"dOE" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "dOH" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -7379,6 +7225,13 @@
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"dQe" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "dQp" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/clinic,
@@ -7452,6 +7305,9 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dSP" = (
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "dSQ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -7483,9 +7339,9 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7527,19 +7383,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/exposed)
-"dUb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "dUk" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
@@ -7589,11 +7432,6 @@
 "dVO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"dVV" = (
-/obj/structure/table/vtable,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "dWd" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/blocks,
@@ -7711,16 +7549,24 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
 	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town/church/chapel)
 "ebe" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7756,6 +7602,14 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/bath)
+"ecb" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ecm" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -7872,13 +7726,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"eeA" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "eeD" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -7971,21 +7818,22 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"ega" = (
-/obj/structure/fluff/walldeco/church/line{
+"egd" = (
+/obj/structure/stairs{
 	dir = 4
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "egl" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"egu" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "egx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -8022,31 +7870,22 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"ehI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ehP" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"eik" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"eip" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "eit" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
-"eiE" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "eiF" = (
 /obj/structure/rack/rogue/shelf/big,
@@ -8081,22 +7920,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"ejk" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+"ejA" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ejC" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/grass,
@@ -8140,6 +7967,12 @@
 /obj/item/dice/d6,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"eli" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "elk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -8190,10 +8023,6 @@
 /obj/structure/crabnest,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
-"emK" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "emM" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -8254,11 +8083,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"enQ" = (
-/obj/machinery/anvil,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "enW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder,
@@ -8267,6 +8091,12 @@
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"eol" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eou" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -8283,11 +8113,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -8298,19 +8125,17 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"ept" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "epy" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
-"epI" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "epQ" = (
 /obj/structure/mineral_door/wood{
 	desc = "I shouldn't go in here...";
@@ -8380,10 +8205,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
-"erz" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "erN" = (
 /obj/structure/table/church{
 	dir = 1
@@ -8431,19 +8252,11 @@
 "esR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"esT" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "ete" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"etq" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "etr" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -8575,13 +8388,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"ewu" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "ewB" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
@@ -8598,12 +8404,6 @@
 /obj/structure/pillory/town_square/reinforced,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"exy" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "exG" = (
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
@@ -8654,8 +8454,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "ezo" = (
 /obj/structure/chair/wood{
@@ -8671,6 +8474,11 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
+"eAm" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -8691,12 +8499,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"eBn" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "eBp" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/adventurerlate{
@@ -8707,9 +8509,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"eBq" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "eBu" = (
 /obj/structure/fluff/statue/femalestatue,
 /turf/open/floor/rogue/grass,
@@ -8717,6 +8516,12 @@
 "eBw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"eBx" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "eBz" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8737,13 +8542,6 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"eBX" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
@@ -8776,6 +8574,14 @@
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"eDI" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "eDN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9018,14 +8824,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"eLK" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "eMc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -9048,13 +8846,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"eMV" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "eNa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9092,6 +8883,14 @@
 "eOg" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter)
+"eOo" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "eOR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop/green{
@@ -9105,10 +8904,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"ePD" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ePQ" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = 1
@@ -9155,6 +8950,10 @@
 /obj/structure/statue/saints/magelady_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eRV" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eSc" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/tile{
@@ -9189,12 +8988,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9204,14 +9000,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
-"eSH" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+"eSE" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"eTc" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 8
@@ -9331,12 +9127,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"eWd" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "eWe" = (
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/grass,
@@ -9360,6 +9150,12 @@
 "eWl" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"eWC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eWM" = (
 /obj/machinery/light/rogue/chand,
 /obj/effect/landmark/start/jester{
@@ -9455,13 +9251,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"faN" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "fbf" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -9473,15 +9262,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"fbv" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "fbz" = (
 /obj/structure/mineral_door/wood,
 /obj/structure/spider/stickyweb,
@@ -9493,6 +9273,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fbP" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fbQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -9534,10 +9328,6 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"fcE" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "fcJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9638,23 +9428,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"ffB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"ffD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "fgl" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -9676,17 +9449,32 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"fgH" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"fha" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "fhg" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"fhk" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
+"fhm" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
 "fhu" = (
 /obj/structure/fluff/railing/fence{
@@ -9718,6 +9506,13 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"fiK" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "fiL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -9761,6 +9556,15 @@
 /obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fjW" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fjX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -9772,6 +9576,16 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"fkr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -9805,6 +9619,13 @@
 "flH" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/garrison)
+"flI" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "flK" = (
 /obj/structure/flora/shroomstump,
 /turf/open/floor/rogue/dirt,
@@ -9845,6 +9666,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fmV" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fnc" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -9887,13 +9712,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fnP" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9954,16 +9772,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fqr" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+"fqy" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
@@ -9992,6 +9809,11 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"fsu" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -10079,14 +9901,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"fuG" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "fuY" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/bookcase/random,
@@ -10108,6 +9922,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fwJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fwL" = (
 /obj/item/rogueweapon/hammer{
 	color = gold;
@@ -10138,14 +9960,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"fxa" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fxf" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/cooking/pan,
@@ -10154,6 +9968,11 @@
 "fxx" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"fxH" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fxK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
@@ -10193,6 +10012,16 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"fyv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fyA" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -10213,18 +10042,9 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"fzf" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "fzk" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"fzv" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "fzO" = (
 /obj/structure/stairs{
 	dir = 4;
@@ -10373,17 +10193,10 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -10392,6 +10205,12 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"fEc" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fEo" = (
 /obj/item/rogueweapon/woodstaff/wise{
 	color = gold;
@@ -10415,6 +10234,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"fEE" = (
+/obj/structure/closet/crate/chest{
+	name = "BREAK INCASE OF VAMPYRE EMERGENCY"
+	},
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fEF" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/church,
@@ -10432,24 +10259,18 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fFL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+"fFW" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
 	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"fGq" = (
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
-"fGt" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/church/chapel)
 "fGF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -10462,6 +10283,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"fGX" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fHi" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -10485,6 +10312,11 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"fHr" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fHC" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -10502,12 +10334,6 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town)
-"fIb" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "fId" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
@@ -10543,11 +10369,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "fID" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -10559,6 +10385,12 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fIK" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fIL" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10582,14 +10414,6 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fJb" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -10618,6 +10442,13 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"fKD" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fKI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/bog)
@@ -10633,13 +10464,28 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"fLv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fLI" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
 /area/rogue/outdoors/mountains)
 "fMc" = (
@@ -10653,15 +10499,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"fMl" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "fNa" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/honey,
@@ -10767,19 +10604,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10796,13 +10622,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"fQQ" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "fRa" = (
 /obj/machinery/anvil{
 	pixel_x = 9
@@ -10843,6 +10662,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"fRP" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -10953,6 +10778,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fVm" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fVE" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -10964,13 +10798,15 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
-"fVN" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10986,16 +10822,6 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fWD" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fWH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -11015,12 +10841,6 @@
 "fXg" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/town)
-"fXr" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "fXu" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -11042,13 +10862,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"fXP" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "fXV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
@@ -11077,6 +10890,15 @@
 "fZe" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
+"fZg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "fZw" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobblerock,
@@ -11101,6 +10923,18 @@
 "gaC" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement)
+"gaI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gaO" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood{
@@ -11108,8 +10942,21 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"gbd" = (
+"gba" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"gbf" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
@@ -11269,15 +11116,17 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"ggo" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "ggu" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ggG" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ggR" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -11303,12 +11152,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -11475,19 +11320,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
+"gof" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "goK" = (
 /obj/effect/decal/cobbleedge{
@@ -11532,14 +11380,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"gqA" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+"gqj" = (
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -11554,12 +11398,6 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
-"gqW" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "grd" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -11567,6 +11405,18 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"grj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
@@ -11584,13 +11434,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"gsD" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
+"gse" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "gsT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -11659,6 +11508,14 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"gum" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gut" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -11672,13 +11529,18 @@
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
+"guS" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gvi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -11692,6 +11554,10 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"gvP" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "gvT" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -11713,11 +11579,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
-"gwz" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11755,13 +11616,6 @@
 /obj/item/reagent_containers/glass/bottle/mercury,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"gxA" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "gxJ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -11792,14 +11646,6 @@
 /obj/structure/chair/bench/coucha,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/church/chapel)
-"gyr" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
 /area/rogue/indoors/town/church/chapel)
 "gys" = (
 /obj/structure/chair/wood,
@@ -11893,10 +11739,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"gBe" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "gBs" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/large,
@@ -11941,6 +11783,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"gDx" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -11956,22 +11802,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
 "gEt" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"gEy" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -12004,12 +11843,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"gFU" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "gFZ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -12045,22 +11878,16 @@
 "gGu" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
-"gGw" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"gGF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gGH" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -12089,6 +11916,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"gHd" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "gHg" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/church,
@@ -12116,6 +11948,14 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"gIo" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "gIv" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -12147,14 +11987,6 @@
 /obj/structure/bed/rogue/inn/wool,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"gIV" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "gJi" = (
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
@@ -12165,10 +11997,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"gJE" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "gJK" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -12209,10 +12037,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"gKU" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "gLf" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
@@ -12243,14 +12067,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"gLJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "gLO" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
@@ -12261,16 +12077,6 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"gMb" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "gMg" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -12286,10 +12092,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"gMG" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "gMO" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
@@ -12330,6 +12132,12 @@
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"gNz" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gOa" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/twig,
@@ -12397,10 +12205,6 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"gQF" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gQM" = (
 /obj/structure/fluff/statue/small{
 	desc = "An expertly carved figure of an elven woman baring a warm yet flirtatious smile.";
@@ -12538,10 +12342,6 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"gTQ" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "gTT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -12549,11 +12349,30 @@
 /obj/structure/roguemachine/musicbox,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"gTY" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "gUx" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"gUC" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguemachine/vendor{
+	keycontrol = "blacksmith"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "gUD" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
 	max_integrity = 99999
@@ -12570,6 +12389,17 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"gUR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "gUV" = (
 /obj/structure/timeddoor,
 /turf/open/floor/rogue/dirt/road{
@@ -12602,6 +12432,10 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"gVW" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -12630,6 +12464,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"gXk" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "gXr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -12641,13 +12482,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"gXT" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "gXW" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -12703,10 +12537,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"gZv" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "gZC" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/wood,
@@ -12727,10 +12557,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"har" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "hax" = (
 /obj/structure/mineral_door/wood{
 	lockid = "roomi";
@@ -12769,20 +12595,9 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/loom,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
-"hbr" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12851,6 +12666,11 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"hcG" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "hcL" = (
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood,
@@ -12957,6 +12777,14 @@
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"heK" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -13019,16 +12847,6 @@
 	dir = 1;
 	icon_state = "vertw"
 	},
-/area/rogue/indoors/town)
-"hfU" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "hfW" = (
 /obj/structure/closet/crate/chest,
@@ -13129,15 +12947,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"hjs" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "hjt" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/churchrough,
@@ -13147,22 +12956,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"hjW" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
 "hkk" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -13232,6 +13032,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hlY" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "hme" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13270,9 +13076,6 @@
 	dir = 4
 	},
 /area/rogue/indoors)
-"hmF" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
 "hmK" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/junglebush/b,
@@ -13305,6 +13108,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/garrison)
+"hmZ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "hnd" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -13335,10 +13144,10 @@
 "hnC" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
-"hnJ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+"hnG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "hnK" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/cup/silver,
@@ -13353,12 +13162,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"hoa" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hob" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -13491,24 +13294,23 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"hre" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
+"hrk" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
-"hrh" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
+/area/rogue/indoors/town/garrison)
+"hrT" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/indoors/town/garrison)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
@@ -13540,11 +13342,9 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
@@ -13586,6 +13386,10 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
+"huL" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "hvf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -13606,6 +13410,10 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"hvo" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "hvx" = (
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/tile,
@@ -13627,10 +13435,6 @@
 "hwg" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors)
-"hwQ" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "hxe" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/naturalstone,
@@ -13670,6 +13474,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"hyM" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "hyR" = (
 /obj/structure/stairs/stone,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -13700,10 +13514,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hzz" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"hzl" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13714,6 +13532,17 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"hzX" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"hzY" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "hAa" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
@@ -13723,6 +13552,11 @@
 /obj/item/roguekey/manor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"hAc" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hAg" = (
 /obj/item/chair/rogue/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -13761,17 +13595,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"hCo" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "hCu" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile{
@@ -13790,6 +13613,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hCQ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hCS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -13802,14 +13632,6 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"hDE" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "hDP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "velder"
@@ -13837,6 +13659,18 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"hEB" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hEG" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -13877,6 +13711,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hFs" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hFM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/ravager,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13978,6 +13816,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"hJj" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hJq" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -14005,10 +13847,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"hJR" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "hKq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -14017,16 +13855,18 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"hKF" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"hKt" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"hKE" = (
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -14072,6 +13912,10 @@
 /obj/effect/rune,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"hMB" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "hMD" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -14094,6 +13938,12 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"hNk" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hND" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
@@ -14101,14 +13951,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"hNE" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "hNF" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14151,10 +13993,6 @@
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"hOC" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "hOF" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/water/river{
@@ -14162,6 +14000,18 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"hOM" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hOP" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /obj/structure/spider/stickyweb,
@@ -14231,17 +14081,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"hQU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"hQY" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "hRc" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -14264,12 +14103,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"hRr" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "hRv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/water/cleanshallow,
@@ -14321,6 +14154,15 @@
 /obj/item/natural/rock,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"hTL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hTT" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/ambush,
 /turf/open/floor/rogue/blocks,
@@ -14372,10 +14214,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"hVO" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "hVZ" = (
 /turf/open/floor/rogue/tile/checkeralt{
 	max_integrity = 99999
@@ -14553,13 +14391,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"icE" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "icI" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
@@ -14667,9 +14498,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14696,11 +14526,6 @@
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"igr" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "igS" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -14737,16 +14562,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"iia" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "iim" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -14776,24 +14591,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"ijW" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -14822,9 +14629,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -14856,6 +14663,11 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"ilL" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14902,10 +14714,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"inC" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14946,6 +14754,9 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"iqs" = (
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -14979,16 +14790,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"iqP" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "iqY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -15033,22 +14834,17 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"isP" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "itv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -15116,13 +14912,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ivz" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -15159,6 +14948,15 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iww" = (
+/obj/structure/rack/rogue,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -15168,6 +14966,15 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ixg" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ixt" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -15295,6 +15102,16 @@
 	dir = 10
 	},
 /area/rogue/outdoors/bog)
+"iAh" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iAi" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -15311,12 +15128,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"iBo" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "iBA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -15334,12 +15145,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"iBE" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iBJ" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
@@ -15352,6 +15157,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"iCm" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "iCn" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/church,
@@ -15402,11 +15211,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "iDV" = (
-/obj/machinery/light/rogue/lanternpost{
-	pixel_x = 15
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -15440,6 +15247,12 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
+"iEB" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -15469,14 +15282,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"iFi" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "iFm" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "manor";
@@ -15512,21 +15317,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
-"iFY" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"iGe" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iGf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5;
@@ -15551,12 +15341,6 @@
 /obj/structure/timeddoor,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"iHs" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "iHz" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -15581,6 +15365,10 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"iIA" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iIG" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -15594,13 +15382,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
-"iJx" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "iJC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -15710,14 +15491,6 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"iMu" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "iMA" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -15726,9 +15499,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -15848,6 +15623,18 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iPF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
+"iPI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "iPJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -15890,14 +15677,9 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15931,7 +15713,10 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "iTv" = (
 /obj/structure/table/wood{
@@ -15994,12 +15779,29 @@
 /obj/item/kitchen/spoon/plastic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"iVA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "iVM" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"iVW" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "iWh" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/veteran{
@@ -16008,12 +15810,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -16052,6 +15853,13 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"iXt" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iXK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -16100,6 +15908,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iYH" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -16154,10 +15967,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"jax" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "jaF" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/purple,
@@ -16230,6 +16039,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"jcT" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jcX" = (
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
@@ -16257,6 +16070,10 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
+"jdJ" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jdK" = (
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
@@ -16280,19 +16097,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
-"jet" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
-"jeM" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "jeR" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16310,15 +16114,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"jeX" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "jfe" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -16346,6 +16141,14 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"jfV" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16375,15 +16178,6 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"jgo" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jgs" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
@@ -16417,9 +16211,15 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "jit" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jiv" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -16439,6 +16239,10 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"jjF" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -16479,12 +16283,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"jkZ" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "jlf" = (
 /obj/structure/stairs{
 	dir = 1
@@ -16493,6 +16291,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"jlk" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jlF" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
@@ -16511,12 +16317,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
@@ -16562,13 +16363,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"jnw" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+"jnN" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"jnO" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "jod" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/feather,
@@ -16615,9 +16416,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16655,6 +16457,16 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jrn" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jrs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/seeds/wheat,
@@ -16695,13 +16507,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"jti" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "jtj" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16718,10 +16523,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"jtq" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "jtN" = (
 /obj/item/clothing/gloves/roguetown/plate/blk,
 /obj/item/rogueweapon/sword/rapier,
@@ -16730,6 +16531,14 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"jtV" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "juc" = (
 /obj/item/rogueweapon/sickle/scythe{
 	color = gold;
@@ -16741,6 +16550,9 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"juf" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "juj" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
@@ -16758,21 +16570,6 @@
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement)
-"jvT" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
-"jvU" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jvW" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4;
@@ -16858,10 +16655,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"jyB" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "jyD" = (
 /obj/machinery/light/rogue/oven/south,
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison{
@@ -16899,10 +16692,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"jzT" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "jAb" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -16920,6 +16709,13 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jAJ" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jAN" = (
 /obj/effect/landmark/start/farmer{
 	dir = 4
@@ -16933,6 +16729,12 @@
 "jAY" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"jBh" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jBv" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -16940,14 +16742,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jBN" = (
-/obj/structure/closet/crate/chest{
-	name = "INCASE OF VAMPYRE EMERGENCY"
-	},
-/obj/item/ingot/silver,
-/obj/item/ingot/silver,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -16956,11 +16750,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
 	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -17003,17 +16797,6 @@
 "jDm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor)
-"jDv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "jDB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -17061,15 +16844,19 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"jEe" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "jEB" = (
-/obj/structure/mineral_door/wood/deadbolt{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -17124,19 +16911,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"jGB" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "jGT" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -17146,17 +16920,19 @@
 "jHc" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"jHh" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "jHj" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
+"jHv" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jHz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
@@ -17193,9 +16969,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
+"jJa" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -17250,6 +17034,14 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"jMc" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jMd" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -17261,12 +17053,8 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -17280,6 +17068,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"jMs" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jMA" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
@@ -17312,6 +17105,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jNj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -17320,12 +17120,12 @@
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17354,6 +17154,12 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"jNV" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "jOn" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -17392,6 +17198,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"jPz" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jPB" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -17519,14 +17332,14 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"jUl" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "jUs" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"jUD" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jUH" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -17567,10 +17380,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
-"jWZ" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/effect/landmark/start/vagrant,
@@ -17600,6 +17409,10 @@
 /obj/effect/landmark/start/seelie,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"jXB" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "jXK" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/churchrough,
@@ -17614,12 +17427,30 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jXU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jXZ" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
 "jYm" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"jYn" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "jYE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/tongs,
@@ -17667,6 +17498,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"jZY" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -17679,23 +17514,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"kat" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "kau" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /turf/open/floor/rogue/grass,
@@ -17720,37 +17538,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"kaH" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "kaO" = (
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"kaP" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "kaQ" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
@@ -17763,12 +17554,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
-"kbp" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/clothing/ring/dragon_ring,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kbR" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
@@ -17778,6 +17563,10 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/church/chapel)
+"kch" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "kcj" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
@@ -17795,18 +17584,24 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"kcR" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kcX" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kde" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+"kdg" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "kds" = (
 /obj/structure/table/wood,
@@ -17817,6 +17612,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"kdv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "kdM" = (
 /obj/structure/mineral_door/wood{
 	dir = 1;
@@ -17826,6 +17630,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"kem" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "keq" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -17850,6 +17662,28 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"keW" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "kfe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -17902,6 +17736,13 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"kgd" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "kgj" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
@@ -17911,6 +17752,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"kgt" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kgC" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -17932,15 +17777,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -18029,11 +17868,6 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"kkP" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "kld" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/concrete,
@@ -18060,10 +17894,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"knq" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "kns" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/herringbone,
@@ -18146,6 +17976,18 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"kqW" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "kra" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/rooftop{
@@ -18189,6 +18031,12 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"ksh" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -18228,12 +18076,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/sword/long,
-/obj/item/rogueweapon/mace/steel,
-/obj/item/listenstone,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -18256,10 +18101,6 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
-"ktb" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "ktg" = (
 /obj/structure/bed/rogue,
 /obj/item/natural/cloth,
@@ -18315,10 +18156,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"kuG" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "kuP" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -18327,22 +18164,24 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kuV" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -18373,6 +18212,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"kwn" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "kwq" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/town/tavern)
@@ -18383,9 +18228,12 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18436,12 +18284,6 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"kzc" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "kzv" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -18465,6 +18307,16 @@
 "kzI" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
+"kzO" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kzQ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -18483,18 +18335,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"kAg" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
-"kAi" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "kAH" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -18566,16 +18406,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"kCe" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kCh" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -18600,12 +18430,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"kCZ" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "kDc" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
@@ -18639,6 +18463,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"kEb" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "kEd" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -18656,16 +18484,6 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"kEA" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "kEB" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -18687,7 +18505,14 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "kFj" = (
 /obj/structure/rack/rogue,
@@ -18707,6 +18532,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"kFr" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kFD" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/metal/barograte,
@@ -18740,10 +18575,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"kHb" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
 "kHs" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -18753,6 +18584,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"kHu" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "kHA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -18806,6 +18643,16 @@
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kIV" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "kJj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -18836,16 +18683,6 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"kKm" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kKr" = (
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
@@ -18865,11 +18702,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"kKN" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "kKS" = (
 /obj/structure/mineral_door/bars{
 	lockid = "dungeon"
@@ -18904,12 +18736,6 @@
 /obj/structure/chair/bench/couch,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"kLV" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kMb" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/machinery/light/rogue/torchholder/l,
@@ -18929,6 +18755,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kMv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "kMx" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -18961,14 +18792,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"kNi" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "kNr" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt/road{
@@ -19014,6 +18837,15 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kOA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "kOB" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -19110,13 +18942,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kRE" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+"kRI" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/outdoors/mountains)
 "kRN" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
@@ -19185,6 +19016,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"kTx" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -19454,14 +19289,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"lff" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -19524,13 +19351,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
-"lgJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "lgN" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/wool,
@@ -19549,11 +19369,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -19563,21 +19381,16 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
-"lhH" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+"lhy" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
 	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -19690,12 +19503,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"llp" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+"llo" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"llq" = (
+/obj/structure/roguemachine/scomm/l,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lls" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -19742,13 +19565,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"lnl" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "The Erlking";
-	health = 1500
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lnq" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/cobble,
@@ -19793,11 +19609,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -19858,20 +19673,13 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"lpU" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"lqg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+"lqm" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -19881,6 +19689,16 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"lqJ" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -19890,6 +19708,12 @@
 "lqR" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
+"lrj" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
@@ -19899,16 +19723,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lsA" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lsD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19943,12 +19757,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"ltI" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "ltM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/rtfield)
@@ -19999,6 +19807,19 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"lvF" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lvO" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobblerock,
@@ -20008,16 +19829,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"lwy" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lwz" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -20031,13 +19842,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"lwO" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "lwV" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood{
@@ -20049,6 +19853,25 @@
 /obj/structure/mirror/fancy,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"lxN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "lxQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -20073,13 +19896,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"lyW" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -20159,14 +19975,11 @@
 "lAB" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"lAE" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+"lAK" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lAO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -20239,6 +20052,13 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
+"lEs" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "lEu" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -20302,13 +20122,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"lFG" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lFP" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_x = -32
@@ -20316,31 +20129,35 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"lFR" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lFV" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"lGI" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"lGN" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+"lGh" = (
+/turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town/garrison)
+"lGI" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"lGS" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "lGX" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
@@ -20357,16 +20174,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"lHy" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lHK" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph2"
@@ -20428,6 +20235,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"lJJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lJO" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -20488,6 +20299,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"lLl" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lLp" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
@@ -20506,14 +20324,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"lMg" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"lMu" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "lMD" = (
 /obj/item/natural/rock,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -20532,12 +20342,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/turf/closed/mineral/rogue/bedrock,
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
-"lNo" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
@@ -20610,12 +20421,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
-"lQH" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "lQT" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 2;
@@ -20686,6 +20491,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"lUT" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lVe" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
@@ -20706,6 +20515,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"lVF" = (
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "lVS" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks{
@@ -20736,6 +20549,13 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"lXh" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lXo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -20761,9 +20581,14 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
+"lXX" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lYl" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -20824,19 +20649,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"lZC" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"lZE" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mab" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
@@ -20859,6 +20671,14 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"maB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "maJ" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -20875,17 +20695,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"mbG" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "mbK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -20893,13 +20702,6 @@
 "mcm" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter)
-"mco" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "mcu" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -20928,11 +20730,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mdd" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "mdo" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20950,11 +20747,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -21015,13 +20813,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"meH" = (
-/obj/structure/rack/rogue,
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "meV" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/structure/table/wood{
@@ -21072,6 +20863,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"mhi" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -21129,12 +20928,6 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"mjE" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "mjG" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
@@ -21151,10 +20944,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/structure/roguewindow/openclose,
-/obj/structure/bars,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/town/roofs)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -21172,16 +20963,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"mky" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "mkO" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -21239,15 +21020,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"mmY" = (
-/obj/structure/stairs{
-	dir = 4
+"mnW" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21319,6 +21100,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"mpr" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mpu" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood,
@@ -21360,15 +21147,10 @@
 	},
 /area/rogue/indoors/town)
 "mrE" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/item/storage/backpack/rogue/backpack/surgery,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mrN" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -21378,10 +21160,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"mrQ" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
 "msk" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
@@ -21543,14 +21321,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"myM" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "myR" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -21568,6 +21338,13 @@
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mzf" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mzk" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -21599,36 +21376,31 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"mAb" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "mAM" = (
 /obj/item/clothing/suit/roguetown/shirt/rags,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"mAZ" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "mBn" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"mCh" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "mCz" = (
 /obj/effect/landmark/start/guardsman{
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"mCT" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "mDe" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0
@@ -21691,6 +21463,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"mEy" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "mEz" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -21747,19 +21526,13 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"mGh" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "mGn" = (
-/obj/structure/fluff/walldeco/painting,
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
@@ -21792,13 +21565,19 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"mJa" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"mIC" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains)
+"mJg" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -21817,19 +21596,18 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"mJU" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "mKd" = (
 /obj/structure/spacevine{
 	opacity = 1
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"mKz" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mKR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -21868,6 +21646,10 @@
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"mMs" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "mMv" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
@@ -21926,14 +21708,6 @@
 "mOh" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
-"mOw" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "mOE" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/natural/feather,
@@ -22002,13 +21776,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"mQA" = (
-/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
+"mQA" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -22067,13 +21843,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"mTs" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+"mTj" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "mTO" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -22112,10 +21887,26 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"mUC" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "mUQ" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"mUY" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mVa" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
@@ -22129,12 +21920,13 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -22156,6 +21948,17 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
+"mWn" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mWx" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -22166,10 +21969,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"mWO" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
 "mWV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -22322,10 +22121,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"nbI" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22333,20 +22128,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"nce" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
-"ncg" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "ncl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road{
@@ -22357,10 +22138,6 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"ncI" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "nda" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/keyring,
@@ -22452,10 +22229,26 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"nfb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nfN" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22480,12 +22273,11 @@
 /area/rogue/indoors/town/vault)
 "nhR" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1";
-	pixel_x = 9
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
@@ -22537,12 +22329,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"nku" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22564,17 +22350,22 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"nle" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nlf" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"nlw" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+"nlC" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "nlG" = (
 /obj/structure/table/wood{
@@ -22604,6 +22395,20 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"nmC" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"nmF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "nmR" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22625,6 +22430,15 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"nnb" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "nnk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
@@ -22638,24 +22452,16 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
+"nnI" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "nnQ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"nnS" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "noi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22802,18 +22608,6 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"ntT" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ntY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -22843,8 +22637,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "nuV" = (
@@ -22856,6 +22651,14 @@
 "nvd" = (
 /turf/open/water/bath,
 /area/rogue/indoors/shelter/rtfield)
+"nvf" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
+"nvr" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nvA" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
@@ -22866,14 +22669,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"nvH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "nvS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -22881,6 +22676,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nvV" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nvW" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
@@ -22957,12 +22758,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"nxC" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "nxF" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -22981,14 +22776,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"nxM" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nxO" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/tile/checker,
@@ -23078,6 +22865,9 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"nAy" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nAS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -23093,16 +22883,33 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"nBp" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "nBq" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -23123,12 +22930,37 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"nBT" = (
+/obj/structure/mineral_door/wood{
+	dir = 4;
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
+"nCA" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nCN" = (
 /obj/machinery/light/rogue/torchholder{
@@ -23153,12 +22985,6 @@
 /area/rogue/indoors/town)
 "nEd" = (
 /turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/garrison)
-"nEe" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
 "nEi" = (
 /obj/structure/chair/stool/rogue,
@@ -23212,6 +23038,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nGn" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nGw" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -23257,10 +23087,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"nHd" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "nHi" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -23287,6 +23113,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"nIq" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nIr" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -23324,16 +23156,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -23356,6 +23186,11 @@
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
+"nKk" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nKt" = (
 /obj/structure/fluff/statue/tdummy2,
 /turf/open/floor/rogue/grass,
@@ -23372,41 +23207,6 @@
 "nKx" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
-"nKy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
-"nKG" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
-"nLx" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "nLy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -23505,13 +23305,6 @@
 /obj/structure/fluff/littlebanners/bluewhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"nOR" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "nOX" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23529,11 +23322,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/structure/chair/wood/rogue{
+/obj/structure/chair/wood/rogue/fancy{
 	dir = 8;
-	icon_state = "chair2"
+	icon_state = "chair1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "nPR" = (
 /obj/structure/stairs/stone{
@@ -23626,15 +23419,6 @@
 /obj/structure/statue/saints/magelady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"nRH" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh1";
-	aportalid = "wh2";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nRW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -23648,7 +23432,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nSr" = (
-/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
@@ -23658,6 +23447,16 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"nSy" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nSS" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -23688,12 +23487,14 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23745,6 +23546,17 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"nVf" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nVF" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -23860,15 +23672,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"nYb" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "nYp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -23918,13 +23721,13 @@
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"nZy" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+"nZw" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "nZQ" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -23935,6 +23738,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"nZV" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "oaa" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -23943,14 +23750,26 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"oaU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"obi" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "obq" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/mountains)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -24035,10 +23854,6 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"odH" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "odT" = (
 /obj/structure/flora/newleaf,
 /obj/structure/chair/bench/coucha{
@@ -24120,12 +23935,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/under/cave)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -24145,13 +23964,20 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"ohA" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	name = "Cathedral of Enigma"
+"ohw" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"ohA" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ohE" = (
 /obj/structure/bed/rogue/shit,
 /obj/structure/spider/stickyweb,
@@ -24191,6 +24017,15 @@
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"oir" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oiC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
@@ -24200,11 +24035,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24212,8 +24044,17 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"oiW" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ojc" = (
-/obj/structure/fluff/railing/wood,
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -24230,14 +24071,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"ojQ" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -24289,16 +24122,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"olU" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "oma" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
@@ -24372,6 +24195,12 @@
 "ooJ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"ooP" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "opc" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
@@ -24405,6 +24234,13 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"oqs" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -24412,6 +24248,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"oqH" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oqQ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/water/cleanshallow,
@@ -24433,12 +24273,26 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"orE" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "orS" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"orT" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "orY" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -24479,6 +24333,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"otr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ots" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
@@ -24540,16 +24401,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -24585,6 +24439,19 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"owf" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"owj" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24643,6 +24510,18 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
+"oye" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "oyi" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -24655,6 +24534,10 @@
 /obj/item/natural/poo/horse,
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"oys" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oyE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/cloth,
@@ -24664,14 +24547,6 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"oyH" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "oyJ" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24700,6 +24575,12 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ozt" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ozw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24759,13 +24640,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"oAX" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "oAZ" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -24798,6 +24672,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"oBF" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -24898,12 +24779,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"oFk" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "oFw" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -24997,15 +24872,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -25016,10 +24886,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"oJk" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "oJn" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -25037,9 +24903,25 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"oJH" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oJO" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -25067,21 +24949,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"oLA" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+"oLg" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oLC" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"oLF" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oLO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb{
@@ -25092,12 +24976,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -25179,12 +25060,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"oOI" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "oOQ" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -25201,23 +25076,17 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"oOV" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "oPi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "oPp" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "oPv" = (
 /obj/structure/stairs/stone{
@@ -25244,12 +25113,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"oQc" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "oQe" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -25289,11 +25152,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "oRs" = (
 /obj/structure/fluff/clock,
@@ -25368,6 +25227,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"oTE" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oUc" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -25413,10 +25280,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"oVn" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "oVp" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town)
@@ -25493,10 +25356,6 @@
 /obj/structure/fluff/walldeco/painting/queen,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
-"oWT" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "oWX" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub/crafted,
@@ -25507,10 +25366,6 @@
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"oXj" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "oXn" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town)
@@ -25529,12 +25384,6 @@
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"oXt" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "oXE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -25672,6 +25521,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"pbg" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pbG" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjaill"
@@ -25740,9 +25597,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -25756,7 +25613,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
@@ -25866,6 +25724,12 @@
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"pho" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "pht" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
@@ -25963,6 +25827,14 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
+"pkt" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pku" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/manor)
@@ -25994,6 +25866,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"plk" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"plR" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -26038,6 +25920,9 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pno" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "pnD" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -26052,14 +25937,6 @@
 "pog" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
-"poP" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "poR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26068,12 +25945,6 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"ppc" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ppi" = (
 /obj/structure/stairs{
 	dir = 1
@@ -26127,19 +25998,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"ppM" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "ppS" = (
 /obj/structure/fluff/walldeco/rpainting/forest,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
-"pqg" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
 "pqr" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26282,14 +26144,11 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"puH" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+"put" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "pvd" = (
 /obj/structure/fluff/railing/border{
@@ -26309,10 +26168,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"pvE" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "pvI" = (
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/table/wood{
@@ -26374,12 +26229,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"pxP" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "pxQ" = (
 /obj/structure/statue/saints/paladin2_l,
 /turf/open/floor/rogue/blocks,
@@ -26440,6 +26289,12 @@
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"pzi" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pzn" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -26476,13 +26331,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"pzY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "pAa" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
@@ -26533,6 +26381,17 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"pBC" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "pBJ" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26557,6 +26416,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"pCH" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "pCW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -26608,6 +26480,29 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"pDM" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"pDO" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pDP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8;
@@ -26640,6 +26535,10 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pEX" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26682,6 +26581,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"pHF" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "pHI" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile{
@@ -26758,13 +26663,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -26783,6 +26684,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pLf" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "pLh" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -26806,14 +26717,16 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
-"pMe" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+"pLK" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pMi" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
@@ -26827,8 +26740,22 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -26914,10 +26841,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"pOC" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "pOO" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood,
@@ -27110,15 +27033,12 @@
 /obj/item/quiver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"pUX" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
+"pUQ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pVg" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27132,20 +27052,24 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"pVO" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+"pVF" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pVW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"pWm" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -27178,12 +27102,6 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"pXo" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "pXp" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -27207,12 +27125,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"pXF" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "pXH" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -27264,12 +27176,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"pZJ" = (
-/obj/structure/stairs{
-	dir = 4
+"qab" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "qad" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -27435,13 +27349,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -27481,21 +27393,6 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qgi" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"qgz" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "qgC" = (
 /turf/open/water/river{
 	dir = 4;
@@ -27555,22 +27452,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qii" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bull,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "qil" = (
 /obj/structure/bars/passage{
 	redstone_id = "tourneytop"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"qir" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -27704,16 +27591,6 @@
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qmJ" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "qne" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/naturalstone,
@@ -27765,6 +27642,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qof" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qoi" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -27786,6 +27673,21 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"qoP" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27832,12 +27734,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "Nelly";
-	health = "1000"
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/under/cave)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -27874,13 +27774,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"qqM" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qqV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -27950,6 +27843,11 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qsC" = (
+/obj/machinery/anvil,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qsI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -27987,6 +27885,10 @@
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"qtK" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "qtT" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -28010,6 +27912,12 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"quy" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -28024,12 +27932,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "priest"
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -28086,9 +27997,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -28119,21 +28029,30 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"qwV" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qxH" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/structure/spider/stickyweb,
 /obj/item/clothing/gloves/roguetown/chain,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"qxL" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "qxN" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue,
 /area/rogue/indoors/town/manor)
+"qxO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qxZ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1;
@@ -28146,10 +28065,17 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"qzb" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
+"qyS" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
@@ -28173,12 +28099,23 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"qzy" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
+"qzx" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"qzy" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
@@ -28256,28 +28193,19 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"qDq" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
@@ -28300,6 +28228,18 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qEj" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"qEq" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
@@ -28315,14 +28255,6 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
-"qFI" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "qFK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/churchbrick,
@@ -28337,10 +28269,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church/mid{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -28452,8 +28385,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28481,9 +28418,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
 "qLF" = (
-/obj/structure/roguewindow/stained/silver,
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qLP" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -28503,29 +28444,19 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"qMA" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"qNO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
+"qNF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -28545,6 +28476,13 @@
 "qOx" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"qOT" = (
+/obj/structure/rack/rogue,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qOW" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
@@ -28601,6 +28539,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qQw" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -28625,11 +28569,13 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "qRp" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
 	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -28639,22 +28585,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qRZ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "qSc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/churchmarble,
@@ -28684,6 +28614,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"qSE" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qSU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
@@ -28765,6 +28700,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"qWS" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -28809,11 +28749,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -28833,19 +28770,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"qYK" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"qYR" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+"qYQ" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qZh" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
@@ -28937,9 +28865,22 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
+"rcx" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -28978,13 +28919,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"rds" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "rdA" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/concrete,
@@ -29050,6 +28984,14 @@
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"rfd" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rfl" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/bog)
@@ -29057,12 +28999,9 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -29092,9 +29031,11 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -29210,16 +29151,6 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"rlu" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29239,17 +29170,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"rma" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "rmd" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -29305,6 +29225,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"rni" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rns" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/globe,
@@ -29312,16 +29239,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"rnE" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "rnN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -29334,6 +29251,12 @@
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"roG" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "roO" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -29362,6 +29285,13 @@
 "rpp" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"rps" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rpv" = (
 /obj/item/roguekey/blacksmith/town,
 /obj/item/roguekey/blacksmith/town,
@@ -29419,11 +29349,6 @@
 /obj/item/reagent_containers/food/snacks/grown/onion/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"rrd" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "rrg" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "velder";
@@ -29546,27 +29471,6 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"rvF" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
-"rvH" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29605,6 +29509,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"rwD" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "rwH" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -29631,6 +29539,16 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"rxa" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rxc" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -29646,9 +29564,12 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "rxp" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rxq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -29675,6 +29596,12 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rxS" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ryc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -29686,22 +29613,16 @@
 "ryg" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"ryk" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
+"ryE" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
-"ryM" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "rzq" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -29767,35 +29688,20 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"rBB" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "rBC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"rBD" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rBO" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"rCc" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rCL" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -29824,10 +29730,12 @@
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"rDF" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"rDD" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -29923,22 +29831,16 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -30036,10 +29938,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"rLE" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "rLL" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -30087,10 +29985,6 @@
 "rNl" = (
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"rNo" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "rNB" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -30110,6 +30004,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"rNT" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "rOb" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -30143,13 +30041,6 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
-"rPA" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "rPE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -30171,13 +30062,10 @@
 /obj/structure/crabnest,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
-"rPT" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+"rPU" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "rPX" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -30223,9 +30111,8 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "rRB" = (
 /obj/structure/stairs{
@@ -30240,9 +30127,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
+"rRM" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
@@ -30250,6 +30146,10 @@
 "rSg" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -30339,6 +30239,15 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"rUm" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
@@ -30362,13 +30271,6 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
-"rUR" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "rVl" = (
 /obj/structure/fluff/traveltile{
@@ -30451,6 +30353,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"rXt" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "rXE" = (
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
@@ -30469,6 +30377,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"rYs" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rYt" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -30559,20 +30475,12 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"sat" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "saP" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "saS" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -30592,10 +30500,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30658,6 +30565,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/bog)
+"sdl" = (
+/obj/machinery/light/rogue/smelter,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sdo" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/rack/rogue/shelf/big,
@@ -30706,21 +30618,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
-"seK" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -30744,10 +30646,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"sfZ" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
 "sgi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -30814,12 +30712,13 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
-"shS" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+"shJ" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "shV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -30855,6 +30754,10 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"siG" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "siI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/crate/roguecloset/inn,
@@ -30871,9 +30774,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
-"sjG" = (
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/town)
 "sjH" = (
 /obj/structure/roguewindow,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -31129,15 +31029,13 @@
 "squ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
-"sqI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"sqL" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sqW" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/mountains)
@@ -31178,6 +31076,36 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"ssD" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"ssF" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ssG" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -31202,11 +31130,6 @@
 	},
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
-"stz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "stD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
@@ -31223,6 +31146,15 @@
 "sue" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors)
+"sug" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sux" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -31269,6 +31201,25 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"svL" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "svX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -31309,9 +31260,18 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -31342,15 +31302,12 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
-"syA" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
+"syt" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "syL" = (
 /obj/structure/chair/bench,
@@ -31375,6 +31332,10 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"szJ" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "szM" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
@@ -31400,6 +31361,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"sAC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "sAP" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -31421,12 +31388,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"sBo" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "sBx" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/grass,
@@ -31442,11 +31403,14 @@
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"sBO" = (
-/obj/structure/fluff/wallclock/l,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+"sBJ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sBX" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -31467,18 +31431,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town)
 "sDa" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
+/obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -31497,20 +31454,17 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"sDR" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sDX" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"sEa" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sFe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger/steel,
@@ -31560,12 +31514,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"sGf" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sGj" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -31585,6 +31533,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sGx" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sGM" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -31644,8 +31596,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -31675,6 +31630,10 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
+"sKs" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "sKL" = (
 /obj/structure/chair/wood/rogue{
@@ -31707,12 +31666,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"sLD" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31724,6 +31677,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"sLM" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "sMb" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/wood,
@@ -31750,6 +31707,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"sNG" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "sNY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -31760,6 +31728,13 @@
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"sOh" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sOy" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -31767,12 +31742,10 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
-"sOL" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"sOY" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "sPj" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt,
@@ -31811,34 +31784,22 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"sQi" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+"sQI" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
 	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"sQl" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"sQV" = (
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -31852,18 +31813,18 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sRG" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+"sRU" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"sSl" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
 "sSm" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/powder,
@@ -31891,6 +31852,10 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"sSL" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "sSS" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave)
@@ -31915,27 +31880,12 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"sTi" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "sTl" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"sTp" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "sTr" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter)
@@ -31996,6 +31946,16 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"sVd" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sVB" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -32009,14 +31969,18 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"sWi" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sWG" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "sWL" = (
 /obj/effect/landmark/start/squire{
 	dir = 4
@@ -32041,19 +32005,25 @@
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"sXS" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+"sXG" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "sXU" = (
 /obj/structure/fermenting_barrel/random,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"sXW" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sYa" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -32065,6 +32035,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"sYv" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sYw" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
@@ -32090,10 +32067,6 @@
 /obj/effect/landmark/start/vampthralllate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"sYW" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "sYY" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -32104,6 +32077,19 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"sZk" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"sZv" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -32111,28 +32097,6 @@
 "sZN" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"tab" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "tag" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -32142,6 +32106,10 @@
 "tak" = (
 /obj/structure/chair/bench/church/mid{
 	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -32158,13 +32126,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"taD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "taK" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -32234,6 +32195,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"tcq" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "tcM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -32267,9 +32234,15 @@
 	},
 /area/rogue/indoors)
 "tdJ" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tei" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/rogue/ruinedwood{
@@ -32319,11 +32292,13 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
 	},
-/area/rogue/outdoors/rtfield)
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -32337,6 +32312,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"tfW" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "tfX" = (
 /obj/structure/stairs{
 	dir = 8
@@ -32382,28 +32366,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
-"tiW" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -32505,6 +32470,16 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"tlB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -32512,8 +32487,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32546,6 +32525,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"tnh" = (
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tnn" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/cobble,
@@ -32592,11 +32576,13 @@
 "tou" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"toC" = (
-/obj/structure/fluff/walldeco/painting{
-	pixel_y = 32
+"tox" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
@@ -32684,10 +32670,6 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"tsF" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32708,6 +32690,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ttW" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -32904,13 +32893,6 @@
 	},
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/exposed)
-"tyU" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "tzf" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
@@ -32972,6 +32954,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"tAs" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tAt" = (
 /obj/structure/fluff/millstone{
 	pixel_y = 7
@@ -32984,6 +32974,18 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"tAT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tAX" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road{
@@ -33055,22 +33057,26 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"tCy" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "tCz" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"tCN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "tCX" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -33107,12 +33113,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"tDN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "tEs" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -33147,15 +33147,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tEL" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
-"tEQ" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "tEU" = (
 /obj/structure/fluff/walldeco/stone{
 	pixel_y = 32
@@ -33212,16 +33203,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"tGA" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "tGF" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/naturalstone,
@@ -33280,15 +33261,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
-"tIZ" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "tJp" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -33302,26 +33274,55 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tJw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "tJx" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
 	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"tKf" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"tKg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tKu" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -33347,10 +33348,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"tLn" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -33391,20 +33388,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"tNb" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
-"tNi" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "tNj" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -33470,6 +33453,10 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"tOv" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
@@ -33502,16 +33489,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"tQK" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33544,6 +33521,11 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tSN" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tTb" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0;
@@ -33551,10 +33533,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"tTq" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "tTF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -33588,12 +33566,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
@@ -33602,8 +33579,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/basement)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -33625,6 +33603,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
+"tVu" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "tVx" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -33679,24 +33664,11 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"tXu" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tXC" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"tXU" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -33753,10 +33725,17 @@
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"uai" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "uaj" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -33870,6 +33849,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"ueS" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ueX" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/grass,
@@ -33889,6 +33876,10 @@
 "ufJ" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"ufN" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "ufR" = (
 /obj/structure/chair/wood/rogue/chair3,
@@ -33953,6 +33944,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uiv" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/obj/item/listenstone,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uiN" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
@@ -33966,6 +33964,10 @@
 /obj/item/candle/lit,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"uje" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ujh" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
@@ -33979,13 +33981,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"ujl" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ujO" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
@@ -34033,11 +34028,26 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"ukL" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ukU" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ulj" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ulu" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -34048,10 +34058,6 @@
 /obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"ulv" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ulY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -34062,10 +34068,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"umS" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "unm" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -34080,10 +34082,6 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"unD" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "unM" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -34145,6 +34143,14 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"upI" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "upU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/asteroid/elite/broodmother,
 /turf/open/floor/rogue/blocks,
@@ -34188,19 +34194,30 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ure" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "urr" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34338,20 +34355,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"uuz" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "uuA" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34368,18 +34371,10 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
-"uvn" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "uvu" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34394,12 +34389,14 @@
 "uvF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
+"uvI" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "uwa" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34448,17 +34445,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "uya" = (
@@ -34495,15 +34491,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"uyS" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "uyU" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/transparent/openspace,
@@ -34524,8 +34511,20 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34647,17 +34646,21 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/cave)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uDw" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uDy" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -34688,25 +34691,17 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -34728,9 +34723,7 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "uGo" = (
 /obj/structure/mineral_door/wood{
@@ -34769,6 +34762,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"uHa" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "uHb" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -34787,24 +34786,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -34828,10 +34815,6 @@
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
-"uKb" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -34933,13 +34916,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"uMC" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "uMO" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -34965,6 +34941,21 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"uOc" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"uOu" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -34997,8 +34988,31 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"uPi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -35076,6 +35090,16 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"uRR" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "uRZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -35086,7 +35110,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/rtfield)
 "uSx" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -35097,6 +35121,14 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"uTc" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uTf" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -35164,10 +35196,18 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uUG" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"uVj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -35175,6 +35215,14 @@
 "uVq" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/church/chapel)
+"uVs" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "uVz" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble,
@@ -35209,6 +35257,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uWj" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uWE" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
@@ -35246,6 +35300,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"uXS" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uXW" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -35290,6 +35348,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uYU" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uYV" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "butcher"
@@ -35302,16 +35367,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"uZf" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "uZk" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -35326,12 +35381,8 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/chapel)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -35356,12 +35407,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"val" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "vat" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -35384,6 +35429,10 @@
 "vaN" = (
 /turf/open/floor/rogue/dirt/snow,
 /area/rogue/indoors/shelter/mountains)
+"vaQ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "vbe" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35413,13 +35462,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
-"vcf" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "vcj" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -35432,6 +35474,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vcA" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -35439,10 +35485,26 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "vdg" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
 	},
-/turf/open/transparent/openspace,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"vdj" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -35452,6 +35514,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vdm" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vdo" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -35463,6 +35529,12 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"vdZ" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "vec" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/golden,
@@ -35497,6 +35569,10 @@
 /obj/structure/plasticflaps,
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
+"veE" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "veK" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -35518,19 +35594,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"veY" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16;
-	pixel_x = 16
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35576,9 +35641,20 @@
 	dir = 1;
 	icon_state = "border"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vgH" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "vgZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35644,9 +35720,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -35696,23 +35772,17 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"vlE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "vlK" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"vlS" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"vlN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vlX" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -35735,13 +35805,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"vmD" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "vmJ" = (
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt,
@@ -35753,6 +35816,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"vmX" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vng" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -35771,6 +35841,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"vnu" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
@@ -35779,6 +35853,10 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"vnO" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vnX" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
@@ -35805,6 +35883,15 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vor" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "vou" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -35813,13 +35900,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -35917,12 +36000,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/under/cave)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35933,14 +36016,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"vsl" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "vsm" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/churchmarble,
@@ -36045,18 +36120,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"vvk" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vvJ" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/dirt,
@@ -36134,6 +36197,17 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"vxV" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"vyn" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -36166,12 +36240,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
-"vzi" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "vzm" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
@@ -36258,13 +36326,6 @@
 /obj/item/listenstone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"vBh" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -36384,6 +36445,10 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"vEx" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vEz" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -36392,10 +36457,6 @@
 /obj/structure/statue/saints/magelady2_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"vEN" = (
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
 "vEQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -36426,11 +36487,15 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vFy" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "vFz" = (
-/obj/structure/fluff/wallclock/r,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -36449,8 +36514,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "vGQ" = (
 /obj/machinery/light/rogue/forge{
 	pixel_x = -1
@@ -36467,13 +36535,20 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"vHh" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36487,6 +36562,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"vII" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vIJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
@@ -36539,9 +36621,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -36563,30 +36648,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"vLJ" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "vLM" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36601,21 +36662,15 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"vMx" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "vMQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/church/chapel)
 "vMT" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -36647,6 +36702,17 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"vND" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "vOa" = (
 /obj/structure/stairs{
 	dir = 8
@@ -36659,12 +36725,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vOD" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "vOU" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/effect/decal/cleanable/cobweb,
@@ -36685,9 +36745,9 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -36728,24 +36788,9 @@
 	},
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
-"vQG" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "vQV" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36761,19 +36806,6 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"vRY" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "vSp" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -36859,33 +36891,13 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/roguemachine/scomm/l,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"vUp" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
 	},
 /area/rogue/indoors/town/shop)
-"vUP" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "vUT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
@@ -36896,6 +36908,12 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vVt" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "vVG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -36942,6 +36960,17 @@
 /obj/structure/table/wood/crafted,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"vWy" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "vWA" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -36956,8 +36985,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/town/roofs)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -36970,6 +37001,12 @@
 	icon_state = "paving"
 	},
 /area/rogue/outdoors/town)
+"vXz" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vXF" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -36995,6 +37032,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"vYE" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vYF" = (
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37010,6 +37054,13 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"vZc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -37094,6 +37145,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"wbE" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -37104,11 +37162,11 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"wcc" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wood,
+"wbT" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "wcd" = (
 /obj/structure/stairs{
@@ -37125,16 +37183,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"wdx" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "wdJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
@@ -37210,10 +37258,16 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"wgf" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wgn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wgt" = (
@@ -37249,6 +37303,16 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"whz" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "whR" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves)
@@ -37260,6 +37324,26 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
+"wiH" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"wjj" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -37287,13 +37371,10 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wkB" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+"wkw" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
@@ -37366,13 +37447,12 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
-"wny" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+"wnE" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "wnG" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/acolyte_r,
@@ -37388,19 +37468,28 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wou" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"woV" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -37424,9 +37513,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -37443,10 +37532,17 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "wqE" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "boat1";
@@ -37469,36 +37565,26 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/obj/structure/stairs{
+	dir = 1
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/outdoors/mountains)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
-"wse" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "wsR" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37510,13 +37596,13 @@
 /area/rogue/outdoors/bog)
 "wte" = (
 /obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "wtl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -37531,14 +37617,6 @@
 "wtF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
-"wtJ" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6";
-	pixel_x = 9
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "wtV" = (
 /obj/structure/closet/crate/chest{
 	lockid = "priest"
@@ -37546,18 +37624,6 @@
 /obj/item/clothing/cloak/stole/red,
 /obj/item/clothing/cloak/chasuble,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/church/chapel)
-"wtX" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "wue" = (
 /obj/structure/chair/wood/rogue/fancy{
@@ -37569,12 +37635,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wuD" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wve" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
@@ -37599,10 +37659,6 @@
 "wvE" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"wvI" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "wvM" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/bog)
@@ -37634,10 +37690,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
-"wwu" = (
-/obj/machinery/light/rogue/smelter,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
+"wwM" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
 /area/rogue/indoors/town/church/chapel)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
@@ -37672,20 +37732,13 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"wyU" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -37698,6 +37751,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"wzb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -37719,12 +37779,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
-"wzZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -37737,16 +37791,21 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"wAE" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
+"wAL" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
 	},
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
 	},
-/turf/open/floor/rogue/churchmarble,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "wAP" = (
 /obj/structure/rack/rogue,
@@ -37809,6 +37868,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wBZ" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "wCg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -37865,23 +37930,40 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
-"wDW" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "wDZ" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"wEa" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37923,12 +38005,21 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
+"wFC" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -37983,6 +38074,14 @@
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
+"wIi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -38075,6 +38174,19 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wKF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "wKL" = (
 /obj/structure/pillory/dungeon/double,
 /turf/open/floor/rogue/cobble,
@@ -38089,6 +38201,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"wLn" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
@@ -38109,6 +38227,18 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wLT" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -38138,6 +38268,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wMo" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "wMr" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -38147,21 +38285,6 @@
 "wNb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bog)
-"wNj" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "wNp" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -38170,11 +38293,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wNv" = (
-/obj/structure/table/vtable/v2,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "wNH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -38195,6 +38313,12 @@
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"wPd" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wPf" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/church,
@@ -38282,7 +38406,7 @@
 	lockid = "church";
 	name = "Cathedral of Enigma"
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "wQq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -38322,6 +38446,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"wRE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "wSc" = (
 /obj/structure/table/wood,
 /obj/item/flint{
@@ -38332,11 +38466,17 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/area/rogue/indoors)
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -38353,20 +38493,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
+/obj/structure/table/wood{
+	icon_state = "longtable"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"wTx" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
@@ -38390,13 +38521,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2";
-	pixel_x = 16
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38430,6 +38560,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"wWE" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wWK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -38438,13 +38574,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"wWU" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wXf" = (
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -38457,14 +38586,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"wXy" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wXz" = (
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -38502,8 +38623,15 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38518,10 +38646,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"wYZ" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "wZg" = (
 /obj/item/wisp_lantern,
 /obj/structure/closet/crate/chest/gold,
@@ -38535,6 +38659,13 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"wZr" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "wZJ" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword,
@@ -38542,18 +38673,34 @@
 /obj/item/rogueweapon/sword,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"xaa" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "xaf" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"xaX" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38594,14 +38741,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38650,25 +38796,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"xdF" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/chair/wood/rogue{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38703,6 +38835,7 @@
 /area/rogue/under/town/basement)
 "xfh" = (
 /obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
 /obj/item/reagent_containers/food/snacks/butter,
 /obj/item/reagent_containers/food/snacks/butter,
 /obj/item/reagent_containers/food/snacks/butter,
@@ -38782,12 +38915,6 @@
 "xhM" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/rtfield)
-"xhT" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "xhX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -38858,6 +38985,14 @@
 "xjl" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"xjp" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xjq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -38902,24 +39037,14 @@
 "xkm" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
-"xkD" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"xkE" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xkF" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
 /area/rogue/indoors/town)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -38938,6 +39063,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"xlb" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xld" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -39034,19 +39167,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"xnV" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "xob" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39078,16 +39198,6 @@
 /obj/item/roguekey/shop,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"xot" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "xou" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
@@ -39134,28 +39244,8 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"xpV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -39228,15 +39318,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
-"xsf" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xsp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -39279,10 +39360,6 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
-"xtx" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "xtA" = (
 /obj/structure/stairs{
 	dir = 4
@@ -39332,16 +39409,6 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
-"xuF" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
-"xvd" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "xvs" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -39371,13 +39438,6 @@
 /obj/item/natural/worms,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"xvC" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "xvK" = (
 /obj/item/rogueweapon/hammer/claw,
 /turf/open/floor/rogue/metal/barograte,
@@ -39397,16 +39457,9 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"xwh" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "xwi" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -39459,6 +39512,15 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
+"xxw" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "xxA" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -39516,14 +39578,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"xzp" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "xzN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road{
@@ -39546,11 +39600,19 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"xAo" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xAt" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
@@ -39695,13 +39757,6 @@
 "xDn" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
-"xDw" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "xDJ" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -39739,8 +39794,11 @@
 	},
 /area/rogue/outdoors/town)
 "xET" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39758,6 +39816,31 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"xFB" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
+"xFC" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xFD" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
@@ -39766,14 +39849,12 @@
 /obj/effect/landmark/start/barkeep,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"xFX" = (
-/obj/structure/stairs{
-	dir = 1
+"xFL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "xFZ" = (
 /obj/structure/spacevine,
 /turf/open/water/cleanshallow,
@@ -39784,25 +39865,11 @@
 	icon_state = "ice"
 	},
 /area/rogue/indoors/shelter/mountains)
-"xGj" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "xGp" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"xGr" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xGz" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/dirt/road{
@@ -39842,16 +39909,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"xGY" = (
-/obj/item/paper{
-	name = "HIT THINE BELL";
-	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "xHe" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39889,6 +39953,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"xId" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -39907,13 +39979,19 @@
 /obj/effect/landmark/start/guardsman,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"xJe" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+"xIK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
+"xJb" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"xJe" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town/church/chapel)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39963,12 +40041,6 @@
 /obj/item/clothing/shoes/roguetown/boots/leather,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"xKZ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "xLf" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -40132,12 +40204,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"xQH" = (
+"xQv" = (
 /obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -40183,14 +40254,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"xRu" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40229,12 +40292,6 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"xTa" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "xTp" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -40278,13 +40335,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
-"xUb" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "xUf" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -40360,6 +40410,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"xWw" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xWN" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
@@ -40379,6 +40436,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"xXc" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "xXd" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/twig,
@@ -40564,9 +40630,18 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"ycL" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -40575,23 +40650,19 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
-"ydj" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ydm" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
-"ydx" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
+"ydJ" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "ydR" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt,
@@ -40629,6 +40700,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"yeA" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "yeF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -40687,18 +40762,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
-"yfy" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "yfz" = (
 /obj/structure/pillory/dungeon/reinforced,
 /obj/effect/decal/cleanable/blood,
@@ -40707,21 +40770,6 @@
 "yfY" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"ygs" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"ygt" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ygF" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -40750,16 +40798,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"yhG" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "yhO" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/rogue/trophy/deer,
@@ -40794,14 +40832,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -40811,6 +40844,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"yjl" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "yjp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -40828,11 +40871,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -40884,12 +40932,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"ylw" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ylC" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/basement)
@@ -183680,18 +183722,18 @@ bpD
 bpD
 bpD
 bpD
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -184082,7 +184124,7 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
 sYw
 sYw
@@ -184092,8 +184134,8 @@ sYw
 sYw
 sYw
 sYw
-nBf
-nBf
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -184484,21 +184526,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-xAh
-xAh
-xAh
-xAh
-xAh
-xAh
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
 sYw
-nBf
-nBf
-nBf
-nBf
-nBf
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -184886,21 +184928,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-vjs
-xHe
-xHe
-ppc
-vjs
-xAh
-sYw
-sYw
+dNL
+gVW
+uaj
+uaj
+rgO
+gVW
+dNL
 sYw
 sYw
 sYw
-nBf
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -185288,21 +185330,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-xHe
-xHe
-ppc
-xHe
-ulv
-xAh
-xAh
-xAh
-xAh
-xAh
+dNL
+uaj
+uaj
+rgO
+uaj
+bDf
+dNL
+dNL
+dNL
+dNL
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -185690,21 +185732,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-ygt
-bEn
-xHe
-xHe
-xHe
-xHe
-xHe
-vjs
-xAh
-xAh
+dNL
+aMK
+sDR
+uaj
+uaj
+uaj
+uaj
+uaj
+gVW
+dNL
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -186092,21 +186134,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-nBf
-nBf
-sQi
-xaa
-rcr
-xHe
-ppc
-vjs
-xAh
-xAh
+dNL
+qpX
+qpX
+tlB
+iME
+eRV
+uaj
+rgO
+gVW
+dNL
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -186494,21 +186536,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-fIB
-nBf
-nBf
-ffB
-wou
-xHe
-xGY
-xHe
-dFS
-xAh
+dNL
+aIT
+qpX
+qpX
+wIi
+cCC
+uaj
+sqL
+uaj
+bUi
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -186896,21 +186938,21 @@ bpD
 bpD
 bpD
 bpD
-nBf
+qpX
 sYw
-xAh
-woq
-nBf
-nBf
-nxM
-wou
-nRH
-xHe
-xHe
-dFS
-xAh
+dNL
+kHu
+qpX
+qpX
+jMc
+cCC
+pDM
+uaj
+uaj
+bUi
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -187298,21 +187340,21 @@ sSS
 sSS
 sSS
 sSS
-nBf
+qpX
 sYw
-xAh
-nBf
-nBf
-rnE
-xHe
-rcr
-xHe
-ppc
-vjs
-xAh
-xAh
+dNL
+qpX
+qpX
+hyM
+uaj
+eRV
+uaj
+rgO
+gVW
+dNL
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -187700,21 +187742,21 @@ sSS
 sSS
 sSS
 sSS
-nBf
+qpX
 sYw
-xAh
-ujl
-wkB
-xHe
-xHe
-xHe
-xHe
-xHe
-vjs
-xAh
-xAh
+dNL
+vII
+orT
+uaj
+uaj
+uaj
+uaj
+uaj
+gVW
+dNL
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -188102,21 +188144,21 @@ sSS
 sSS
 sSS
 sSS
-nBf
+qpX
 sYw
-xAh
-xHe
-xHe
-xHe
-xHe
-ulv
-xAh
-xAh
-xAh
-xAh
-xAh
+dNL
+uaj
+uaj
+uaj
+uaj
+bDf
+dNL
+dNL
+dNL
+dNL
+dNL
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -188504,21 +188546,21 @@ sSS
 sSS
 sSS
 sSS
-nBf
+qpX
 sYw
-xAh
-vjs
-cwo
-ppc
-ppc
-vjs
-xAh
-sYw
-sYw
+dNL
+gVW
+bHe
+rgO
+rgO
+gVW
+dNL
 sYw
 sYw
 sYw
-nBf
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -188906,21 +188948,21 @@ sSS
 sSS
 sSS
 sSS
-nBf
+qpX
 sYw
-xAh
-xAh
-xAh
-xAh
-xAh
-xAh
-xAh
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
 sYw
-nBf
-nBf
-nBf
-nBf
-nBf
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -189308,7 +189350,7 @@ sSS
 sSS
 sSS
 sSS
-nBf
+qpX
 sYw
 sYw
 sYw
@@ -189318,7 +189360,7 @@ sYw
 sYw
 sYw
 sYw
-nBf
+qpX
 bpD
 bpD
 bpD
@@ -189710,17 +189752,17 @@ sSS
 sSS
 sSS
 sSS
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -202946,15 +202988,15 @@ vRu
 vRu
 vRu
 fjw
-tUR
-tUR
-tUR
-tUR
-tUR
-tUR
-tUR
-tUR
-tUR
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 vup
 iTw
 iTw
@@ -203348,7 +203390,7 @@ vRu
 vRu
 fjw
 fjw
-tUR
+bCb
 txa
 txa
 txa
@@ -206965,8 +207007,8 @@ sYw
 sYw
 sYw
 sYw
-tUR
-tUR
+bCb
+bCb
 txa
 cFQ
 cBf
@@ -227873,7 +227915,7 @@ acD
 acD
 fhw
 acD
-iia
+wRE
 acD
 acD
 acD
@@ -228276,8 +228318,8 @@ acD
 acD
 acD
 vuH
-cdn
-aok
+uDi
+vsg
 acD
 azH
 azH
@@ -228675,7 +228717,7 @@ vRu
 vRu
 acD
 qgC
-aok
+vsg
 qgC
 vuH
 qgC
@@ -229076,12 +229118,12 @@ vRu
 vRu
 vRu
 acD
-aok
+vsg
 qgC
-cdn
+uDi
 vuH
-cdn
-aok
+uDi
+vsg
 acD
 qgC
 qgC
@@ -229479,11 +229521,11 @@ vRu
 vRu
 acD
 qgC
-aok
+vsg
 qgC
 vuH
-cdn
-aok
+uDi
+vsg
 acD
 qgC
 qgC
@@ -229880,12 +229922,12 @@ vRu
 vRu
 vRu
 acD
-aok
+vsg
 qgC
 qgC
 vuH
-cdn
-aok
+uDi
+vsg
 acD
 qgC
 qgC
@@ -230284,9 +230326,9 @@ vRu
 acD
 qgC
 qgC
-odH
+bsS
 vuH
-cdn
+uDi
 qgC
 acD
 vRu
@@ -230687,7 +230729,7 @@ acD
 acD
 acD
 acD
-jEB
+xxw
 acD
 acD
 acD
@@ -231488,12 +231530,12 @@ vRu
 vRu
 acD
 qgC
-aok
-dso
+vsg
+ogC
 vuH
 ffw
 qgC
-aok
+vsg
 acD
 vRu
 vRu
@@ -231891,7 +231933,7 @@ vRu
 acD
 qgC
 qgC
-dso
+ogC
 qgC
 vuH
 vuH
@@ -232292,9 +232334,9 @@ vRu
 vRu
 acD
 qgC
-aok
+vsg
 qgC
-dso
+ogC
 vuH
 vuH
 qgC
@@ -233096,9 +233138,9 @@ vRu
 vRu
 acD
 qgC
-emK
+diG
 qgC
-emK
+diG
 ffw
 vuH
 qgC
@@ -233499,11 +233541,11 @@ vRu
 acD
 qgC
 vRu
-dso
+ogC
 vuH
 vuH
 vuH
-aok
+vsg
 acD
 vRu
 vRu
@@ -233903,8 +233945,8 @@ acD
 acD
 acD
 acD
-mdd
-inC
+hcG
+hnG
 acD
 acD
 vRu
@@ -280972,12 +281014,12 @@ hcW
 hcW
 hcW
 cWT
-tlQ
-tlQ
-tlQ
-tlQ
-tlQ
-tlQ
+mjP
+mjP
+mjP
+mjP
+mjP
+mjP
 uSw
 uSw
 uSw
@@ -280997,35 +281039,35 @@ uSw
 uSw
 uSw
 uSw
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281373,12 +281415,12 @@ uaL
 uaL
 uaL
 uaL
-bCb
-cCS
-hVO
-dNL
-dNL
-kEA
+veW
+qYw
+iRN
+jMf
+jMf
+nSy
 nrw
 nrw
 nrw
@@ -281408,26 +281450,26 @@ ykt
 ykt
 ykt
 ykt
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
+veW
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281775,61 +281817,61 @@ wSn
 wSn
 uaL
 uaL
-bCb
-cCS
-wpm
-dNL
-dNL
-dNL
+veW
+qYw
+jnN
+jMf
+jMf
+jMf
 nrw
 nrw
-hfU
-hRr
-bVa
-uKb
-uKb
-aHl
+ydJ
+uWj
+qwp
+uwa
+uwa
+cVu
 nrw
-ryk
-bmL
-bmL
-iHs
+qxL
+jlY
+jlY
+hmZ
 kzQ
-xsf
-rRA
-rRA
-aVK
-rvF
+aac
+fDB
+fDB
+dsg
+djd
 nrw
-dNL
-dNL
-mQA
+jMf
+jMf
+uHk
 uaL
 uaL
 paf
 qvR
 qvR
-rgO
+khc
 uaL
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
 kVc
-bCb
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -282177,62 +282219,62 @@ wSn
 wSn
 tzK
 uaL
-bCb
-cCS
-fzv
-dNL
-fVN
-unD
+veW
+qYw
+aSD
+jMf
+tOv
+vnO
 nrw
 nrw
-pKQ
-bVa
-bVa
-ePD
-ePD
-ePD
+pVF
+qwp
+qwp
+vnu
+vnu
+vnu
 nrw
 jlO
-bmL
-dvG
-bmL
+jlY
+wTs
+jlY
 jlO
-xsf
-rRA
-rRA
-tGA
-tJC
+aac
+fDB
+fDB
+kIV
+baV
 nrw
-dNL
-dNL
-mQA
-qii
+jMf
+jMf
+uHk
+roG
 uaL
 paf
 qvR
 qvR
-rgO
+khc
 uaL
 uaL
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 cWT
 cWT
@@ -282579,65 +282621,65 @@ wSn
 uaL
 uaL
 uaL
-bCb
-cCS
-jax
-dNL
-dNL
-unD
+veW
+qYw
+rwD
+jMf
+jMf
+vnO
 nrw
 nrw
-tyU
-bVa
-bVa
-hRr
-bVa
-bVa
-aym
+owf
+qwp
+qwp
+uWj
+qwp
+qwp
+oJO
 jlO
-bmL
-lAE
-bmL
+jlY
+gIo
+jlY
 jlO
 evo
-qeY
-rRA
-aDw
-rRA
+cqU
+fDB
+buB
+fDB
 nrw
-dNL
-dNL
-mQA
-ppM
+jMf
+jMf
+uHk
+iWj
 uaL
 paf
 qvR
 qvR
-rgO
+khc
 fxx
 aJj
 wSn
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -282981,66 +283023,66 @@ wSn
 uaL
 uaL
 uaL
-bCb
-cCS
-cCS
-tEQ
-tEQ
-knq
-cCS
-nrw
-fIb
 veW
-bVa
-bVa
-bVa
-bVa
-aym
+qYw
+qYw
+mQr
+mQr
+nZV
+qYw
+nrw
+ksh
+nle
+qwp
+qwp
+qwp
+qwp
+oJO
 jlO
-bmL
-isP
-bmL
+jlY
+wFC
+jlY
 jlO
 nrw
-qRZ
-rRA
-rRA
-rRA
-rPA
-dNL
-dNL
-mQA
+tKg
+fDB
+fDB
+fDB
+lGS
+jMf
+jMf
+uHk
 uaL
 uaL
-tfp
+lrj
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 wSn
 wSn
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 hcW
@@ -283383,68 +283425,68 @@ wSn
 wSn
 uaL
 uaL
-bCb
-cCS
-jax
-tEQ
-tEQ
-knq
-cCS
+veW
+qYw
+rwD
+mQr
+mQr
+nZV
+qYw
 nrw
-nPQ
-hRr
-bVa
-xkF
-xkF
-xkF
+iXt
+uWj
+qwp
+aem
+aem
+aem
 nrw
-cTc
 bmL
-aeu
+jlY
+wEa
+jlY
 bmL
-cTc
 nrw
-ncg
-rRA
-dNL
-dNL
-rPA
-dNL
-dNL
-mQA
+hlY
+fDB
+jMf
+jMf
+lGS
+jMf
+jMf
+uHk
 ykt
 ykt
 ykt
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 wSn
 aJj
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 uaL
@@ -283746,7 +283788,7 @@ cWT
 hcW
 hcW
 hcW
-kaP
+oye
 wSn
 wSn
 wSn
@@ -283785,69 +283827,69 @@ uaL
 uaL
 uaL
 uaL
-bCb
-cCS
-hVO
-tEQ
-tLn
-tEQ
-vUp
-bVa
-bVa
-bVa
-aTq
-ePD
-ePD
-kKN
+veW
+qYw
+iRN
+mQr
+hMB
+mQr
+wiH
+qwp
+qwp
+qwp
+lUT
+vnu
+vnu
+nKk
 nrw
-nhR
-bmL
-bmL
-bmL
+tJw
+jlY
+jlY
+jlY
 jlO
 nrw
-qeY
-rRA
-dNL
-dNL
-rPA
-cwd
-dNL
-mQA
+cqU
+fDB
+jMf
+jMf
+lGS
+cCS
+jMf
+uHk
 uaL
 uaL
-tfp
+lrj
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 wSn
 uaL
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 uaL
 uaL
 wSn
@@ -284187,15 +284229,15 @@ hcW
 hcW
 uaL
 uaL
-bCb
-cCS
-wpm
-tEQ
-tEQ
-tEQ
-cCS
+veW
+qYw
+jnN
+mQr
+mQr
+mQr
+qYw
 nrw
-aym
+oJO
 nrw
 nrw
 nrw
@@ -284204,51 +284246,51 @@ nrw
 nrw
 nrw
 jlO
-aXQ
-cTc
+bDh
+bmL
 jlO
 nrw
-fXr
-rRA
-dNL
-ewu
+vVt
+fDB
+jMf
+nlC
 nrw
-ycz
-dNL
-mQA
-shS
+vdm
+jMf
+uHk
+xIK
 uaL
 paf
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
 wSn
 uaL
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 wSn
@@ -284589,67 +284631,67 @@ hcW
 hcW
 uaL
 uaL
-bCb
-cCS
-fzv
-bFu
-tEQ
-tEQ
-ltI
-dNL
-dNL
-sBO
-dNL
-har
-har
-dNL
+veW
+qYw
+aSD
+xbW
+mQr
+mQr
+fFW
+jMf
+jMf
+jMs
+jMf
+jdJ
+jdJ
+jMf
 mwq
 nrw
-gEy
+fyv
 nrw
 jlO
 jlO
 nrw
-fMl
-nZy
-dNL
-mJU
+xkF
+xaX
+jMf
+otr
 nrw
-cwd
-dNL
-mQA
-val
+cCS
+jMf
+uHk
+uHa
 uaL
 paf
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
 uaL
 wSn
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 qvR
@@ -284991,65 +285033,65 @@ hcW
 hcW
 hcW
 uaL
-bCb
-cCS
-cCS
-cCS
-cCS
+veW
+qYw
+qYw
+qYw
+qYw
 nrw
 nrw
 mwq
-dNL
-fVN
-dNL
-fVN
-dNL
-dNL
-dNL
-dNL
-dNL
+jMf
+tOv
+jMf
+tOv
+jMf
+jMf
+jMf
+jMf
+jMf
 nrw
-jNF
-nrw
-nrw
+wzb
 nrw
 nrw
-oMa
 nrw
 nrw
-dNL
-dNL
-mQA
+wZr
+nrw
+nrw
+jMf
+jMf
+uHk
 lsD
 lsD
-pUX
+jJa
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
 fxx
 wSn
-bCb
+veW
 kVc
-bCb
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -285393,65 +285435,65 @@ hcW
 hcW
 uaL
 uaL
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
 evo
 nrw
 nrw
-wTx
-wTx
-pzY
-eBq
-xvd
-xvd
-xvd
-eBq
-dNL
+pHF
+pHF
+wbE
+gip
+rxp
+rxp
+rxp
+gip
+jMf
 nrw
-bVa
-eWd
-xkE
+qwp
+eol
+fIK
 nrw
-uxV
-cwd
-ycz
-cwd
-dNL
-dNL
-mQA
+cSi
+cCS
+vdm
+cCS
+jMf
+jMf
+uHk
 rhD
 rhD
 rhD
 rhD
 rhD
-rgO
+khc
 rZt
 fxx
 fxx
 fxx
 uaL
-bCb
+veW
 kVc
-bCb
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 uaL
@@ -285799,31 +285841,31 @@ uaL
 uaL
 qvR
 qvR
-bCb
+veW
 evo
-hJR
-ycz
+pEX
+vdm
 cbG
 cbG
-tiW
-eBq
-sTi
-dIl
-hDE
-gKU
-dNL
+uPa
+gip
+gum
+avN
+lFR
+sKs
+jMf
 nrw
-bVa
-xGr
-bVa
-vsg
-dNL
-dNL
-cwd
-dNL
-dNL
-dNL
-jkZ
+qwp
+dHw
+qwp
+jPz
+jMf
+jMf
+cCS
+jMf
+jMf
+jMf
+owj
 fxx
 fxx
 fxx
@@ -285836,24 +285878,24 @@ fxx
 fxx
 aJj
 wSn
-bCb
-bCb
+veW
+veW
 kVc
 kVc
-bCb
+veW
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 uaL
@@ -286201,34 +286243,34 @@ uaL
 uaL
 qvR
 qvR
-bHX
+fQq
 evo
-fVM
-ycz
+gDx
+vdm
 cbG
 cbG
-jlY
-eBq
-kNi
-vox
-xDw
-eBq
-dNL
-yhG
-bVa
-rNo
-bVa
-jNF
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
-jkZ
+rYs
+gip
+tfp
+ohw
+ure
+gip
+jMf
+fLv
+qwp
+tUR
+qwp
+wzb
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+owj
 fxx
 fxx
-uwa
+rXt
 fxx
 fxx
 fxx
@@ -286238,24 +286280,24 @@ fxx
 fxx
 uaL
 wSn
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 wSn
@@ -286603,31 +286645,31 @@ uaL
 uaL
 qvR
 qvR
-bHX
+fQq
 evo
-kHb
-ycz
+yiI
+vdm
 cbG
 cbG
-pzY
-eBq
-eSH
-rUR
-seK
-eBq
-dNL
+wbE
+gip
+bkF
+rni
+llo
+gip
+jMf
 nrw
-bJC
-bJC
-rNo
-jNF
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
-jkZ
+fEc
+fEc
+tUR
+wzb
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+owj
 fxx
 fxx
 fxx
@@ -286641,23 +286683,23 @@ fxx
 uaL
 uaL
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -286969,7 +287011,7 @@ uaL
 uaL
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -287005,37 +287047,37 @@ uaL
 uaL
 qvR
 qvR
-bHX
+fQq
 evo
 nrw
 nrw
-htf
-htf
-pzY
-gKU
-sTp
-sTp
-sTp
-eBq
-dNL
+xFB
+xFB
+wbE
+sKs
+nPQ
+nPQ
+nPQ
+gip
+jMf
 nrw
-sOL
-csH
-bVa
-vsg
-dNL
-dNL
-cwd
-dNL
-dNL
-dNL
-mQA
+fRP
+wsR
+qwp
+jPz
+jMf
+jMf
+cCS
+jMf
+jMf
+jMf
+uHk
 rhD
 rhD
 rhD
 rhD
 rhD
-rgO
+khc
 rZt
 fxx
 fxx
@@ -287043,23 +287085,23 @@ fxx
 fxx
 aJj
 kVc
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -287407,37 +287449,37 @@ uaL
 uaL
 qvR
 qvR
-bCb
+veW
 evo
 nrw
 mwq
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
-dNL
-fVN
-dNL
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+tOv
+jMf
 nrw
 nrw
 nrw
-fqr
+sVd
 nrw
-uxV
-cwd
-ycz
-cwd
-dNL
-dNL
-mQA
-afy
+cSi
+cCS
+vdm
+cCS
+jMf
+jMf
+uHk
+orE
 qvR
 qvR
 qvR
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -287445,23 +287487,23 @@ fxx
 fxx
 uaL
 aJj
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
-bCb
+veW
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
-bCb
+veW
 kVc
 qvR
 qvR
@@ -287809,37 +287851,37 @@ uaL
 uaL
 uaL
 qvR
-bCb
+veW
 evo
 nrw
-wUw
-lMg
-vFz
-dNL
-lMg
-lMg
-dNL
+ulj
+iCm
+sQV
+jMf
+iCm
+iCm
+jMf
 mwq
 nrw
 nrw
 nrw
 nrw
-rRD
-bVa
+rRA
+qwp
 nrw
 nrw
-cXu
+vGN
 nrw
 nrw
-cwd
-dNL
-mQA
+cCS
+jMf
+uHk
 uaL
 uaL
 uaL
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -287847,23 +287889,23 @@ fxx
 fxx
 wSn
 aJj
-bCb
-bCb
-bCb
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 wSn
@@ -288180,7 +288222,7 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -288209,9 +288251,9 @@ uaL
 uaL
 uaL
 hcW
-bCb
-bCb
-bCb
+veW
+veW
+veW
 evo
 nrw
 nrw
@@ -288223,25 +288265,25 @@ nrw
 nrw
 nrw
 nrw
-gLJ
-gLJ
+iPF
+iPF
 nrw
-rRD
-bVa
-rRD
-bOC
-hQY
-uKb
+rRA
+qwp
+rRA
+pWm
+aym
+uwa
 nrw
-ycz
-dNL
-mQA
+vdm
+jMf
+uHk
 uaL
 uaL
 uaL
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -288250,20 +288292,20 @@ fxx
 wSn
 aJj
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-sxM
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+aZu
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -288613,37 +288655,37 @@ hcW
 hcW
 hcW
 cWT
-tlQ
-tlQ
-tlQ
-tlQ
-rRD
-rRD
-rRD
-gLJ
-gLJ
-rRD
-rRD
-rRD
-bVa
-vPA
+mjP
+mjP
+mjP
+mjP
+rRA
+rRA
+rRA
+iPF
+iPF
+rRA
+rRA
+rRA
+qwp
+cjJ
 nrw
-dbH
-bVa
-rNo
-bVa
-xGr
-bVa
-vBh
-cwd
-dNL
-mQA
+bhR
+qwp
+tUR
+qwp
+dHw
+qwp
+vYE
+cCS
+jMf
+uHk
 qvR
 qvR
 qvR
 qvR
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -288652,20 +288694,20 @@ fxx
 wSn
 wSn
 kVc
-bCb
+veW
 kVc
-bCb
+veW
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -289012,40 +289054,40 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 cWT
-tlQ
+mjP
 iJR
-wDz
-dCd
-bVa
-qDn
-vPA
-stz
-qDn
-qDn
-vPA
-qDn
-bhe
-bVa
-fVM
-hQY
-bVa
-bVa
-bVa
-rNo
-bVa
-vsg
-dNL
-dNL
-mQA
+ikM
+qNF
+qwp
+rRD
+cjJ
+ijU
+rRD
+rRD
+cjJ
+rRD
+oaU
+qwp
+gDx
+aym
+qwp
+qwp
+qwp
+tUR
+qwp
+jPz
+jMf
+jMf
+uHk
 uaL
 uaL
 uaL
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -289060,15 +289102,15 @@ kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 lyL
@@ -289378,25 +289420,22 @@ uaL
 uaL
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
-sIE
-hcW
-hcW
-hcW
-hcW
-sIE
+dbH
 hcW
 hcW
 hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289405,11 +289444,14 @@ hcW
 hcW
 hcW
 hcW
-sIE
 hcW
 hcW
 hcW
-sIE
+dbH
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289417,37 +289459,37 @@ hcW
 hcW
 hcW
 cWT
-tlQ
+mjP
 iJR
-gJE
-dCd
-bVa
-qDn
-vPA
-hQU
-qDn
-vPA
-stz
-vPA
-vPA
-bVa
+blT
+qNF
+qwp
+rRD
+cjJ
+cvC
+rRD
+cjJ
+ijU
+cjJ
+cjJ
+qwp
 nrw
-bVa
-bVa
-xkF
-xkF
-bVa
-bVa
-vsg
-dNL
-dNL
-mQA
+qwp
+qwp
+aem
+aem
+qwp
+qwp
+jPz
+jMf
+jMf
+uHk
 uaL
 uaL
 uaL
 uaL
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -289455,22 +289497,22 @@ fxx
 fxx
 uaL
 wSn
-bCb
+veW
 kVc
 kVc
 kVc
-bCb
+veW
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -289814,42 +289856,42 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 cWT
-tlQ
-tlQ
-tlQ
-tlQ
-rRD
-rRD
-rRD
-nlw
-nlw
-rRD
-rRD
-rRD
-stz
-bVa
-cSb
-bVa
-bVa
-hNE
-jWZ
-coy
-rRD
+mjP
+mjP
+mjP
+mjP
+rRA
+rRA
+rRA
+nhR
+nhR
+rRA
+rRA
+rRA
+ijU
+qwp
+aev
+qwp
+qwp
+vHd
+uvu
+vEx
+rRA
 nrw
-dNL
-dNL
-mQA
-bHT
+jMf
+jMf
+uHk
+fZg
 qvR
 qvR
 qvR
 qvR
-rgO
+khc
 fxx
 fxx
 fxx
@@ -289857,22 +289899,22 @@ fxx
 fxx
 fxx
 wSn
-bCb
+veW
 kVc
-bCb
-kVc
-kVc
+veW
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -290209,7 +290251,7 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -290224,7 +290266,7 @@ cWT
 cWT
 cWT
 cWT
-tlQ
+mjP
 nrw
 nrw
 nrw
@@ -290261,20 +290303,20 @@ fxx
 uaL
 kVc
 kVc
-bCb
+veW
 kVc
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -290593,7 +290635,7 @@ qvR
 uaL
 uaL
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -290611,14 +290653,14 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -290627,10 +290669,10 @@ hcW
 hcW
 hcW
 cWT
-bHX
-bHX
-sjG
-sjG
+fQq
+fQq
+pno
+pno
 evo
 ykt
 ykt
@@ -290665,17 +290707,17 @@ aJj
 kVc
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 qvR
@@ -290996,7 +291038,7 @@ qvR
 qvR
 hcW
 hcW
-sIE
+dbH
 hcW
 kYc
 kYS
@@ -291005,7 +291047,7 @@ mzx
 kYc
 mzx
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -291029,8 +291071,8 @@ hcW
 hcW
 hcW
 hcW
-sjG
-bHX
+pno
+fQq
 evo
 evo
 evo
@@ -291065,19 +291107,19 @@ fxx
 uaL
 uaL
 uaL
-bCb
+veW
 uaL
 kVc
 kVc
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
-bCb
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -291410,16 +291452,16 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -291810,18 +291852,18 @@ msk
 ntQ
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -291874,13 +291916,13 @@ uaL
 uaL
 fxx
 fxx
-xwh
-cLL
-cLL
-cLL
-cLL
-cLL
-xwh
+jNF
+goz
+goz
+goz
+goz
+goz
+jNF
 wSn
 uaL
 uaL
@@ -292201,7 +292243,7 @@ sJZ
 sJZ
 qvR
 hcW
-sIE
+dbH
 hcW
 hcW
 ldI
@@ -292276,13 +292318,13 @@ fxx
 fxx
 fxx
 fxx
-xUb
+lEs
 peN
 peN
 peN
 peN
 peN
-rfO
+kgd
 fxx
 fxx
 fxx
@@ -292591,7 +292633,7 @@ uaL
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 qvR
@@ -292623,13 +292665,13 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -292678,13 +292720,13 @@ fxx
 fxx
 fxx
 fxx
-cLL
+goz
 peN
 peN
 peN
-wYZ
+hzY
 peN
-cLL
+goz
 fxx
 fxx
 fxx
@@ -293028,10 +293070,10 @@ hcW
 hcW
 hcW
 hcW
-sIE
-sIE
+dbH
+dbH
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -293052,14 +293094,14 @@ wSn
 wSn
 wSn
 xKz
-xdF
-urF
+upI
+nTR
 lLa
 xKz
 xKz
-nKy
-bLl
-aOJ
+jXU
+uai
+mnW
 xKz
 jeb
 jeb
@@ -293425,8 +293467,8 @@ hcW
 hcW
 hcW
 hcW
-sIE
-sIE
+dbH
+dbH
 hcW
 hcW
 hcW
@@ -293454,18 +293496,18 @@ wSn
 wSn
 wSn
 xKz
-vMQ
+bUr
 iYQ
 fVQ
-iGe
+nZw
 qpt
-wgn
+sDa
 peN
 rUr
-kKm
-iGe
+quL
+nZw
 fVQ
-vMx
+sNG
 xKz
 qvR
 qvR
@@ -293482,13 +293524,13 @@ wSn
 uaL
 fTe
 wSn
-jet
-nOR
-oiE
-oiE
-oiE
-nOR
-jet
+xHe
+dQe
+aIb
+aIb
+aIb
+dQe
+xHe
 uaL
 uaL
 uaL
@@ -293829,7 +293871,7 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -293856,18 +293898,18 @@ wSn
 wSn
 wSn
 xKz
-wyA
-urF
+qWS
+nTR
 fVQ
 lLa
 qpt
-wgn
+sDa
 peN
 rUr
-kKm
+quL
 lLa
 fVQ
-aet
+seC
 xKz
 qvR
 qvR
@@ -293887,7 +293929,7 @@ uaL
 xKz
 bOK
 jeb
-iMu
+sRU
 jeb
 bOK
 xKz
@@ -294224,14 +294266,14 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -294258,18 +294300,18 @@ wSn
 wSn
 wSn
 xKz
-vMQ
+bUr
 iYQ
 fVQ
-dzB
+xaD
 qpt
-wgn
+sDa
 peN
 rUr
-kKm
+quL
 hmU
 fVQ
-aet
+seC
 xKz
 qvR
 qvR
@@ -294289,7 +294331,7 @@ uaL
 bOK
 tYP
 tYP
-mdB
+ozt
 tYP
 tYP
 xKz
@@ -294602,7 +294644,7 @@ uaL
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 qvR
 qvR
@@ -294624,7 +294666,7 @@ ndD
 kYc
 msk
 nxV
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -294660,18 +294702,18 @@ wSn
 wSn
 wSn
 xKz
-wyA
-urF
+qWS
+nTR
 fVQ
 jeb
 jeb
-wgn
+sDa
 peN
 rUr
 jeb
 jeb
 fVQ
-wFp
+jNj
 xKz
 qvR
 qvR
@@ -294688,11 +294730,11 @@ uaL
 qvR
 qvR
 uaL
-jnw
+uOu
 tYP
-gsD
+gTY
 tYP
-rds
+bHX
 tYP
 xKz
 qvR
@@ -295062,18 +295104,18 @@ wSn
 wSn
 wSn
 xKz
-lgJ
+ycL
 iYQ
 fVQ
 fVQ
 jeb
-cOb
+wgn
 peN
 rUr
 jeb
 fVQ
 tYP
-ffD
+kdv
 xKz
 qvR
 qvR
@@ -295091,7 +295133,7 @@ qvR
 uaL
 wSn
 xKz
-dNp
+wDz
 tYP
 tYP
 tYP
@@ -295416,7 +295458,7 @@ uaL
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -295464,18 +295506,18 @@ wSn
 wSn
 wSn
 xKz
-wuD
+dwO
 lLa
 fVQ
 fVQ
-cMm
-wgn
+nBT
+sDa
 peN
 rUr
-cMm
+nBT
 fVQ
 sCg
-qYR
+mrE
 xKz
 qvR
 uaL
@@ -295494,10 +295536,10 @@ uaL
 wSn
 bOK
 tYP
-mQr
+szJ
 tYP
 sCg
-lNo
+jUD
 xKz
 qvR
 qvR
@@ -295825,7 +295867,7 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -295866,18 +295908,18 @@ xKz
 xKz
 xKz
 xKz
-wuD
+dwO
 lLa
 kMi
-qCT
+gXk
 jeb
-cOb
+wgn
 peN
 rUr
 jeb
 fVQ
 sCg
-qYR
+mrE
 xKz
 qvR
 uaL
@@ -295897,9 +295939,9 @@ wSn
 xKz
 xKz
 xKz
-vUP
+nnI
 sCg
-qYR
+mrE
 xKz
 qvR
 qvR
@@ -296271,15 +296313,15 @@ fVQ
 fVQ
 fVQ
 kMi
-lgJ
+ycL
 jeb
-wgn
+sDa
 peN
 rUr
 jeb
 fVQ
 tYP
-qYR
+mrE
 xKz
 qvR
 qvR
@@ -296301,7 +296343,7 @@ xKz
 xKz
 tYP
 sCg
-qYR
+mrE
 xKz
 qvR
 qvR
@@ -296611,7 +296653,7 @@ hcW
 wSn
 uaL
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -296671,17 +296713,17 @@ xKz
 mDY
 fVQ
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 qpt
-wgn
+sDa
 peN
 rUr
-kKm
+quL
 lLa
 fVQ
-sBo
+ohA
 xKz
 qvR
 uaL
@@ -296701,9 +296743,9 @@ wSn
 xKz
 xKz
 xKz
-vUP
+nnI
 sCg
-lNo
+jUD
 xKz
 qvR
 uaL
@@ -297013,7 +297055,7 @@ wSn
 wSn
 uaL
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
@@ -297022,7 +297064,7 @@ hcW
 hcW
 hcW
 hcW
-sIE
+dbH
 wSn
 wSn
 qvR
@@ -297069,7 +297111,7 @@ xqL
 wSn
 wSn
 xKz
-qCT
+gXk
 gqa
 fVQ
 fVQ
@@ -297077,13 +297119,13 @@ fVQ
 fVQ
 fVQ
 qpt
-wgn
+sDa
 peN
 rUr
-kKm
+quL
 lLa
 fVQ
-qqM
+hrT
 xKz
 qvR
 qvR
@@ -297103,7 +297145,7 @@ uaL
 xKz
 xKz
 xKz
-uZf
+jit
 xKz
 xKz
 xKz
@@ -297412,19 +297454,19 @@ fyc
 cWT
 cWT
 wSn
-sIE
-sIE
-sIE
-sIE
+dbH
+dbH
+dbH
+dbH
 hcW
-sIE
+dbH
 hcW
 hcW
 hcW
-sIE
-sIE
-sIE
-sIE
+dbH
+dbH
+dbH
+dbH
 wSn
 wSn
 qvR
@@ -297471,21 +297513,21 @@ aJj
 uaL
 qvR
 xKz
-vMQ
+bUr
 iYQ
 lLa
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 qpt
-wgn
+sDa
 peN
 rUr
-kKm
-ijU
+quL
+xFC
 fVQ
-wWU
+mGn
 xKz
 uaL
 uaL
@@ -297814,9 +297856,9 @@ fyc
 cWT
 cWT
 uaL
-sIE
-sIE
-sIE
+dbH
+dbH
+dbH
 hcW
 hcW
 hcW
@@ -297873,18 +297915,18 @@ evo
 evo
 evo
 xKz
-lgJ
-urF
+ycL
+nTR
 kds
-saP
+sOh
 xKz
-dzB
+xaD
 fVQ
 xKz
-jDv
-mOw
+gUR
+nmC
 kIf
-nEe
+fhm
 xKz
 xKz
 xKz
@@ -298284,29 +298326,29 @@ xKz
 xKz
 xKz
 uWL
-pZJ
-pZJ
+egd
+egd
 xKz
 xKz
-uPa
-uPa
+uGf
+uGf
+bPz
+bPz
+bPz
+bPz
+bPz
+bPz
+lGh
+lGh
+bPz
+bPz
 uGf
 uGf
 uGf
 uGf
-uGf
-uGf
-hmF
-hmF
-uGf
-uGf
-uPa
-uPa
-uPa
-uPa
-uGf
-uGf
-uGf
+bPz
+bPz
+bPz
 axq
 dnx
 axl
@@ -305521,7 +305563,7 @@ xKz
 wVI
 wbg
 wbg
-xpM
+ovj
 wbg
 wbg
 wbg
@@ -305877,7 +305919,7 @@ mcK
 nBW
 mOY
 nBW
-jtq
+jXB
 nBW
 wtF
 wbg
@@ -307491,7 +307533,7 @@ wtF
 wbg
 wbg
 wbg
-xpM
+ovj
 wbg
 wbg
 wbg
@@ -309614,9 +309656,9 @@ bwS
 lVe
 bwS
 lVe
-wSl
+kwn
 goK
-tNb
+nvf
 sux
 pYf
 pYf
@@ -310750,14 +310792,14 @@ wbg
 wbg
 wbg
 wVI
-iDV
-uaj
+rDD
+plk
 nHz
 wVI
 wVI
 wVI
-hbr
-iDV
+fVM
+rDD
 wVI
 tUw
 wVI
@@ -310793,7 +310835,7 @@ fxx
 fxx
 fxx
 fxx
-lMu
+kch
 fxx
 boU
 fxx
@@ -310811,13 +310853,13 @@ qvR
 wSn
 cyr
 hHF
-nTR
+fiK
 wlD
 sIG
 wlD
 wlD
 wlD
-tNb
+nvf
 wlD
 sIG
 wlD
@@ -311118,7 +311160,7 @@ wbg
 xXq
 yhZ
 yhZ
-ikM
+qtK
 yhZ
 yhZ
 xXq
@@ -311531,13 +311573,13 @@ xez
 wbg
 wbg
 wbg
-xpM
+ovj
 wbg
 wbg
 wbg
 wbg
 wbg
-xpM
+ovj
 wbg
 wbg
 wbg
@@ -311585,7 +311627,7 @@ fxx
 fxx
 fxx
 fxx
-lMu
+kch
 fxx
 fxx
 fxx
@@ -311953,7 +311995,7 @@ wbg
 wbg
 wbg
 wbg
-xpM
+ovj
 wbg
 wbg
 wbg
@@ -311961,7 +312003,7 @@ wbg
 wbg
 wbg
 wbg
-xpM
+ovj
 wbg
 wbg
 wbg
@@ -313170,7 +313212,7 @@ wbg
 xGM
 xGM
 qzH
-wsR
+adK
 ukb
 wvE
 rLt
@@ -313211,7 +313253,7 @@ trG
 ryI
 fZw
 fxx
-lMu
+kch
 rhD
 qvR
 qvR
@@ -313569,10 +313611,10 @@ wew
 wxZ
 nRo
 bQf
-lqg
+bez
 iPY
-llp
-wsR
+vdZ
+adK
 ukb
 wvE
 wvE
@@ -313926,7 +313968,7 @@ aOn
 aOn
 lpa
 nCh
-xpM
+ovj
 wbg
 wbg
 hOh
@@ -313959,22 +314001,22 @@ pUl
 rJX
 tCr
 guP
-qgz
-vLA
-ogC
+wte
+jjF
+vlN
 wbg
 qtV
 iPY
 iPY
-iPY
-tCz
+mwE
+qeY
 wVI
 weX
 wVI
-uyS
+dua
 hRv
-llp
-wsR
+vdZ
+adK
 xMr
 yho
 wvE
@@ -314361,22 +314403,22 @@ rJX
 eai
 tCr
 guP
-wra
-dCl
+grj
+vmX
 iGf
 viq
 qtV
 iPY
-aOn
-aOn
-rPT
+iPY
+iPY
+hCQ
 wxZ
 wVI
 bQf
-ava
+wKF
 nXd
-qmJ
-wsR
+whz
+adK
 dHZ
 xww
 wvE
@@ -314765,20 +314807,20 @@ fQm
 guP
 guP
 guP
-vLA
+jjF
 uTQ
 qtV
 nXd
-kRE
-kRE
-aCr
+kwN
+cND
+wYv
 wVI
 wVI
 wVI
 wVI
 wVI
 rmJ
-wsR
+adK
 pht
 vwQ
 vwQ
@@ -314835,7 +314877,7 @@ lVe
 uxL
 sZI
 xlx
-mWO
+dTa
 iTv
 cXU
 iTv
@@ -315113,7 +315155,7 @@ uOL
 jxy
 vbO
 oif
-tTq
+uvI
 oif
 uJk
 tOz
@@ -315164,22 +315206,22 @@ wKT
 hpJ
 wKT
 wKT
-sxR
+gUC
 sxR
 sxR
 sxR
 abh
 wbg
-qzy
-qzy
+jCr
+jCr
 aSH
-qzy
+jCr
 wVI
 wVI
 wVI
 wVI
 wVI
-loE
+aEG
 oUn
 xMr
 vwQ
@@ -315561,7 +315603,7 @@ tYm
 oAn
 wbg
 wbg
-oyH
+dsR
 dTB
 tVP
 tVP
@@ -315570,7 +315612,7 @@ tCG
 tVP
 tVP
 tCG
-hrh
+rUm
 wbg
 wVI
 wVI
@@ -315972,9 +316014,9 @@ tVP
 tVP
 tVP
 tVP
-qMA
+nnb
 qtV
-iJx
+fKD
 rZY
 wVI
 wxZ
@@ -316362,21 +316404,21 @@ pAS
 sZN
 sZN
 xdq
-cbQ
+sIE
 wbg
 wbg
-oyH
+dsR
 rJC
 tVP
-yjP
-mAZ
+wnE
+iYH
 tVP
-kwN
+kEb
 tVP
 tVP
-qMA
+nnb
 qtV
-iJx
+fKD
 rZY
 wVI
 wxZ
@@ -316386,7 +316428,7 @@ wVI
 bQf
 wVI
 rZY
-gXT
+qKU
 kjH
 kjH
 kjH
@@ -316416,7 +316458,7 @@ vLS
 uaL
 sjP
 wSn
-lMu
+kch
 fxx
 lcg
 fQg
@@ -316764,23 +316806,23 @@ sZN
 sZN
 sZN
 xdq
-tCz
+qeY
 wbg
 wbg
 wKT
 kFS
 tVP
-pvE
-wdx
-tab
-aFX
+veE
+lqJ
+keW
+wgf
 tVP
 tCG
-qMA
+nnb
 wbg
 wbg
 wVI
-hwQ
+uEX
 wVI
 wVI
 wVI
@@ -317116,7 +317158,7 @@ oif
 oif
 oif
 oif
-cMR
+rNT
 eUJ
 eUJ
 jxy
@@ -317166,7 +317208,7 @@ sZN
 sZN
 lzC
 xdq
-cbQ
+sIE
 wbg
 wbg
 wKT
@@ -317184,8 +317226,8 @@ qEa
 vXm
 vXm
 vXm
-aPg
-rvH
+nCA
+mUY
 wVI
 wVI
 wVI
@@ -317586,12 +317628,12 @@ wbg
 uqe
 ewM
 uqe
-xpV
-tCz
+lxN
+qeY
 wVI
 wVI
 rZY
-fQq
+fbP
 rZY
 jXw
 xgi
@@ -317970,7 +318012,7 @@ pDy
 sZN
 sZN
 xdq
-cbQ
+sIE
 wbg
 wbg
 cCQ
@@ -317982,18 +318024,18 @@ yfY
 yfY
 yfY
 yfY
-hjW
+fha
 wbg
-xtx
+mMs
 uqe
 uqe
 uqe
-bRy
+tCN
 wew
 weX
 wVI
 rZY
-lhH
+uzT
 rZY
 jXw
 xgi
@@ -318035,7 +318077,7 @@ gkv
 hLK
 njv
 fxx
-lMu
+kch
 wxd
 wxd
 wSn
@@ -318341,7 +318383,7 @@ wrj
 jDm
 jDm
 mwE
-gZv
+sLM
 mwE
 wbg
 wbg
@@ -318372,25 +318414,25 @@ pAS
 sZN
 sZN
 xdq
-tCz
+qeY
 wbg
 wbg
 cJz
 yfY
-mCh
+dfH
 ijS
-xTa
+eBx
 vGQ
 tZZ
 kfr
-yfy
+nBp
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-bRy
+tCN
 wew
 wVI
 wVI
@@ -318774,7 +318816,7 @@ ygF
 ygF
 uDv
 xdq
-cbQ
+sIE
 wbg
 wbg
 wKT
@@ -318792,13 +318834,13 @@ qEa
 gGZ
 gGZ
 gGZ
-vLJ
-mky
-xdw
-xdw
-xdw
-xdw
-xdw
+ssF
+kzO
+wqq
+wqq
+wqq
+wqq
+wqq
 kjH
 kjH
 kjH
@@ -319180,13 +319222,13 @@ qls
 wbg
 wbg
 wKT
-tCy
-eik
-bPv
+wBZ
+mTj
+ksK
 qRm
-bPv
+ksK
 qRm
-bPv
+ksK
 qRm
 wKT
 wbg
@@ -319980,7 +320022,7 @@ pMj
 pPI
 xdq
 xdq
-cbQ
+sIE
 wbg
 wbg
 wKT
@@ -319998,13 +320040,13 @@ wbg
 usR
 ncb
 ncb
-vgA
+kem
 wbg
 wVI
 wVI
 wVI
 wVI
-hnJ
+lJJ
 wVI
 wVI
 wbg
@@ -320382,25 +320424,25 @@ pOs
 pRW
 xdq
 qls
-wzZ
+jEe
 wbg
 wbg
 wKT
 wKT
 jCs
-bPv
-rHj
-bPv
-rHj
-bPv
-rHj
+ksK
+wFp
+ksK
+wFp
+ksK
+wFp
 wKT
 wbg
 wbg
 usR
 xAt
 xAt
-vHd
+vgA
 wbg
 kjH
 xxF
@@ -320783,7 +320825,7 @@ xdq
 xdq
 xdq
 xdq
-uMC
+xWw
 wbg
 wbg
 wbg
@@ -320801,7 +320843,7 @@ wbg
 wbg
 vAB
 bnQ
-fFL
+heK
 nWM
 wbg
 kjH
@@ -321185,7 +321227,7 @@ xMr
 xMr
 xMr
 xMr
-tCz
+qeY
 wbg
 wbg
 wbg
@@ -321587,7 +321629,7 @@ dCV
 csA
 dCV
 hXf
-cbQ
+sIE
 wbg
 wbg
 wbg
@@ -321989,7 +322031,7 @@ dCV
 dCV
 dCV
 qee
-wzZ
+jEe
 wbg
 wbg
 wbg
@@ -322795,11 +322837,11 @@ xMr
 xMr
 gGZ
 qCy
-iFY
+bfE
 wVI
 weX
 wVI
-lGI
+tJC
 wbg
 ekQ
 qDx
@@ -323196,7 +323238,7 @@ bmi
 mgx
 xMr
 xAt
-cfm
+wjj
 wbg
 wVI
 wVI
@@ -323599,11 +323641,11 @@ oVp
 xMr
 qnO
 oZC
-qYK
+qRp
 wVI
 xbo
 wVI
-lGI
+tJC
 wbg
 hOh
 qDx
@@ -324001,11 +324043,11 @@ nTe
 qhC
 wbg
 wbg
-qYK
+qRp
 wVI
 wVI
 wVI
-lGI
+tJC
 wbg
 hOh
 qDx
@@ -324401,7 +324443,7 @@ oXn
 oXn
 oXn
 xMr
-cyy
+bqu
 wbg
 wbg
 wVI
@@ -324803,13 +324845,13 @@ paz
 bmi
 bmi
 xMr
-uMC
+xWw
 wbg
-iFY
+bfE
 wVI
 weX
 wVI
-lGI
+tJC
 wbg
 lHf
 rfx
@@ -325205,7 +325247,7 @@ gVS
 gVS
 bmi
 xMr
-cbQ
+sIE
 wbg
 wbg
 wbg
@@ -325607,7 +325649,7 @@ poR
 pPs
 bmi
 qhR
-uMC
+xWw
 wbg
 wbg
 wbg
@@ -326033,7 +326075,7 @@ bJG
 wbg
 jpZ
 aOv
-gwz
+kMv
 aOv
 aOv
 aOv
@@ -326411,7 +326453,7 @@ orY
 orY
 bmi
 xMr
-cbQ
+sIE
 wbg
 wbg
 wbg
@@ -326434,7 +326476,7 @@ ewt
 cEF
 wbg
 xll
-sWG
+gHd
 aOn
 jHc
 mwE
@@ -326813,7 +326855,7 @@ bmi
 mou
 bmi
 xMr
-cbQ
+sIE
 wbg
 wbg
 wbg
@@ -327215,7 +327257,7 @@ xMr
 xMr
 xMr
 xMr
-tCz
+qeY
 wbg
 wbg
 wbg
@@ -328501,7 +328543,7 @@ kVc
 kVc
 hcW
 cWT
-bCb
+veW
 hcW
 hcW
 hcW
@@ -328902,8 +328944,8 @@ kVc
 kVc
 kVc
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -329304,8 +329346,8 @@ wxd
 kVc
 kVc
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -329706,8 +329748,8 @@ wxd
 kVc
 kVc
 kVc
-bCb
-bCb
+veW
+veW
 hcW
 hcW
 hcW
@@ -330020,9 +330062,9 @@ xKF
 xKF
 xKF
 xKF
-mTs
-dTa
-aPR
+oqs
+oys
+hbc
 xKF
 xKF
 xKF
@@ -330108,8 +330150,8 @@ xqL
 kVc
 kVc
 kVc
-bCb
-bCb
+veW
+veW
 hcW
 hcW
 hcW
@@ -330416,10 +330458,10 @@ uaL
 xAt
 xAt
 xKF
-nce
-wDZ
-wDZ
-qir
+ueS
+oRp
+oRp
+rHj
 xKF
 xKF
 eBN
@@ -330427,10 +330469,10 @@ eBN
 eBN
 iug
 iug
-pXo
+gse
 trI
-aem
-aem
+uHj
+uHj
 hcp
 tkZ
 xKF
@@ -330510,8 +330552,8 @@ wxd
 kVc
 kVc
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -330818,10 +330860,10 @@ paf
 xAt
 xAt
 xKF
-pOC
-wDZ
-wDZ
-qir
+xAh
+oRp
+oRp
+rHj
 xKF
 xKF
 ejY
@@ -330831,9 +330873,9 @@ iug
 iug
 ejY
 trI
-aem
+uHj
 rTm
-aem
+uHj
 obL
 xKF
 vtw
@@ -330912,8 +330954,8 @@ sJZ
 wxd
 wxd
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -331220,10 +331262,10 @@ afX
 xAt
 xAt
 xKF
-ksK
-wDZ
-wDZ
-qir
+uiv
+oRp
+oRp
+rHj
 xKF
 xKF
 xKF
@@ -331233,9 +331275,9 @@ xKF
 xKF
 xKF
 xKF
-aem
-aem
-aem
+uHj
+uHj
+uHj
 oiC
 xKF
 vtw
@@ -331314,8 +331356,8 @@ sJZ
 sJZ
 feP
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -331622,22 +331664,22 @@ paf
 xAt
 xAt
 xKF
-diV
-wDZ
-wDZ
-bor
+gvP
+oRp
+oRp
+rxS
 xKF
 ofq
 ofq
 xKF
-tEL
+quy
 ofq
 eBN
-aem
+uHj
 suN
-aem
+uHj
 bok
-aem
+uHj
 tkZ
 xKF
 vtw
@@ -331716,8 +331758,8 @@ sJZ
 sJZ
 wxd
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -332024,10 +332066,10 @@ paf
 xAt
 xAt
 xKF
-eip
-wDZ
-wDZ
-wtX
+nGn
+oRp
+oRp
+wLT
 xKF
 ofq
 ofq
@@ -332037,13 +332079,13 @@ ofq
 eBN
 bok
 suN
-aem
+uHj
 nrx
 idG
 obL
 xKF
 vtw
-vEN
+hKE
 wOR
 vtw
 eEC
@@ -332118,8 +332160,8 @@ qet
 sJZ
 wxd
 kVc
-bCb
-bCb
+veW
+veW
 kVc
 hcW
 hcW
@@ -332426,10 +332468,10 @@ paf
 xAt
 xAt
 xKF
-jyB
-wDZ
-kCZ
-xKZ
+bqt
+oRp
+sZk
+wLn
 xKF
 ofq
 ofq
@@ -332437,9 +332479,9 @@ wVy
 ofq
 ofq
 eBN
-aem
+uHj
 suN
-aem
+uHj
 iIl
 xKF
 xKF
@@ -332520,8 +332562,8 @@ qet
 qet
 wxd
 kVc
-bCb
-bCb
+veW
+veW
 hcW
 hcW
 hcW
@@ -332828,10 +332870,10 @@ paf
 xAt
 xAt
 xKF
-tUp
-tUp
+mdB
+mdB
 xKF
-bea
+xFL
 xKF
 xKF
 xKF
@@ -332841,13 +332883,13 @@ ofq
 eBN
 bok
 suN
-aem
+uHj
 tkZ
 xKF
 vtw
 vtw
 vtw
-vEN
+hKE
 gLx
 vtw
 rkf
@@ -332922,8 +332964,8 @@ qet
 qet
 wxd
 kVc
-bCb
-bCb
+veW
+veW
 hcW
 hcW
 hcW
@@ -333229,21 +333271,21 @@ uaL
 afX
 xAt
 xAt
-gTQ
+eTc
 fCM
 fCM
 cNo
 twX
 cNo
-kvj
+uVj
 eeO
 sKd
-aac
+vdj
 eBN
 eBN
-aem
+uHj
 suN
-aem
+uHj
 vCr
 xKF
 vtw
@@ -333631,20 +333673,20 @@ uaL
 paf
 xAt
 xAt
-gTQ
+eTc
 fCM
 fCM
 fCM
 fCM
-qwp
-wny
+sOY
+cPd
 dsW
 sKd
 xgL
-aem
-aem
-aem
-aem
+uHj
+uHj
+uHj
+uHj
 nrx
 obL
 xKF
@@ -334034,21 +334076,21 @@ uaL
 xAt
 xAt
 xKF
-oVn
+bsh
 iuo
 iuo
 iuo
-qwp
+sOY
 wPC
 dsW
 sKd
 xgL
-sSl
-aem
-aem
-aem
-aem
-aem
+huL
+uHj
+uHj
+uHj
+uHj
+uHj
 xKF
 vtw
 vWe
@@ -334436,21 +334478,21 @@ paf
 xAt
 xAt
 xKF
-bvV
-bvV
-bvV
+auL
+auL
+auL
 iuo
 fCM
 sKd
 sKd
 vSM
-oIv
-aem
-aem
+pBC
+uHj
+uHj
 wIl
 dXw
 uHg
-aem
+uHj
 xKF
 vtw
 vWe
@@ -334461,7 +334503,7 @@ vtw
 qZh
 ltk
 mwE
-gZv
+sLM
 mwE
 mwE
 aOv
@@ -334838,11 +334880,11 @@ paf
 xAt
 xAt
 xKF
-xvC
-hCo
-fQQ
+gof
+bON
+vLA
 iuo
-aIK
+oIv
 sKd
 sKd
 xKF
@@ -335248,7 +335290,7 @@ xKF
 xKF
 xKF
 xKF
-ojQ
+pkt
 eCn
 eCn
 xKF
@@ -383885,31 +383927,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-iSJ
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -383923,8 +383965,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384287,31 +384329,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-iSJ
-wYv
-sLD
-cNM
-xaD
-cZi
-wYv
-xaD
-xaD
-wYv
-wqq
-iSJ
-caL
-iSJ
-lsA
-caL
-caL
-fXP
-iSJ
-iSJ
-caL
-bPz
+dAf
+dAf
+dAf
+dAf
+xpM
+nvV
+gNz
+oiE
+uFp
+xpM
+oiE
+oiE
+xpM
+fxH
+dAf
+hJj
+dAf
+lhy
+hJj
+hJj
+woV
+dAf
+dAf
+hJj
+pzi
 erZ
 erZ
 erZ
@@ -384325,8 +384367,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384689,31 +384731,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-iSJ
-wYv
-sLD
-xFX
-xaD
-cZi
-wYv
-xaD
-xaD
-wYv
-ifg
-jeM
-jeM
-ifg
-wYv
-ydx
-ylw
-wYv
-hzz
-iSJ
-tXu
-bPz
+dAf
+dAf
+dAf
+dAf
+xpM
+nvV
+wra
+oiE
+uFp
+xpM
+oiE
+oiE
+xpM
+abZ
+wou
+wou
+abZ
+xpM
+doN
+ijW
+xpM
+lhd
+dAf
+nvr
+pzi
 erZ
 erZ
 erZ
@@ -384728,8 +384770,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385091,31 +385133,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-iSJ
-wYv
-wYv
-wYv
-wvI
-xaD
-wYv
-xaD
-xaD
-wYv
-khc
-uxZ
-iSJ
-sDa
-wYv
-cTP
-cTP
-wYv
-faN
-jMf
-jIP
-bPz
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+dbt
+oiE
+xpM
+oiE
+oiE
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+qDn
+qDn
+xpM
+wUw
+ukL
+cld
+pzi
 erZ
 erZ
 erZ
@@ -385130,8 +385172,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385493,31 +385535,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-iSJ
-wYv
-wYv
-wYv
-wvI
-cZi
-wYv
-xaD
-xaD
-wYv
-kbp
-iSJ
-iSJ
-uEX
-wYv
-sGf
-sGf
-wYv
-wYv
-wYv
-wYv
-wYv
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+dbt
+uFp
+xpM
+oiE
+oiE
+xpM
+wbT
+dAf
+dAf
+sbF
+xpM
+eWC
+eWC
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -385532,8 +385574,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385895,31 +385937,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-iSJ
-wYv
-wYv
-wYv
-bbA
-xaD
-wYv
-xaD
-xaD
-wYv
-dFx
-iSJ
-iSJ
-uEX
-wYv
-tsF
-iSJ
-wYv
-wYv
-wYv
-wYv
-wYv
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+egu
+oiE
+xpM
+oiE
+oiE
+xpM
+ehI
+dAf
+dAf
+sbF
+xpM
+lGI
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -385934,8 +385976,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385954,8 +385996,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 aUc
 vIa
 erZ
@@ -386297,31 +386339,31 @@ erZ
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-wYv
-wYv
-wYv
-wYv
-wYv
-qDq
-wYv
-wYv
-wYv
-wYv
-xot
-uxZ
-iSJ
-vRY
-wYv
-jeM
-jeM
-fXP
-iSJ
-tXu
-caL
-bPz
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+nfb
+xpM
+xpM
+xpM
+xpM
+kFr
+kvj
+dAf
+gbf
+xpM
+wou
+wou
+woV
+dAf
+nvr
+hJj
+pzi
 erZ
 erZ
 erZ
@@ -386336,8 +386378,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386356,9 +386398,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386699,31 +386741,31 @@ vIa
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-wYv
-eeA
-xaD
-esT
-xaD
-xaD
-oXj
-wYv
-bVk
-iSJ
-iSJ
-iSJ
-jeM
-ifg
-wYv
-iSJ
-iSJ
-wYv
-iSJ
-iSJ
-iSJ
-bPz
+dAf
+dAf
+dAf
+xpM
+gvi
+oiE
+dey
+oiE
+oiE
+sXG
+xpM
+hAc
+dAf
+dAf
+dAf
+wou
+abZ
+xpM
+dAf
+dAf
+xpM
+dAf
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -386738,8 +386780,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386757,10 +386799,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387101,31 +387143,31 @@ vIa
 erZ
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-wYv
-aBn
-xaD
-xaD
-xaD
-cZi
-iME
-wYv
-bVk
-iSJ
-dkx
-iSJ
-jUl
-ifg
-wYv
-tsF
-iSJ
-wYv
-igr
-dOj
-jIP
-bPz
+dAf
+dAf
+dAf
+xpM
+gba
+oiE
+oiE
+oiE
+uFp
+uXS
+xpM
+hAc
+dAf
+fqy
+dAf
+csE
+abZ
+xpM
+lGI
+dAf
+xpM
+loE
+tAs
+cld
+pzi
 erZ
 erZ
 erZ
@@ -387140,8 +387182,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387158,11 +387200,11 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387503,31 +387545,31 @@ vIa
 vIa
 erZ
 erZ
-iSJ
-iSJ
-iSJ
-wYv
-oJk
-xaD
-xaD
-cZi
-xaD
-iME
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-oLA
-oLA
-wYv
-wYv
-wYv
-wYv
-wYv
+dAf
+dAf
+dAf
+xpM
+jcT
+oiE
+oiE
+uFp
+oiE
+uXS
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ajD
+ajD
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -387543,7 +387585,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -387560,10 +387602,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387908,24 +387950,24 @@ erZ
 erZ
 erZ
 erZ
-wYv
-erz
-xaD
-xaD
-xaD
-xaD
-oXj
-wYv
-bmF
-nuH
-cBG
-esT
-cBG
-nuH
-exy
-xaD
-vOD
-nHd
+xpM
+iIA
+oiE
+oiE
+oiE
+oiE
+sXG
+xpM
+hjD
+lAK
+qzy
+dey
+qzy
+lAK
+mKz
+oiE
+pUQ
+htf
 erZ
 erZ
 erZ
@@ -387945,7 +387987,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -387961,9 +388003,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388310,24 +388352,24 @@ erZ
 erZ
 erZ
 erZ
-wYv
-lwO
-cZi
-xaD
-lpU
-xaD
-hjD
-wYv
-xaD
-kAi
-kAi
-xaD
-iWj
-iWj
-xaD
-cZi
-xaD
-nHd
+xpM
+vHh
+uFp
+oiE
+rGY
+oiE
+kTx
+xpM
+oiE
+xdw
+xdw
+oiE
+xAo
+xAo
+oiE
+uFp
+oiE
+htf
 erZ
 erZ
 erZ
@@ -388347,7 +388389,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -388363,9 +388405,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388712,24 +388754,24 @@ erZ
 erZ
 erZ
 erZ
-wYv
-qGh
-xaD
-bmF
-dVV
-xaD
-bqt
-wTs
-xaD
-cZi
-xaD
-cZi
-xaD
-xaD
-xaD
-xaD
-xaD
-nHd
+xpM
+qSE
+oiE
+hjD
+fHr
+oiE
+vQV
+gGF
+oiE
+uFp
+oiE
+uFp
+oiE
+oiE
+oiE
+oiE
+oiE
+htf
 erZ
 erZ
 erZ
@@ -388749,7 +388791,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -388765,9 +388807,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389114,24 +389156,24 @@ erZ
 erZ
 erZ
 erZ
-wYv
-cjJ
-xaD
-bmF
-wNv
-xaD
+xpM
+pdm
+oiE
 hjD
-wYv
-xaD
-tDN
-tDN
-xaD
-xaD
-pxP
-pxP
-xaD
-cZi
-nHd
+tnh
+oiE
+kTx
+xpM
+oiE
+iSJ
+iSJ
+oiE
+oiE
+nIq
+nIq
+oiE
+uFp
+htf
 erZ
 erZ
 erZ
@@ -389151,7 +389193,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -389167,9 +389209,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389516,24 +389558,24 @@ erZ
 erZ
 erZ
 erZ
-wYv
-cDG
-xaD
-xaD
-xaD
-xaD
-cRP
-wYv
-bmF
-cBG
-cBG
-exy
-vOD
-xaD
-cNM
-qRp
-xaD
-nHd
+xpM
+tSN
+oiE
+oiE
+oiE
+oiE
+tKf
+xpM
+hjD
+qzy
+qzy
+mKz
+pUQ
+oiE
+gNz
+nuH
+oiE
+htf
 erZ
 erZ
 erZ
@@ -389553,8 +389595,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389568,10 +389610,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389918,24 +389960,24 @@ erZ
 erZ
 erZ
 erZ
-wYv
-rDF
-xaD
-bmF
-dVV
-xaD
-cRP
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-rlu
-rlu
-wYv
+xpM
+uje
+oiE
+hjD
+fHr
+oiE
+tKf
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+pLK
+pLK
+xpM
 erZ
 erZ
 erZ
@@ -389955,8 +389997,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389970,10 +390012,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390320,28 +390362,28 @@ erZ
 erZ
 erZ
 erZ
-wYv
-cjJ
-xaD
-bmF
-wNv
-xaD
-mAb
-wYv
-sqI
-hjs
-gvi
-gMb
-gvi
-hjs
-gMb
-qRp
-xaD
-wYv
-wYv
-wYv
-wYv
-wYv
+xpM
+pdm
+oiE
+hjD
+tnh
+oiE
+uDw
+xpM
+vor
+rcr
+uVs
+fLK
+uVs
+rcr
+fLK
+nuH
+oiE
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -390358,7 +390400,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -390372,10 +390414,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390721,29 +390763,29 @@ erZ
 erZ
 aUc
 erZ
-wYv
-wYv
-wvI
-xaD
-xaD
-vmD
-xaD
-uvn
-wYv
-xaD
-xaD
-xaD
-xaD
-xaD
-xaD
-xaD
-eiE
-xaD
-fXP
-iSJ
-iSJ
-caL
-bPz
+xpM
+xpM
+dbt
+oiE
+oiE
+hzX
+oiE
+xwi
+xpM
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+vjs
+oiE
+woV
+dAf
+dAf
+hJj
+pzi
 erZ
 erZ
 erZ
@@ -390760,7 +390802,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -390774,10 +390816,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -391123,29 +391165,29 @@ vIa
 vIa
 aUc
 aUc
-wYv
-wYv
-wvI
-cZi
-xaD
-xaD
-xaD
-bqt
-wYv
+xpM
+xpM
+dbt
+uFp
+oiE
+oiE
+oiE
+vQV
+xpM
+pKQ
+oiE
+oiE
+lXh
+oiE
+vjs
+oiE
+oiE
+oiE
+xpM
+hNk
 dAf
-xaD
-xaD
-qpX
-xaD
-eiE
-xaD
-xaD
-xaD
-wYv
-hoa
-iSJ
-iSJ
-bPz
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -391162,7 +391204,7 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -391176,10 +391218,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -391525,62 +391567,62 @@ vIa
 vIa
 aUc
 aUc
+eoz
+eoz
+dbt
+rfd
+vQV
+oiE
+uFp
+oiE
+iAh
+oiE
+vjs
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+xpM
+lhd
+dAf
+dAf
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 ebe
 ebe
-wvI
-wtJ
-bqt
-xaD
-cZi
-xaD
-tQK
-xaD
-eiE
-xaD
-xaD
-xaD
-xaD
-xaD
-xaD
-xaD
-wYv
-hzz
-iSJ
-iSJ
-bPz
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-oJO
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -391928,61 +391970,61 @@ vIa
 vIa
 vIa
 aUc
+eoz
+eoz
+eoz
+vQV
+vQV
+oiE
+oiE
+yjl
+xId
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+vjs
+oiE
+xpM
+lGI
+dAf
+dAf
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 ebe
 ebe
 ebe
-bqt
-bqt
-xaD
-xaD
-sEa
-aLg
-xaD
-xaD
-xaD
-xaD
-xaD
-xaD
-eiE
-xaD
-wYv
-tsF
-iSJ
-iSJ
-bPz
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-oJO
-oJO
 erZ
 erZ
 erZ
@@ -392332,59 +392374,59 @@ vIa
 vIa
 aUc
 aUc
+eoz
+eoz
+hvo
+vQV
+vQV
+xpM
+xpM
+nJy
+nJy
+kOA
+nJy
+nuH
+oiE
+oiE
+oiE
+xpM
+ejA
+cld
+fsu
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 ebe
 ebe
-uUG
-bqt
-bqt
-wYv
-wYv
-ahS
-ahS
-mGh
-ahS
-qRp
-xaD
-xaD
-xaD
-wYv
-gQF
-jIP
-qzb
-bPz
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-oJO
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -392735,58 +392777,58 @@ vIa
 vIa
 aUc
 aUc
+eoz
+eoz
+eoz
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+yeA
+yeA
+yeA
+yeA
+xpM
+xpM
+xpM
+xpM
+xpM
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 ebe
 ebe
 ebe
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-adK
-adK
-adK
-adK
-wYv
-wYv
-wYv
-wYv
-wYv
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-oJO
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-oJO
-oJO
-oJO
 erZ
 erZ
 erZ
@@ -393141,7 +393183,7 @@ aUc
 aUc
 aUc
 aUc
-oJO
+ebe
 erZ
 erZ
 erZ
@@ -393172,9 +393214,9 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -393185,10 +393227,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -393576,20 +393618,20 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -393982,15 +394024,15 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -394385,13 +394427,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xwi
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394787,13 +394829,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xJe
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395165,12 +395207,12 @@ xKz
 xKz
 xKz
 xKz
-ydj
-wXy
-hKF
-xQH
-drL
-jvU
+lqm
+aen
+qof
+sXW
+maB
+qxO
 xKz
 erZ
 erZ
@@ -395189,13 +395231,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xwi
-pdm
-xwi
-mrQ
-pdm
-uHk
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395562,10 +395604,10 @@ erZ
 fVQ
 fVQ
 xKz
-lwy
-nYb
-nYb
-dyH
+tdJ
+tCz
+tCz
+qzx
 xKz
 fVQ
 fVQ
@@ -395591,13 +395633,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-pdm
-pdm
-xJe
-xwi
-pdm
-uHk
+cxZ
+jIP
+jIP
+eza
+eSt
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395972,14 +396014,14 @@ xKz
 fVQ
 fVQ
 jeb
-uvu
+mVz
 fVQ
-gqA
+xlb
 xKz
 fVQ
 bvN
 tYP
-pcQ
+kgt
 jeb
 erZ
 erZ
@@ -395993,13 +396035,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-pdm
-pdm
-xwi
-mrQ
-pdm
-uHk
+cxZ
+jIP
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -396370,18 +396412,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-xbW
+oir
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-xbW
+oir
 fVQ
 bvN
 tYP
-icE
+cRP
 jeb
 erZ
 erZ
@@ -396395,13 +396437,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xwi
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -396766,24 +396808,24 @@ erZ
 erZ
 erZ
 xKz
-fGt
-clR
+pLf
+cAj
 fVQ
 fVQ
 lLa
-vQV
+dfz
 jeb
-rBD
-cGa
-dCO
-jgo
+dpr
+fkr
+oJH
+xQv
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-fhk
+bcO
 jeb
 erZ
 erZ
@@ -396797,13 +396839,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xJe
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -397168,12 +397210,12 @@ erZ
 erZ
 erZ
 xKz
-mco
-clR
+oLF
+cAj
 fVQ
 fVQ
 lLa
-vQV
+dfz
 jeb
 xKz
 xKz
@@ -397185,7 +397227,7 @@ xKz
 fVQ
 tYP
 tYP
-myM
+jlk
 jeb
 erZ
 erZ
@@ -397199,13 +397241,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xwi
-pdm
-xwi
-mrQ
-pdm
-uHk
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -397570,24 +397612,24 @@ erZ
 erZ
 erZ
 xKz
-lQH
-clR
+vXz
+cAj
 fVQ
 fVQ
 fVQ
 fVQ
-xbW
+oir
 fVQ
-fxa
-wyU
-uDi
+xjp
+rxa
+uOc
 fVQ
-lff
+sBJ
 xKz
 fVQ
 bvN
 tYP
-pcQ
+kgt
 jeb
 erZ
 erZ
@@ -397601,13 +397643,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-pdm
-pdm
-xJe
-xwi
-pdm
-uHk
+cxZ
+jIP
+jIP
+eza
+eSt
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -397972,24 +398014,24 @@ erZ
 erZ
 erZ
 xKz
-ygs
-clR
+oTE
+cAj
 fVQ
-qwV
+fGX
 fVQ
 fVQ
 jeb
-bxo
+qEj
 fVQ
 fVQ
 fVQ
 fVQ
-kLV
+guS
 xKz
 fVQ
 bvN
 tYP
-icE
+cRP
 jeb
 erZ
 erZ
@@ -398003,13 +398045,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xwi
-pdm
-xwi
-mrQ
-pdm
-uHk
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -398378,20 +398420,20 @@ xKz
 xKz
 xKz
 xKz
-aWS
+mWn
 xKz
 xKz
-iBE
+wPd
 fVQ
 jeb
-uvu
+mVz
 fVQ
-seC
+fjW
 xKz
 fVQ
 tYP
 tYP
-fhk
+bcO
 jeb
 erZ
 erZ
@@ -398405,13 +398447,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xJe
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -398783,7 +398825,7 @@ fVQ
 fVQ
 fVQ
 xKz
-lGN
+rRM
 fVQ
 fVQ
 fVQ
@@ -398793,7 +398835,7 @@ xKz
 fVQ
 tYP
 tYP
-myM
+jlk
 jeb
 erZ
 erZ
@@ -398807,13 +398849,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-xwi
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -399185,17 +399227,17 @@ vZP
 lLa
 fVQ
 xKz
-kCe
-fWD
-vvk
-gGw
+brt
+hrk
+hOM
+cbo
 fVQ
-ntT
+tAT
 xKz
 fVQ
-lhd
+fIB
 tYP
-pcQ
+kgt
 jeb
 erZ
 erZ
@@ -399209,13 +399251,13 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-pdm
-pdm
-pdm
-pdm
-pdm
-uHk
+cxZ
+jIP
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -399585,7 +399627,7 @@ fVQ
 lLa
 noC
 lLa
-gqA
+xlb
 xKz
 xKz
 xKz
@@ -399595,7 +399637,7 @@ xKz
 xKz
 xKz
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 jeb
@@ -399611,10 +399653,10 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-pdm
+cxZ
+jIP
 xKz
-goz
+jrn
 bOK
 jeb
 xKz
@@ -399996,7 +400038,7 @@ fVQ
 fVQ
 xKz
 xKz
-aWS
+mWn
 xKz
 xKz
 xKz
@@ -400013,8 +400055,8 @@ erZ
 erZ
 erZ
 erZ
-sfZ
-pdm
+cxZ
+jIP
 jeb
 fVQ
 ugK
@@ -419269,7 +419311,7 @@ ygF
 ygF
 ygF
 ygF
-gMG
+rfO
 jYR
 lHe
 lHe
@@ -432129,8 +432171,8 @@ wAm
 wAm
 wAm
 wAm
-yiI
-yiI
+hTL
+hTL
 wAm
 wAm
 wAm
@@ -432528,22 +432570,22 @@ teW
 kwf
 nRx
 rwH
-uSx
+lMZ
 teW
 kqc
-dFv
+hEB
 jjS
-ejk
-wte
+svL
+vMQ
 vsf
 rwH
 nKu
 jiv
 rwH
 teW
-nJy
-nLx
-wte
+yjP
+dBO
+vMQ
 enq
 fZJ
 fZJ
@@ -432930,10 +432972,10 @@ teW
 dvD
 jiv
 jiv
-gyr
+uSx
 teW
-jti
-cLX
+obi
+vgH
 jiv
 jiv
 jiv
@@ -432944,9 +432986,9 @@ jiv
 jjS
 teW
 hqI
-xuF
+cwd
 hqI
-enq
+vZc
 fZJ
 fZJ
 fZJ
@@ -433334,8 +433376,8 @@ jiv
 jiv
 teW
 teW
-wte
-cLX
+vMQ
+vgH
 jiv
 jiv
 jiv
@@ -433346,11 +433388,11 @@ jiv
 vIX
 teW
 hqI
-xuF
+cwd
 hqI
-oFk
-oFk
-ebb
+cwd
+sAC
+qab
 fZJ
 fZJ
 fZJ
@@ -433731,7 +433773,7 @@ erZ
 fZJ
 fZJ
 teW
-mrE
+cBG
 jiv
 jiv
 hcx
@@ -433741,18 +433783,18 @@ jiv
 jiv
 jiv
 qfh
-kde
+uYU
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-xuF
+cwd
 hqI
-jFM
-jFM
-hbc
+cwd
+cwd
+eAm
 fZJ
 fZJ
 fZJ
@@ -434133,7 +434175,7 @@ erZ
 fZJ
 fZJ
 teW
-mrE
+cBG
 jiv
 jiv
 hcx
@@ -434142,19 +434184,19 @@ xSI
 jiv
 jiv
 jiv
-aBq
 nSr
+ojc
 htU
 teW
 ael
 hqI
 hqI
 hqI
-xuF
+cwd
 hqI
-jFM
-jFM
-iRN
+lVF
+cwd
+mCT
 fZJ
 fZJ
 fZJ
@@ -434535,28 +434577,28 @@ erZ
 fZJ
 fZJ
 teW
-mrE
+cBG
 vAK
 xSI
 tML
 wAm
 wAm
-tIZ
-tIZ
+kdg
+kdg
 wAm
-wAE
+vND
 tML
-wAE
+vND
 tML
 pDA
 hqI
 hqI
 hqI
-xuF
+cwd
 hqI
-jFM
-jFM
-iRN
+cwd
+cwd
+mCT
 fZJ
 fZJ
 fZJ
@@ -434948,17 +434990,17 @@ ntK
 gbA
 cAe
 cAe
-jHh
-teW
+bPv
+kqW
 ulu
 hqI
 fVE
-bAU
+hqI
 lLK
 hqI
-eBn
-eBn
-rBB
+cwd
+nfN
+wSl
 fZJ
 fZJ
 fZJ
@@ -435347,18 +435389,18 @@ lPt
 swm
 nyc
 ntK
-lYl
 tak
-tak
-tak
+qGh
+qGh
+qGh
 teW
 uNz
 hqI
 hqI
-xuF
-bON
+cwd
+wAL
 ojc
-enq
+itC
 fZJ
 fZJ
 fZJ
@@ -435749,10 +435791,10 @@ pLs
 swm
 nyc
 ntK
-tNi
 rSg
-rSg
-rSg
+jNV
+jNV
+jNV
 tML
 ajj
 lLK
@@ -436151,16 +436193,16 @@ vrG
 wtl
 ntK
 ntK
-nKG
+lYl
 xrf
 xrf
 xrf
-ohA
+wQn
 bcN
 bcN
 bcN
 vWe
-vdg
+put
 ffv
 fZJ
 fZJ
@@ -436551,7 +436593,7 @@ oBU
 sUQ
 xXs
 ntK
-kuG
+vFy
 ntK
 uTT
 swm
@@ -436952,19 +436994,19 @@ uKB
 aur
 uZa
 cPw
-pXF
+pho
 ntK
 ntK
-syA
+azR
 ybm
 ybm
 ybm
-ohA
+wQn
 bcN
 bcN
 bcN
 vWe
-auL
+siG
 ffv
 fZJ
 fZJ
@@ -437358,13 +437400,13 @@ swm
 nyc
 ntK
 gbA
-jHh
-jHh
-jHh
+bPv
+bPv
+bPv
 tML
 eYI
-vGN
-vGN
+uZC
+uZC
 wAm
 wAm
 ffv
@@ -437759,14 +437801,14 @@ oyP
 swm
 nyc
 ntK
-lYl
 tak
-tak
-tak
+qGh
+qGh
+qGh
 teW
-rma
-rma
-rma
+vWy
+vWy
+vWy
 tML
 tML
 tML
@@ -438161,14 +438203,14 @@ wAm
 aXE
 nyc
 ntK
-jGB
-ega
-ega
-olU
+pCH
+uRR
+uRR
+cMs
 teW
-dwO
-dwO
-dwO
+wpm
+wpm
+wpm
 wAm
 wAm
 wAm
@@ -438185,7 +438227,7 @@ squ
 squ
 squ
 rTC
-qKU
+jnO
 squ
 squ
 squ
@@ -438561,7 +438603,7 @@ tML
 teW
 tML
 tML
-xRu
+tox
 fnF
 wAm
 aGb
@@ -438575,7 +438617,7 @@ wpe
 fQd
 eCn
 sNY
-sat
+ggG
 teW
 teW
 teW
@@ -438587,7 +438629,7 @@ squ
 squ
 squ
 rTC
-qKU
+jnO
 rTC
 rTC
 rTC
@@ -438981,7 +439023,7 @@ eCn
 teW
 aor
 xfh
-uHj
+ebb
 teW
 squ
 squ
@@ -439377,8 +439419,8 @@ cfY
 cfY
 teW
 aTF
-dOE
-lyW
+sQI
+jAJ
 eCn
 mYi
 gbX
@@ -439779,8 +439821,8 @@ uZy
 cfY
 alk
 eCn
-xGj
-mVz
+pbg
+shJ
 eCn
 mYi
 gbX
@@ -440161,16 +440203,16 @@ erZ
 erZ
 erZ
 fZJ
-mjP
+vWY
 hIC
-mjE
+jBh
 uKB
 uBv
 tML
 tML
 tML
 xnv
-pMe
+hKt
 tML
 rMM
 cfY
@@ -440185,9 +440227,9 @@ eCn
 eCn
 eCn
 teW
-sQl
-puH
-arp
+aAo
+iVW
+wwM
 teW
 squ
 squ
@@ -440563,9 +440605,9 @@ erZ
 erZ
 erZ
 fZJ
-mjP
+vWY
 uKB
-oWT
+kcR
 uKB
 uKB
 uKB
@@ -440965,12 +441007,12 @@ erZ
 erZ
 erZ
 fZJ
-mjP
+vWY
 uKB
-bIM
+agV
 uKB
-ktb
-umS
+vox
+iDV
 uKB
 nIr
 swm
@@ -440989,8 +441031,8 @@ eCn
 teW
 mYi
 teW
-lMZ
-lMZ
+xJe
+xJe
 teW
 squ
 squ
@@ -441391,8 +441433,8 @@ teW
 teW
 eCn
 teW
-lMZ
-lMZ
+xJe
+xJe
 teW
 squ
 squ
@@ -441768,14 +441810,14 @@ vIa
 vIa
 aUc
 teW
-fuG
+jfV
 teW
-eMV
+fgH
 uKB
-hOC
-wwu
-nbI
-enQ
+wkw
+sdl
+xJb
+qsC
 tML
 swm
 swm
@@ -441793,8 +441835,8 @@ eCn
 fQd
 eCn
 teW
-lMZ
-lMZ
+xJe
+xJe
 teW
 eQa
 rTC
@@ -442170,10 +442212,10 @@ vIa
 vIa
 aUc
 teW
-sYW
+vyn
 teW
-pVO
-poP
+mhi
+eOo
 tML
 tML
 ydR
@@ -442189,15 +442231,15 @@ idu
 sct
 sNp
 cfY
-xzp
-vcf
-nvH
-oOV
+kuV
+tlQ
+oPp
+ecb
 eCn
 teW
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
 aUc
 aUc
 aUc
@@ -442578,26 +442620,26 @@ uKB
 uKB
 cgD
 tML
-veY
+bDN
 hqI
 pjB
 swm
 swm
 tML
-gqW
+qQw
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-xzp
-cZU
-rrd
-eBX
+kuV
+qYQ
+ilL
+tVu
 eCn
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -442974,11 +443016,11 @@ vIa
 vIa
 aUc
 teW
-toC
+aTn
 uKB
 uKB
 uKB
-jBN
+fEE
 tML
 gdJ
 hqI
@@ -442988,18 +443030,18 @@ lDq
 tML
 rMM
 eVa
-jeX
+xXc
 tcW
 tcW
 tcW
 eVa
-eLK
-eSt
-sXS
-duo
+alQ
+lLl
+hzl
+wMo
 eCn
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -443376,7 +443418,7 @@ vIa
 vIa
 aUc
 teW
-rLE
+pcQ
 nMd
 uKB
 uKB
@@ -443385,7 +443427,7 @@ tML
 tML
 tML
 wAm
-pMe
+hKt
 wAm
 wAm
 wAm
@@ -443401,7 +443443,7 @@ eCn
 grk
 eCn
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -443780,22 +443822,22 @@ aUc
 teW
 teW
 teW
-bzl
+iww
 uKB
 uKB
-fnP
+ept
 iYx
-iBo
-uzT
-uzT
-iYx
-iYx
+fGq
+vUf
+vUf
 iYx
 iYx
 iYx
-lMZ
-lMZ
-lMZ
+iYx
+iYx
+xJe
+xJe
+xJe
 teW
 teW
 teW
@@ -443803,7 +443845,7 @@ teW
 teW
 teW
 teW
-lMZ
+xJe
 lAs
 lAs
 vIa
@@ -444179,33 +444221,33 @@ vIa
 vIa
 vIa
 aUc
-lMZ
-lMZ
+xJe
+xJe
 teW
-umS
+iDV
 uKB
 uKB
-oRp
+syt
 iYx
 vaa
-uzT
-gFU
-iYx
-epI
-wDW
 vUf
+dmH
 iYx
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
-lMZ
+fVm
+eli
+llq
+iYx
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
 lAs
 lAs
 vIa
@@ -444582,22 +444624,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
+xJe
 teW
-meH
+qOT
 uKB
 uKB
-gEt
+sZv
 iYx
-oPp
-uzT
-uzT
+tcq
+vUf
+vUf
 iYx
-lZE
-uzT
-uzT
+cOL
+vUf
+vUf
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -444984,22 +445026,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
+xJe
 teW
-cQs
+anO
 uKB
 uKB
-kat
+pMn
 iYx
-cVn
-uzT
-uzT
-abZ
-uzT
-uzT
-uzT
+aVU
+vUf
+vUf
+jHv
+vUf
+vUf
+vUf
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -445386,22 +445428,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
+xJe
 teW
 teW
 teW
 teW
 teW
 iYx
-kkP
-uzT
-gBe
+baG
+vUf
+oqH
 iYx
-vlS
-tdJ
-sbF
+lXX
+jZY
+oLg
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -445788,22 +445830,22 @@ vIa
 vIa
 vIa
 lAs
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
 iYx
 iYx
 iYx
 iYx
-iBo
-uzT
-xhT
+fGq
+vUf
+rCc
 iYx
 iYx
 iYx
 iYx
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -446188,24 +446230,24 @@ vIa
 vIa
 vIa
 vIa
-mGn
+vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-xhT
-wse
+rCc
+mJg
 iYx
 iYx
-uzT
-gBe
-iYx
-epI
-wDW
 vUf
+oqH
 iYx
-lMZ
+fVm
+eli
+llq
+iYx
+xJe
 lAs
 lAs
 lAs
@@ -446594,20 +446636,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-lZE
-uzT
-abZ
-uzT
-uzT
-uzT
+cOL
+vUf
+jHv
+vUf
+vUf
+vUf
 iYx
-lZE
-uzT
-uzT
+cOL
+vUf
+vUf
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -446996,20 +447038,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-uzT
-uzT
+vUf
+vUf
 iYx
-uzT
-uzT
-uzT
-abZ
-uzT
-uzT
-uzT
+vUf
+vUf
+vUf
+jHv
+vUf
+vUf
+vUf
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -447398,20 +447440,20 @@ vIa
 lAs
 lAs
 lAs
-lMZ
+xJe
 iYx
-bFx
-sbF
+fmV
+oLg
 iYx
-uzT
-dbt
-uuz
+vUf
+hFs
+cPT
 iYx
-vlS
-tdJ
-sbF
+lXX
+jZY
+oLg
 iYx
-lMZ
+xJe
 lAs
 lAs
 lAs
@@ -447801,18 +447843,18 @@ vIa
 vIa
 vIa
 aUc
-pqg
+juf
 iYx
 iYx
 iYx
-gIV
+eDI
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-pqg
+juf
 aUc
 vIa
 vIa
@@ -448206,14 +448248,14 @@ aUc
 aUc
 iYx
 iYx
-jpw
+sSL
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-lMZ
+xJe
 aUc
 aUc
 vIa
@@ -448607,15 +448649,15 @@ vIa
 vIa
 aUc
 iYx
-jzT
-vWY
+eSE
+iqs
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-lMZ
+xJe
 vIa
 vIa
 vIa
@@ -449009,15 +449051,15 @@ vIa
 vIa
 aUc
 iYx
-rxp
-vWY
+qEq
+iqs
 tWY
 tWY
 iyd
 iyd
 iyd
 iYx
-lMZ
+xJe
 vIa
 vIa
 vIa
@@ -449411,15 +449453,15 @@ vIa
 vIa
 aUc
 iYx
-ryM
-aFh
-vGN
-vGN
-vGN
+iEB
+rPU
+uZC
+uZC
+uZC
 iYx
 iYx
 iYx
-lMZ
+xJe
 vIa
 vIa
 vIa
@@ -449815,13 +449857,13 @@ aUc
 iYx
 iYx
 iYx
-etq
-etq
-fzf
+vcA
+vcA
+ufN
 iYx
-lMZ
-lMZ
-lMZ
+xJe
+xJe
+xJe
 vIa
 vIa
 vIa
@@ -451813,16 +451855,16 @@ iyK
 iyK
 iyK
 iyK
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -452214,17 +452256,17 @@ iyK
 iyK
 iyK
 iyK
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -452617,16 +452659,16 @@ iyK
 iyK
 iyK
 iyK
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -453019,16 +453061,16 @@ iyK
 iyK
 iyK
 iyK
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
-itC
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -486391,36 +486433,36 @@ vIa
 aUc
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-aSD
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+obq
 erZ
 erZ
 erZ
@@ -486790,39 +486832,39 @@ vIa
 vIa
 vIa
 vIa
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iSJ
-vQG
-wYv
-wYv
-wYv
-caL
-iSJ
-iSJ
-iSJ
-caL
-fXP
-iSJ
-wYv
-lZC
-aev
-hre
-vzi
-fLK
-vzi
-xkD
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+aok
+xpM
+xpM
+xpM
+hJj
+dAf
+dAf
+dAf
+hJj
+woV
+dAf
+xpM
+rps
+rcx
+bYH
+kRI
+uxV
+kRI
+aPR
 erZ
 erZ
 erZ
@@ -487192,39 +487234,39 @@ vIa
 erZ
 erZ
 erZ
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iSJ
-oXt
-wYv
-wYv
-wYv
-iSJ
-iSJ
-dzV
-gbd
-gbd
-wYv
-iSJ
-tXU
-fLK
-jCr
-fLK
-jCr
-fLK
-fLK
-lHy
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+nmF
+xpM
+xpM
+xpM
+dAf
+dAf
+gEt
+flI
+flI
+xpM
+dAf
+ixg
+uxV
+mpr
+uxV
+mpr
+uxV
+uxV
+kFh
 erZ
 erZ
 erZ
@@ -487594,39 +487636,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iSJ
-iSJ
-uEX
-wYv
-khc
-lFG
-tiH
-iqP
-wYv
-wYv
-wYv
-fXP
-wYv
-nxC
-fLK
-fLK
-fLK
-fLK
-fLK
-brz
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+sbF
+xpM
+nBf
+sYv
+uxZ
+oiW
+xpM
+xpM
+xpM
+woV
+xpM
+ooP
+uxV
+uxV
+uxV
+uxV
+uxV
+sWi
 erZ
 erZ
 erZ
@@ -487996,39 +488038,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iSJ
-iSJ
-uEX
-wYv
-obq
-iSJ
-iSJ
-cMs
-wYv
-tsF
-eoz
-iSJ
-wYv
-fJb
-fbv
-vsl
-fLK
-fLK
-fLK
-xkD
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+sbF
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+lGI
+ycz
+dAf
+xpM
+uTc
+sug
+fwJ
+uxV
+uxV
+uxV
+aPR
 erZ
 erZ
 erZ
@@ -488398,39 +488440,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-fXP
-wYv
-wYv
-wYv
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+woV
+xpM
+xpM
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+ycz
+dAf
+dAf
 obq
-iSJ
-iSJ
-cMs
-wYv
-eoz
-iSJ
-iSJ
-aSD
-ivz
-uZC
-mmY
-kaH
-fLK
-jCr
-lHy
+mQA
+mzf
+tfW
+qoP
+uxV
+mpr
+kFh
 erZ
 erZ
 erZ
@@ -488800,39 +488842,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-wYv
-eza
-eza
-qFI
-wYv
-khc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+sGx
+sGx
+jtV
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+dAf
 uxZ
-iSJ
-sDa
-wYv
-iSJ
-tiH
-eoz
-aSD
+ycz
+obq
 wQI
-oQc
+plR
 wQI
-wNj
-fLK
-fLK
-brz
+anS
+uxV
+uxV
+sWi
 erZ
 erZ
 erZ
@@ -489202,39 +489244,39 @@ erZ
 erZ
 erZ
 erZ
-oJO
+ebe
 fIL
 wQD
 aUc
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-khc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nBf
+kvj
+dAf
+oiW
+xpM
+jpw
 uxZ
-iSJ
-iqP
-wYv
+uxZ
+tiH
+xpM
+dAf
+dAf
+dAf
 obq
-tiH
-tiH
-cMs
-wYv
-iSJ
-iSJ
-iSJ
-aSD
 wQI
 wQI
-aZS
-dUb
-fLK
-fLK
-xkD
+iPI
+sxM
+uxV
+uxV
+aPR
 erZ
 erZ
 erZ
@@ -489609,34 +489651,34 @@ eNY
 hby
 aUc
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+dAf
+ycz
+dAf
 obq
-iSJ
-iSJ
-cMs
-wYv
-obq
-iSJ
-iSJ
-cMs
-wYv
-iSJ
-eoz
-iSJ
-aSD
-art
+vaQ
 wQI
-art
-nnS
-fLK
-fLK
-lHy
+vaQ
+gaI
+uxV
+uxV
+kFh
 erZ
 erZ
 erZ
@@ -490012,33 +490054,33 @@ twI
 aUc
 aUc
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-dFx
-iSJ
-eza
-uEX
-wYv
-khc
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ehI
+dAf
+sGx
+sbF
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+lGI
+dAf
 uxZ
-iSJ
-sDa
-wYv
-tsF
-iSJ
-tiH
-wYv
-wYv
-wYv
-wYv
-vlE
-vlE
-vlE
-fDB
+xpM
+xpM
+xpM
+xpM
+iVA
+iVA
+iVA
+qyS
 erZ
 erZ
 erZ
@@ -490413,30 +490455,30 @@ twI
 twI
 twI
 aUc
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-oAX
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ryE
+kvj
+dAf
+gEt
+xpM
+ehI
+dAf
+dAf
+sbF
+xpM
+dAf
 uxZ
-iSJ
-dzV
-wYv
-dFx
-iSJ
-iSJ
-uEX
-wYv
-iSJ
-tiH
-iSJ
-iSJ
-iSJ
-gxA
-sRG
+dAf
+dAf
+dAf
+uPi
+bzl
 erZ
 erZ
 erZ
@@ -490814,31 +490856,31 @@ aUc
 aUc
 xGC
 oWI
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-taD
-uxZ
-iSJ
-iqP
-wYv
-obq
-iSJ
-iSJ
-cMs
-wYv
-iSJ
-iSJ
-iSJ
-iSJ
-qNO
-pMn
-sRG
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jEB
+kvj
+dAf
+oiW
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+dAf
+dAf
+dAf
+dAf
+wDZ
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -491216,31 +491258,31 @@ vIa
 aUc
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-dFx
-eza
-iSJ
-cMs
-wYv
-khc
-uxZ
-iSJ
-sDa
-wYv
-iSJ
-iSJ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ehI
+sGx
+dAf
 tiH
-iSJ
-gxA
-qgi
-ccT
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+dAf
+dAf
+uxZ
+dAf
+uPi
+saP
+bVa
 erZ
 erZ
 erZ
@@ -491615,34 +491657,34 @@ erZ
 erZ
 erZ
 bQB
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-obq
-iSJ
-iSJ
-uEX
-wYv
-uEX
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+dAf
+sbF
+xpM
+sbF
+uxZ
+uxZ
 tiH
-tiH
-cMs
-wYv
-tsF
-iSJ
-iSJ
-iSJ
-gxA
-pMn
-sRG
+xpM
+lGI
+dAf
+dAf
+dAf
+uPi
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -492017,34 +492059,34 @@ erZ
 erZ
 erZ
 bQB
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-khc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nBf
+kvj
+dAf
+mUC
+mUC
+mUC
+dAf
+dAf
+mUC
+mUC
 uxZ
-iSJ
-nku
-nku
-nku
-iSJ
-iSJ
-nku
-nku
-tiH
-iSJ
-iSJ
-cld
-ovj
-pMn
-sRG
+dAf
+dAf
+wWE
+vdg
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -492419,34 +492461,34 @@ erZ
 erZ
 erZ
 bQB
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-obq
-eza
-iSJ
-xnV
-wYv
-xot
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+sGx
+dAf
+lvF
+xpM
+kFr
+kvj
+dAf
+gbf
+xpM
+lGI
 uxZ
-iSJ
-vRY
-wYv
-tsF
-tiH
-iSJ
-iSJ
-iSJ
-ovj
-sRG
+dAf
+dAf
+dAf
+vdg
+bzl
 erZ
 erZ
 erZ
@@ -492821,37 +492863,37 @@ erZ
 erZ
 erZ
 bQB
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-obq
-iSJ
-eza
-iSJ
-fXP
-iSJ
-iSJ
-iSJ
-wYv
-wYv
-wYv
-wYv
-wYv
-rGY
-iSJ
-iSJ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+sGx
+dAf
+woV
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+cTb
+dAf
+dAf
 uLh
 uLh
-ggo
-ncI
+vFz
+gqj
 uLh
 erZ
 erZ
@@ -493223,39 +493265,39 @@ erZ
 erZ
 erZ
 bQB
-oJO
+ebe
 uXW
 oRe
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-mbG
-uxZ
-iSJ
-uFp
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-oJO
-oJO
-wYv
-iSJ
-eoz
-eoz
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nVf
+kvj
+dAf
+pDO
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ebe
+ebe
+xpM
+dAf
+ycz
+ycz
 uLh
-kAg
-bUi
-jvT
+ssD
+dSP
+oBF
 uLh
-fcE
+oMa
 erZ
 erZ
 erZ
@@ -493619,46 +493661,46 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 hqA
 pCW
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-wYv
-wYv
-wYv
-wYv
-wYv
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iSJ
-iSJ
-iSJ
-gip
-bUi
-bUi
-oOI
-ncI
-bUi
-bUi
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+dAf
+vxV
+dSP
+dSP
+tUp
+gqj
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -494016,13 +494058,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 lgg
 lgg
 lgg
@@ -494034,33 +494076,33 @@ lgg
 lgg
 lgg
 lgg
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-wYv
-wYv
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iSJ
-iSJ
-iSJ
-gip
-bUi
-bUi
-bUi
-gip
-bUi
-bUi
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+dAf
+vxV
+dSP
+dSP
+dSP
+vxV
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -494414,13 +494456,13 @@ vIa
 vIa
 vIa
 vIa
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 lgg
 lgg
 lgg
@@ -494440,29 +494482,29 @@ lgg
 lgg
 vIa
 vIa
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-tsF
-eoz
-iSJ
-gip
-bUi
-bUi
-bUi
-ncI
-bUi
-bUi
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+lGI
+ycz
+dAf
+vxV
+dSP
+dSP
+dSP
+gqj
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -494819,7 +494861,7 @@ vIa
 erZ
 erZ
 erZ
-oJO
+ebe
 lgg
 lgg
 lgg
@@ -494845,25 +494887,25 @@ vIa
 vIa
 vIa
 vIa
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-oJO
-wYv
-iFi
-lnl
-iSJ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+wyA
+ttW
+dAf
 uLh
-jit
-bUi
-bUi
+vPA
+dSP
+dSP
 uLh
-fcE
+oMa
 erZ
 erZ
 erZ
@@ -495249,22 +495291,22 @@ vIa
 vIa
 vIa
 aUc
-oJO
-wYv
-wcc
-wcc
-wcc
-wcc
-wcc
-wcc
-wcc
-qYw
-qYw
+ebe
+xpM
+xET
+xET
+xET
+xET
+xET
+xET
+xET
+woq
+woq
 uLh
 uLh
-kzc
-kzc
-mJa
+mIC
+mIC
+mEy
 erZ
 erZ
 erZ
@@ -495651,8 +495693,8 @@ vIa
 vIa
 vIa
 vIa
-oJO
-oJO
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -497273,14 +497315,14 @@ erZ
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -497670,19 +497712,19 @@ erZ
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498072,24 +498114,24 @@ erZ
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498474,24 +498516,24 @@ erZ
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498874,26 +498916,26 @@ sri
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -499276,26 +499318,26 @@ sri
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -499678,26 +499720,26 @@ sri
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -500080,26 +500122,26 @@ erZ
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -500482,26 +500524,26 @@ erZ
 erZ
 erZ
 erZ
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -500884,7 +500926,7 @@ erZ
 erZ
 erZ
 erZ
-kFh
+cLL
 iJC
 bOK
 nEd
@@ -500892,18 +500934,18 @@ nEd
 nEd
 bOK
 iJC
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -501286,7 +501328,7 @@ erZ
 erZ
 erZ
 erZ
-kFh
+cLL
 bOK
 fVQ
 fVQ
@@ -501294,18 +501336,18 @@ bmG
 fVQ
 fVQ
 bOK
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -501688,7 +501730,7 @@ erZ
 erZ
 erZ
 erZ
-kFh
+cLL
 nEd
 fVQ
 lgN
@@ -501696,18 +501738,18 @@ jJC
 lgN
 fVQ
 nEd
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -502090,7 +502132,7 @@ erZ
 erZ
 erZ
 erZ
-kFh
+cLL
 nEd
 fVQ
 qxZ
@@ -502104,12 +502146,12 @@ vxC
 vxC
 vxC
 ppx
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -502492,7 +502534,7 @@ erZ
 erZ
 erZ
 erZ
-kFh
+cLL
 nEd
 fVQ
 fVQ
@@ -502506,12 +502548,12 @@ fZJ
 fZJ
 fZJ
 kZS
-kFh
-kFh
-kFh
-kFh
-kFh
-kFh
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -543084,11 +543126,11 @@ qzV
 nLH
 pil
 aqS
-quL
+jYn
 fCM
 fCM
 fCM
-tUp
+mdB
 fCM
 nQU
 cGD
@@ -543877,8 +543919,8 @@ vIa
 vIa
 vIa
 vIa
-xET
-xET
+cbQ
+cbQ
 lAs
 woj
 qPA
@@ -544279,8 +544321,8 @@ vIa
 vIa
 vIa
 vIa
-xET
-xET
+cbQ
+cbQ
 lAs
 woj
 qPA
@@ -544681,8 +544723,8 @@ vIa
 vIa
 vIa
 vIa
-xET
-xET
+cbQ
+cbQ
 lAs
 woj
 qPA
@@ -545083,8 +545125,8 @@ vIa
 vIa
 vIa
 vIa
-xET
-xET
+cbQ
+cbQ
 lAs
 eJN
 bHY
@@ -545485,8 +545527,8 @@ vIa
 vIa
 vIa
 vIa
-xET
-xET
+cbQ
+cbQ
 lAs
 lAs
 lAs
@@ -545887,7 +545929,7 @@ vIa
 vIa
 vIa
 vIa
-xET
+cbQ
 vIa
 vIa
 vIa
@@ -546289,7 +546331,7 @@ vIa
 vIa
 vIa
 vIa
-xET
+cbQ
 vIa
 vIa
 vIa
@@ -546691,7 +546733,7 @@ vIa
 vIa
 vIa
 vIa
-xET
+cbQ
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,9 +7,8 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "aad" = (
 /turf/closed/mineral/rogue,
@@ -497,17 +496,13 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/fluff/wallclock{
-	pixel_y = -30
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -988,7 +983,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "adL" = (
 /obj/item/natural/stone,
@@ -1130,24 +1125,31 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ael" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "WHEAT"
 	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aev" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -1223,6 +1225,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"agj" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "agq" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "sheriff"
@@ -1271,6 +1281,20 @@
 /obj/structure/statue/saints/father,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ajl" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"ajm" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "ajo" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -1379,11 +1403,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "aok" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1395,6 +1419,10 @@
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
+/area/rogue/indoors/town/church/chapel)
+"aoB" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aoD" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1447,6 +1475,12 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"arv" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1524,14 +1558,12 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "woodsmprison"
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1623,7 +1655,7 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "axs" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -1641,11 +1673,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1728,6 +1761,17 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
+"aBA" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"aBY" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1820,6 +1864,13 @@
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"aFP" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "aFS" = (
 /obj/structure/chair/wood/rogue,
 /obj/item/rogueweapon/whip,
@@ -1832,10 +1883,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "aGb" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/bars,
+/turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/indoors/town/church/chapel)
 "aGO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
@@ -1879,6 +1928,26 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"aHA" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"aHF" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"aHI" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aHK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/tavern)
@@ -1979,6 +2048,12 @@
 "aKg" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves)
+"aKi" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "aKj" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
@@ -1986,6 +2061,14 @@
 "aKu" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/bath)
+"aKy" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aKH" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/dirt/road{
@@ -2019,6 +2102,14 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town)
+"aLq" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "aLG" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -2031,6 +2122,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"aLR" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "aMh" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -2077,7 +2175,7 @@
 	dir = 1;
 	pixel_y = -6
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "aNW" = (
 /obj/structure/table/wood,
@@ -2135,9 +2233,18 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/flora/roguetree/burnt,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2212,15 +2319,18 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "aSO" = (
 /obj/structure/fluff/walldeco/steward,
@@ -2329,6 +2439,15 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"aWR" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "aXa" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
@@ -2386,6 +2505,12 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"aYo" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town)
 "aZj" = (
 /obj/structure/table/vtable,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -2425,6 +2550,11 @@
 "baS" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
+"bbl" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "bbm" = (
 /obj/structure/flora/wildplant/wild_poppy,
 /turf/open/floor/rogue/grass,
@@ -2484,6 +2614,22 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"bei" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "ben" = (
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
@@ -2553,6 +2699,10 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"bgT" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
 "bgW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -2587,6 +2737,12 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"bhY" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2666,6 +2822,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"bkC" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "bkD" = (
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
@@ -2679,6 +2839,14 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/shop)
+"blx" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "blA" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/dirt/road{
@@ -2723,11 +2891,14 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2761,9 +2932,22 @@
 	icon_state = "border"
 	},
 /obj/structure/flora/roguegrass,
-/obj/item/natural/rock,
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	icon_state = "woodrailing"
+	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"bnU" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "bnV" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -2790,9 +2974,7 @@
 /area/rogue/under/cavewet/bogcaves/tomb)
 "bok" = (
 /obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "bow" = (
 /obj/structure/mineral_door/wood{
@@ -2840,6 +3022,10 @@
 /obj/item/pestle,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"bpA" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "bpD" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
@@ -2888,11 +3074,8 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -2985,6 +3168,11 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"btb" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3062,6 +3250,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"buQ" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "bvs" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/tongs,
@@ -3228,9 +3423,12 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/item/rogueweapon/mace/wsword,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"bzz" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
@@ -3261,6 +3459,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"bAs" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "bAw" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -3297,8 +3503,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/turf/closed/wall/mineral/rogue/wooddark/end,
-/area/rogue/outdoors/rtfield)
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3341,6 +3548,15 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
+"bEu" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "bEC" = (
 /obj/structure/lever/wall{
 	dir = 4;
@@ -3397,6 +3613,13 @@
 "bFU" = (
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"bGf" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "bGg" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
@@ -3438,11 +3661,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3519,6 +3740,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"bKg" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "bKi" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/concrete,
@@ -3546,10 +3776,20 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"bLV" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bMh" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"bMt" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "bMK" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road{
@@ -3580,10 +3820,22 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
 /obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"bNW" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bOh" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/metal/barograte,
@@ -3629,21 +3881,18 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
-"bPz" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
+"bPz" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"bPL" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3660,8 +3909,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "bQf" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "bQo" = (
 /obj/structure/stairs{
@@ -3746,6 +3998,9 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"bSF" = (
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "bSW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -3781,20 +4036,24 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"bUD" = (
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "bVa" = (
-/obj/structure/bed/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -3811,6 +4070,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"bVJ" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bWj" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -3888,6 +4151,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"bYK" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "bYM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -3931,6 +4202,12 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"caC" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4019,9 +4296,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4133,6 +4414,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"chs" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "chN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -4143,6 +4434,10 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors/town/tavern)
+"chY" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "cif" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4182,6 +4477,16 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"cix" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ciX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -4210,11 +4515,19 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cjJ" = (
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 1
+"cjy" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/rooftop,
+/area/rogue/indoors/town/garrison)
+"cjJ" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4267,12 +4580,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "woodsm"
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"clm" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/garrison)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4301,6 +4617,9 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"cmp" = (
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "cmB" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/shop)
@@ -4369,6 +4688,25 @@
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"coP" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "cpf" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -4561,9 +4899,10 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors/town/garrison)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4663,6 +5002,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"cxS" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cxW" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
@@ -4670,6 +5013,11 @@
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"cyK" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "czb" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
@@ -4743,11 +5091,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
 "cAe" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -4812,7 +5161,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/fermenting_barrel/random/water,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/storage/backpack/rogue/backpack/surgery,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
@@ -4836,7 +5189,9 @@
 "cCQ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "mason"
+	lockid = "mason";
+	max_integrity = 9999;
+	name = "The Door That Does Not Break"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -4850,9 +5205,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/machinery/light/rogue/torchholder/r,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
 /obj/structure/rack/rogue,
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "cDC" = (
 /obj/structure/rack/rogue,
@@ -5014,7 +5371,7 @@
 	pixel_x = -1;
 	pixel_y = 31
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "cIy" = (
 /obj/item/chair/stool/bar/rogue,
@@ -5098,18 +5455,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5127,12 +5475,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/natural/saddle,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5220,6 +5565,14 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"cPr" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "cPw" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -5284,12 +5637,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/cave)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5443,6 +5794,13 @@
 /obj/structure/floordoor/gatehatch/outer,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"cWr" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cWu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5573,6 +5931,15 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"cZP" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -5606,6 +5973,12 @@
 /obj/item/clothing/suit/roguetown/armor/plate/half,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"daJ" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "daO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/storage/roguebag,
@@ -5613,15 +5986,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "dbH" = (
-/obj/machinery/light/rogue/campfire,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -5658,6 +6029,21 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"dcE" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "dcF" = (
 /obj/structure/stairs{
 	dir = 1
@@ -5904,18 +6290,27 @@
 /obj/item/candle/skull/lit,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
+"djR" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "djX" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dkf" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/tongs,
 /obj/item/rogueweapon/hammer{
 	color = gold;
 	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
 	name = "Hammer of Malum"
 	},
+/obj/item/rogueweapon/tongs,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -6095,6 +6490,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"dqi" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dqq" = (
 /obj/structure/fluff/walldeco/innsign{
 	alpha = 200;
@@ -6111,6 +6510,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
+"dqD" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "dqU" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -6165,9 +6568,23 @@
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
 "dsW" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
+"dte" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dth" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
@@ -6255,13 +6672,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6294,6 +6711,21 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"dyi" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"dyu" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "dyD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/red,
@@ -6333,10 +6765,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6361,10 +6791,24 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"dBs" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4"
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dBt" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"dBA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6460,6 +6904,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dFU" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -6541,6 +6991,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"dJj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dJr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6551,12 +7010,26 @@
 	dir = 4
 	},
 /area/rogue/outdoors/bog)
+"dKn" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dKq" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"dKL" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "dKV" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/herringbone,
@@ -6640,11 +7113,8 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -6737,6 +7207,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"dPE" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "dPL" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/rogue/tile,
@@ -6745,6 +7223,10 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
+"dPZ" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "dQa" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -6774,6 +7256,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"dQz" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "dQJ" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
@@ -6861,10 +7351,8 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -6923,6 +7411,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dUX" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -6986,7 +7486,7 @@
 	dir = 10;
 	icon_state = "tablewood2"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "dXC" = (
 /obj/structure/fluff/railing/border{
@@ -7072,14 +7572,18 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/turf/open/floor/rogue/rooftop,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "ebe" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7259,8 +7763,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "eeO" = (
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
 "eeR" = (
 /obj/structure/window/plasma/reinforced/spawner{
@@ -7391,6 +7897,12 @@
 "eiV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"eiY" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "eja" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road{
@@ -7408,9 +7920,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "ejJ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "ejL" = (
 /obj/structure/bed/rogue,
@@ -7428,6 +7945,12 @@
 "ekI" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/shop)
+"ekK" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "ekQ" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -7461,6 +7984,17 @@
 "els" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"elE" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"elO" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "emp" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road{
@@ -7495,6 +8029,16 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"emT" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "emX" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -7517,7 +8061,7 @@
 	pixel_y = 7
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/town/roofs)
 "ent" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road{
@@ -7575,10 +8119,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/chest/reward,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -7690,6 +8233,13 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
+"ess" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "esv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -7719,6 +8269,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"ett" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "etu" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/butler{
@@ -7761,13 +8316,11 @@
 /area/rogue/indoors/shelter/rtfield)
 "euo" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/church/chapel)
 "eur" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "euC" = (
 /obj/structure/flora/roguegrass/bush,
@@ -7821,12 +8374,28 @@
 /area/rogue/indoors/town)
 "evw" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "evJ" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"evW" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
+"ewj" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ewq" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjailr"
@@ -7888,7 +8457,9 @@
 "eyJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "blacksmith"
+	lockid = "blacksmith";
+	max_integrity = 9999;
+	name = "Blacksmith Door"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -7901,9 +8472,17 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
+"ezc" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -7914,6 +8493,12 @@
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
+"ezK" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "eAh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
@@ -7923,6 +8508,14 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"eAG" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "eAW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -7978,6 +8571,13 @@
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"eCx" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "eCK" = (
 /obj/structure/flora/rogueshroom2,
 /turf/open/floor/rogue/grass,
@@ -8015,6 +8615,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
+"eEh" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "eEy" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -8036,6 +8643,12 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
+"eEY" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eFa" = (
 /obj/effect/landmark/start/wapprentice,
 /obj/structure/bed/rogue/shit,
@@ -8081,6 +8694,10 @@
 /obj/item/signal_horn,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"eGn" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eGD" = (
 /obj/item/natural/stone,
 /obj/item/natural/stone,
@@ -8161,6 +8778,22 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"eIm" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
+"eIA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "eIK" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -8271,6 +8904,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"eMR" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eNa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8362,6 +9002,24 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"eRE" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "eRQ" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/magelady_r,
@@ -8401,11 +9059,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8415,6 +9078,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
+"eSD" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"eTk" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 8
@@ -8440,6 +9115,13 @@
 	dir = 1
 	},
 /area/rogue/indoors)
+"eTX" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "eUb" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/town)
@@ -8546,9 +9228,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "eWj" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eWl" = (
@@ -8651,8 +9334,9 @@
 	dir = 1
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -8725,16 +9409,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "fdo" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
 "fdF" = (
 /obj/structure/table/wood{
@@ -8836,6 +9513,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"fhc" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fhg" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8926,6 +9615,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"fks" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/magician)
@@ -8979,6 +9675,13 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
+"fmh" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "fmm" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -9040,6 +9743,12 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fnW" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9159,6 +9868,11 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
+"ftd" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "ftw" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -9224,6 +9938,10 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fvP" = (
+/obj/structure/fluff/wallclock/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fwp" = (
 /obj/structure/bars,
 /turf/closed/mineral/rogue,
@@ -9419,7 +10137,7 @@
 /area/rogue/under/town/basement)
 "fBF" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "fBL" = (
 /obj/structure/flora/shroomstump,
@@ -9438,6 +10156,12 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"fCr" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "fCw" = (
 /obj/structure/chair/bench/coucha/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -9484,8 +10208,8 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -9604,6 +10328,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fIp" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fIw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
@@ -9621,13 +10349,9 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "fID" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -9662,6 +10386,16 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fJL" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -9710,18 +10444,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/apple,
-/obj/item/seeds/apple,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9748,6 +10473,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"fNp" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "fNw" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
@@ -9838,11 +10568,12 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/effect/landmark/events/testportal{
-	aportalloc = "woodsman"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -9899,6 +10630,23 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"fRO" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/rtfield)
+"fRS" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -9995,6 +10743,10 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fUW" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "fVa" = (
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/dirt/road{
@@ -10020,9 +10772,15 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/machinery/light/rogue/torchholder,
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
+"fVN" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10127,6 +10885,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
+"gaA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "gaC" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement)
@@ -10155,14 +10921,18 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gbN" = (
 /obj/structure/statue/saints/knight2,
 /turf/open/floor/rogue/blocks,
@@ -10262,10 +11032,23 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves)
+"gfg" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "gfl" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"gfE" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gfG" = (
 /obj/structure/mineral_door/secret/merchant,
 /turf/open/floor/rogue/tile/checkeralt,
@@ -10298,6 +11081,13 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"ggX" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/ruinedwood{
@@ -10319,9 +11109,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/fluff/walldeco/stone,
-/turf/closed/wall/mineral/rogue/decostone/cand,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -10493,12 +11282,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "goK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -10530,6 +11316,12 @@
 	icon_state = "glyph4"
 	},
 /area/rogue/indoors/town/church/chapel)
+"gpZ" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gqa" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10562,6 +11354,9 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
+/area/rogue/indoors/town)
+"gre" = (
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -10652,20 +11447,36 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"guw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "guH" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"guL" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "gvi" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -10903,6 +11714,18 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"gDl" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -10930,6 +11753,10 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"gEJ" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "gEL" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood{
@@ -10997,7 +11824,7 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "gGN" = (
 /obj/structure/winch{
@@ -11074,6 +11901,16 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"gJo" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "gJs" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -11154,6 +11991,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"gLV" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "gLY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -11255,6 +12098,20 @@
 /obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"gOY" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"gPt" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gPy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor)
@@ -11419,6 +12276,16 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"gTE" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "gTT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -11507,6 +12374,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"gXa" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "gXr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -11534,6 +12405,12 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"gYB" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gYC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -11631,12 +12508,13 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/machinery/light/rogue/smelter,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/turf/open/floor/rogue/metal,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -11679,9 +12557,7 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "hcq" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -11762,7 +12638,6 @@
 	},
 /area/rogue/indoors)
 "hdG" = (
-/obj/item/rogueweapon/sword/long/vlord,
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
@@ -11800,13 +12675,13 @@
 	pixel_x = 1;
 	pixel_y = 7
 	},
-/obj/machinery/light/rogue/smelter,
 /obj/structure/window/plasma/reinforced/spawner{
 	dir = 1;
 	icon = null;
 	max_integrity = 50000;
 	name = "RPW North"
 	},
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -11906,6 +12781,15 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"hgt" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "hgG" = (
 /obj/structure/stairs{
 	dir = 4
@@ -12109,14 +12993,23 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "hmU" = (
-/obj/structure/fluff/statue/myth{
-	desc = "A heroic figure that seems to be in mid-wink toward the viewer.";
-	name = "The Champion"
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hmV" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/concrete,
@@ -12229,12 +13122,18 @@
 "hpJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "blacksmith"
+	lockid = "blacksmith";
+	max_integrity = 9999;
+	name = "Blacksmith Door"
 	},
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"hpK" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hpO" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -12248,6 +13147,20 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"hpV" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "hpY" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/magician)
@@ -12304,6 +13217,10 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"hsa" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "hsg" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/churchrough,
@@ -12319,6 +13236,20 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"hsD" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "hsQ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -12331,16 +13262,24 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
@@ -12353,6 +13292,18 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"htF" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "htU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -12360,7 +13311,9 @@
 "htZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	desc = "Forges of Malum";
+	name = "Forges of Malum"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -12509,6 +13462,19 @@
 /obj/item/roguekey/manor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"hAe" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"hAf" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hAg" = (
 /obj/item/chair/rogue/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -12547,6 +13513,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"hCt" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hCu" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile{
@@ -12661,11 +13635,11 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/outdoors/mountains)
 "hGE" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12847,6 +13821,13 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"hMZ" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "hND" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
@@ -12908,6 +13889,16 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"hOS" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "hOY" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -13037,6 +14028,16 @@
 	dir = 1
 	},
 /area/rogue/outdoors/bog)
+"hSF" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hSK" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -13061,6 +14062,9 @@
 	dir = 6
 	},
 /obj/machinery/light/rogue/lanternpost,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "hUI" = (
@@ -13086,6 +14090,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"hVn" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hVo" = (
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/church,
@@ -13115,6 +14127,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "hXf" = (
@@ -13133,6 +14146,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"hXt" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hXu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -13140,6 +14161,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"hXE" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hYd" = (
 /turf/open/water/river{
 	dir = 1;
@@ -13233,6 +14264,11 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iaM" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "iaR" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13314,9 +14350,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "idR" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -13379,13 +14413,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -13418,6 +14447,14 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"ihj" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "iho" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -13489,6 +14526,17 @@
 "ike" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"ikk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "ikt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -13510,15 +14558,27 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"ilf" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ilm" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -13588,6 +14648,9 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
+"inf" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "int" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
@@ -13632,6 +14695,18 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"iqo" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -13681,6 +14756,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"irw" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "irz" = (
 /obj/structure/mineral_door/bars{
 	locked = 1
@@ -13709,26 +14794,25 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"isO" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "itv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
 	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -13736,12 +14820,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/obj/structure/stairs{
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving-t"
-	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
@@ -13834,6 +14917,10 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iwf" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -13842,6 +14929,10 @@
 "iwV" = (
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"ixl" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "ixt" = (
 /obj/item/grown/log/tree/small,
@@ -13943,6 +15034,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"izB" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "izL" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobblerock,
@@ -14031,6 +15128,10 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"iDe" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iDg" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/under/roguetown/trou,
@@ -14064,6 +15165,14 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iEd" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -14166,8 +15275,19 @@
 	dir = 5;
 	pixel_x = -6
 	},
+/obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
+"iGg" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "iGh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14202,9 +15322,7 @@
 /area/rogue/indoors/town/manor)
 "iIl" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "iIo" = (
 /obj/structure/bars/cemetery,
@@ -14223,6 +15341,15 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
+"iJu" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "iJC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -14340,15 +15467,12 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -14419,14 +15543,8 @@
 	},
 /area/rogue/indoors)
 "iOq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	icon_state = "woodrailing"
-	},
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cleanable/generic,
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "iOI" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -14487,7 +15605,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "iQh" = (
 /obj/structure/closet/crate/chest/crafted,
@@ -14516,14 +15634,13 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
 	},
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/thresher,
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "iRR" = (
 /obj/structure/table/wood{
@@ -14558,10 +15675,7 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "iTv" = (
@@ -14639,9 +15753,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14728,15 +15844,23 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iYF" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/shop)
 "iYQ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "iZl" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -14779,10 +15903,21 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"jaB" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jaF" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"jaR" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jaU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/naturalstone,
@@ -14931,6 +16066,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"jfz" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "jfF" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/woodturned,
@@ -14945,6 +16086,10 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"jfQ" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -14974,6 +16119,16 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"jgm" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jgs" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
@@ -14981,6 +16136,10 @@
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
+"jhf" = (
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -15091,14 +16250,20 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/item/roguekey/dungeon{
-	lockid = "woodsm";
-	name = "old key"
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
+"jme" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
@@ -15189,9 +16354,20 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
+"jpF" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/dwarfin)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -15269,6 +16445,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"jtc" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jtj" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -15343,6 +16523,13 @@
 	icon_state = "horzw"
 	},
 /area/rogue/under/town/basement)
+"jwj" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jwn" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -15432,6 +16619,14 @@
 /obj/structure/closet/crate/chest/reward,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"jzd" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"jzv" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jzy" = (
 /obj/structure/fluff/statue/tdummy,
 /obj/effect/decal/cleanable/blood/old,
@@ -15466,6 +16661,16 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"jAT" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "jAV" = (
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
@@ -15480,6 +16685,12 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jBO" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -15488,16 +16699,17 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
 /obj/structure/roguemachine/withdraw,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "jCt" = (
@@ -15579,18 +16791,31 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "jEB" = (
-/obj/structure/chair/bench{
+/obj/effect/decal/cobbleedge{
 	dir = 1;
-	icon_state = "bench"
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"jER" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"jEU" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jFa" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -15689,9 +16914,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -15943,6 +17167,12 @@
 "jQy" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
+"jQX" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jRk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -15968,6 +17198,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
 "jRR" = (
+/obj/structure/bars,
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
@@ -16014,6 +17245,12 @@
 "jTP" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"jTZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "jUk" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -16041,6 +17278,18 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
+"jVi" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"jWd" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -16063,6 +17312,16 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"jWX" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"jWZ" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -16142,6 +17401,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"jZi" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "jZn" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/tile,
@@ -16231,6 +17498,12 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
+"kcE" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "kcG" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -16242,12 +17515,27 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kds" = (
-/obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
+"kdb" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"kds" = (
+/obj/structure/table/wood,
+/obj/item/dice{
+	pixel_y = 13
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "kdM" = (
 /obj/structure/mineral_door/wood{
@@ -16300,7 +17588,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "kfr" = (
-/obj/machinery/light/rogue/forge,
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "kfv" = (
@@ -16357,9 +17646,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/flora/roguetree,
-/turf/open/water/swamp,
-/area/rogue/outdoors/rtfield)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -16448,10 +17740,25 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"kkT" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "kld" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"klm" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "klp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -16460,6 +17767,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"kmo" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "kms" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper,
@@ -16508,6 +17819,13 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"kpI" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kpZ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -16515,15 +17833,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "kqc" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -16537,6 +17849,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kqt" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kqI" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree,
@@ -16605,6 +17921,14 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"krZ" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16643,10 +17967,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -16737,10 +18060,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -16781,13 +18108,13 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -16801,6 +18128,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"kxz" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "kxB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16920,7 +18257,9 @@
 /area/rogue/outdoors/rtfield)
 "kBs" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/craftstone/window{
+	icon_state = "stonewindow"
+	},
 /area/rogue/indoors/town/garrison)
 "kBy" = (
 /obj/structure/mineral_door/wood{
@@ -16948,6 +18287,24 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"kBS" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kCh" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -17043,10 +18400,8 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -17071,17 +18426,6 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kFG" = (
 /obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/luckpot,
-/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,
-/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot,
-/obj/item/reagent_containers/glass/bottle/rogue/endurancepot,
-/obj/item/reagent_containers/glass/bottle/rogue/constitutionpot,
-/obj/item/reagent_containers/glass/bottle/rogue/alacritypot,
-/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot,
-/obj/item/reagent_containers/glass/bottle/rogue/virilitypot,
-/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,
-/obj/item/reagent_containers/glass/bottle/rogue/soporpot,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
 "kFS" = (
@@ -17140,7 +18484,10 @@
 "kIf" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
+"kIt" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "kIu" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -17239,6 +18586,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kLB" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -17310,7 +18664,7 @@
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_x = -31
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "kNv" = (
 /obj/effect/landmark/start/adventurer{
@@ -17434,6 +18788,14 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"kRw" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kRA" = (
 /obj/effect/landmark/start/mercenary{
 	dir = 4
@@ -17509,6 +18871,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"kTt" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -17630,6 +18996,13 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"kZn" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "kZr" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
@@ -17704,6 +19077,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"lbA" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lbB" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/scomstone,
@@ -17730,6 +19107,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ldc" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ldf" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -17778,6 +19159,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"lft" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -17853,17 +19242,26 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"lgX" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "lha" = (
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -17962,6 +19360,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"lku" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lkv" = (
 /obj/structure/fluff/dryingrack,
 /obj/item/needle/thorn,
@@ -18003,7 +19405,7 @@
 	lockid = "church";
 	name = "Temple of the One"
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "lmo" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -18021,6 +19423,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"lmP" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lmV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -18032,6 +19441,16 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"lmZ" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "lnq" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/cobble,
@@ -18077,14 +19496,10 @@
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
+	dir = 10;
+	icon_state = "largetable"
 	},
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -18286,10 +19701,24 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
+"lxc" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "lxe" = (
 /obj/structure/mirror/fancy,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"lxB" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lxQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -18314,6 +19743,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"lyW" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -18419,6 +19858,15 @@
 /obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"lBN" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lCn" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -18473,6 +19921,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"lEz" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "lEB" = (
 /obj/item/rogueweapon/spear/banner{
 	desc = "A blessed standard of Pestra, marking the Champion of her Healing Crafts.";
@@ -18539,11 +19994,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "lGI" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
@@ -18619,6 +20071,17 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"lJr" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "lJA" = (
 /obj/structure/chair/stool/rogue{
 	dir = 4
@@ -18647,7 +20110,8 @@
 "lKa" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "mason"
+	lockid = "mason";
+	max_integrity = 9999
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -18662,6 +20126,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"lKp" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
@@ -18695,7 +20175,7 @@
 /area/rogue/under/town/basement)
 "lLK" = (
 /obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -18720,14 +20200,35 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/obj/structure/bed/rogue/inn/hay,
-/obj/effect/landmark/start/vagrantlate,
-/turf/open/floor/rogue/herringbone,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/town/church/chapel)
+"lNn" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lOd" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"lOh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "lOl" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -18856,6 +20357,12 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"lUn" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lUv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -18879,6 +20386,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"lVo" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "lVE" = (
 /obj/structure/bars{
 	alpha = 190
@@ -18898,6 +20409,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"lWe" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "lWv" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/junglebush/b,
@@ -18927,6 +20450,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lXG" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "lXJ" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
@@ -18943,12 +20473,13 @@
 /area/rogue/under/town/sewer)
 "lYl" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "lYs" = (
 /obj/structure/mineral_door/wood{
@@ -19036,6 +20567,10 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mbt" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -19076,6 +20611,12 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mcY" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mdo" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19093,9 +20634,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -19138,6 +20680,12 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"men" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "mer" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
@@ -19206,6 +20754,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"mgR" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -19279,11 +20831,11 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -19448,6 +21000,12 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"mpQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mpX" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -19470,13 +21028,8 @@
 	},
 /area/rogue/indoors/town)
 "mrE" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "mrN" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -19498,6 +21051,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"mst" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "msw" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble,
@@ -19517,6 +21074,11 @@
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
 	},
@@ -19565,6 +21127,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
+"mvg" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mvp" = (
 /obj/structure/mineral_door/wood{
 	lockid = "townroom2"
@@ -19579,9 +21148,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "mwq" = (
-/obj/structure/well,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "mwz" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19745,10 +21313,11 @@
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
 "mDY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
+/obj/structure/ladder,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "mEg" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -19827,7 +21396,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
@@ -19835,6 +21404,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mGL" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "mHb" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -19927,6 +21500,10 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"mMB" = (
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "mMJ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -20050,17 +21627,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "mQA" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -20174,9 +21746,12 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -20208,6 +21783,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"mWP" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mWV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -20243,6 +21825,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"mXz" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "mYd" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -20285,6 +21874,33 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mZp" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"mZu" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"mZy" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mZE" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -20472,6 +22088,12 @@
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nfX" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -20495,14 +22117,12 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "woodsm"
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -20532,10 +22152,21 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"niJ" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "niU" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"niV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "njq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -20631,6 +22262,16 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"nnt" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "nnz" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -20685,6 +22326,15 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"nqe" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "nqf" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/blocks,
@@ -20743,9 +22393,7 @@
 /area/rogue/indoors/town)
 "nrx" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "nrD" = (
 /obj/structure/fermenting_barrel/beer,
@@ -20804,6 +22452,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"nux" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nuD" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
@@ -20823,11 +22475,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/candle,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -20970,10 +22622,11 @@
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
 "nyc" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/closed/wall/mineral/rogue/decostone/long{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "nyd" = (
 /obj/structure/glowshroom,
@@ -21051,11 +22704,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21123,6 +22773,21 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"nEp" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"nEA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "nFg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shield/wood,
@@ -21273,14 +22938,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/obj/structure/handcart,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/church,
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
@@ -21312,6 +22971,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/blocks{
 	icon_state = "newstone2"
 	},
@@ -21329,6 +22989,15 @@
 /obj/structure/roguewindow/stained/yellow,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"nLB" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "nLF" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/copper,
@@ -21374,6 +23043,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"nNy" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "nNJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -21504,18 +23184,10 @@
 	},
 /area/rogue/outdoors/rtfield)
 "nRo" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nRs" = (
 /obj/structure/bed/rogue/shit,
@@ -21549,9 +23221,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nSr" = (
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -21590,9 +23264,10 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -21603,6 +23278,17 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"nUr" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nUw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -21680,6 +23366,7 @@
 	dir = 9;
 	icon_state = "border"
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nWP" = (
@@ -21777,6 +23464,10 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town)
+"nYQ" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "nYR" = (
 /obj/item/roguebin/water/gross,
 /obj/machinery/light/rogue/torchholder{
@@ -21825,18 +23516,17 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"oaX" = (
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "obq" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -21851,13 +23541,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town/roofs)
+"obE" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "obL" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "obT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -21905,6 +23598,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"oda" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "odi" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
@@ -21941,6 +23640,15 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"oey" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oeI" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -21957,6 +23665,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -22005,15 +23714,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -22034,8 +23738,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "ohA" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	name = "Cathedral of Enigma"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -22075,14 +23780,33 @@
 "ohU" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
+"ohY" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"oiq" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oiC" = (
 /obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "oiD" = (
 /obj/effect/decal/remains/human,
@@ -22101,10 +23825,13 @@
 /area/rogue/indoors/town/manor)
 "ojc" = (
 /obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"oje" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ojp" = (
 /obj/structure/closet/dirthole/grave,
 /turf/closed/wall/mineral/rogue/stone,
@@ -22118,6 +23845,15 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"ojM" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -22199,6 +23935,15 @@
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
+"omS" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "one" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -22210,6 +23955,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
+"onl" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "onz" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -22220,7 +23969,7 @@
 /area/rogue/under/cavewet/bogcaves/tomb)
 "onR" = (
 /obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "onT" = (
 /obj/structure/table/wood{
@@ -22275,6 +24024,26 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"oqj" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
+"oqk" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -22388,6 +24157,16 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"oud" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "ouf" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -22410,11 +24189,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -22529,6 +24309,10 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"oyI" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "oyJ" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22549,6 +24333,13 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"oyU" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "oze" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/grass,
@@ -22781,6 +24572,14 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"oGH" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "oGI" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -22840,8 +24639,16 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"oIb" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "oIv" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -22870,11 +24677,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "oJO" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/garrison)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -22917,10 +24726,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 1
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -22970,6 +24778,11 @@
 "oNE" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
+"oOf" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "oOh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23086,11 +24899,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "oRs" = (
 /obj/structure/fluff/clock,
@@ -23177,10 +24990,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "oUn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "oUS" = (
 /obj/structure/roguewindow/openclose{
@@ -23328,6 +25147,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"oYd" = (
+/mob/living/simple_animal/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "oYq" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -23363,6 +25188,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"oZt" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oZC" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -23431,6 +25260,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"paK" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "pbe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -23502,6 +25337,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"pcC" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "pcK" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -23513,12 +25354,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
@@ -23533,13 +25370,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -23558,6 +25391,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"peB" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "peN" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -23842,6 +25679,15 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"ppb" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "ppi" = (
 /obj/structure/stairs{
 	dir = 1
@@ -23899,6 +25745,12 @@
 /obj/structure/fluff/walldeco/rpainting/forest,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
+"pqm" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "pqr" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -23912,6 +25764,20 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
+"pqI" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pqP" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -23937,6 +25803,10 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"prC" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "prN" = (
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/cobble,
@@ -24027,6 +25897,12 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/church/chapel)
+"puf" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "puj" = (
 /obj/structure/gate/bars{
 	gid = "forestgate2";
@@ -24059,6 +25935,11 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"pvC" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "pvI" = (
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/table/wood{
@@ -24091,6 +25972,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pwO" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pwQ" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/dirt,
@@ -24279,6 +26167,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"pCe" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "pCl" = (
 /obj/structure/handcart,
 /obj/item/grown/log/tree,
@@ -24309,17 +26204,30 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"pDm" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "pDy" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "pDA" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "pDF" = (
@@ -24368,6 +26276,18 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pFy" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -24486,9 +26406,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/item/reagent_containers/food/snacks/smallrat/dead,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -24543,9 +26464,12 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -24926,6 +26850,10 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"pYF" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "pYO" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
@@ -24954,6 +26882,10 @@
 /obj/effect/landmark/start/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"qaq" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "qas" = (
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/ruinedwood,
@@ -25047,6 +26979,12 @@
 /obj/structure/statue/saints/mother,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"qcK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "qcO" = (
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
@@ -25080,6 +27018,28 @@
 /obj/structure/closet/crate/roguecloset/inn/chest,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"qdu" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "qdB" = (
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/dirt/road{
@@ -25113,20 +27073,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7;
@@ -25197,6 +27147,16 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qhQ" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qhR" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -25229,6 +27189,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"qin" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -25323,8 +27291,10 @@
 /turf/closed/mineral/rogue/gem,
 /area/rogue/under/cavewet/bogcaves)
 "qls" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qlt" = (
 /obj/structure/rack/rogue/shelf/big,
@@ -25451,10 +27421,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qpt" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/garrison)
 "qpJ" = (
 /obj/structure/stairs/fancy/l{
 	dir = 1
@@ -25475,11 +27448,21 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -25571,9 +27554,21 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors/town/manor)
+"qrI" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qrN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"qsb" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "qse" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/remains/human,
@@ -25619,6 +27614,14 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"qtA" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
@@ -25659,18 +27662,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -25727,13 +27724,14 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck{
-	tame = 1
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -25808,17 +27806,30 @@
 	},
 /area/rogue/outdoors/bog)
 "qzy" = (
-/obj/structure/flora/tree/jungle/small,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
+"qzB" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
@@ -25854,6 +27865,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"qBr" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "qBu" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
@@ -25886,17 +27901,21 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3,
-/turf/open/floor/rogue/grass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/structure/flora/wildplant/wild_poppy,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -25944,11 +27963,21 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"qGh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+"qGb" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"qGh" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "qGD" = (
 /obj/structure/spider/stickyweb,
@@ -25990,6 +28019,14 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"qHJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qIi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/villager,
@@ -26054,6 +28091,14 @@
 "qKq" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cave)
+"qKr" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qKu" = (
 /obj/structure/bars{
 	alpha = 190
@@ -26061,11 +28106,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -26094,6 +28137,7 @@
 /area/rogue/indoors)
 "qLF" = (
 /obj/structure/roguewindow/stained/silver,
+/obj/structure/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/chapel)
 "qLP" = (
@@ -26117,12 +28161,30 @@
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"qNq" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"qNR" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"qOe" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "qOf" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -26192,6 +28254,15 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qQR" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -26211,17 +28282,16 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/metal,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "qRp" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -26301,11 +28371,26 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"qUQ" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qUX" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
+"qVz" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "qVD" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -26327,6 +28412,18 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"qWc" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "qWh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -26341,6 +28438,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"qXo" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -26385,10 +28489,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -26485,6 +28588,12 @@
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
+"rce" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "rcg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -26492,6 +28601,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"rch" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -26499,12 +28612,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/flora/roguetree,
-/obj/structure/flora/roguetree,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -26615,10 +28725,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -26648,14 +28760,15 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -26730,6 +28843,10 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"rjQ" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rjZ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -26771,6 +28888,13 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"rlG" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26817,8 +28941,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rmJ" = (
-/obj/structure/flora/wildplant/wild_herbs,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "rmK" = (
 /obj/structure/flora/wildplant/wild_herbs,
@@ -27148,6 +29275,7 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "rxp" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rxq" = (
@@ -27326,7 +29454,7 @@
 	dir = 5;
 	icon_state = "border"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "rEA" = (
 /obj/structure/bed/rogue/shit/bier,
@@ -27386,19 +29514,21 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "rHM" = (
@@ -27464,6 +29594,7 @@
 /area/rogue/indoors/town/dwarfin)
 "rKn" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -27504,6 +29635,17 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"rMj" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "rMl" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -27576,6 +29718,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"rOi" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rOt" = (
 /obj/structure/stairs{
 	dir = 1;
@@ -27644,6 +29791,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"rQE" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
@@ -27662,8 +29817,13 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rRB" = (
 /obj/structure/stairs{
@@ -27678,22 +29838,22 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church/mid{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rSn" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -27742,9 +29902,7 @@
 "rTm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "rTv" = (
 /obj/structure/fluff/traveltile/vampire{
@@ -27787,11 +29945,15 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -27951,6 +30113,18 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"rZn" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rZs" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -28017,12 +30191,20 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/roguemachine/withdraw{
-	pixel_x = -1;
-	pixel_y = 31
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -28077,7 +30259,7 @@
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "sdj" = (
 /obj/structure/fluff/railing/border{
@@ -28128,17 +30310,23 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"sep" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "sey" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -28373,6 +30561,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"smn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "smt" = (
 /obj/item/grown/log/tree/small,
 /obj/structure/fluff/railing/wood,
@@ -28483,6 +30676,16 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"spD" = (
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "spJ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/dirt,
@@ -28620,6 +30823,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"suC" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "suG" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors/town)
@@ -28635,9 +30842,7 @@
 /area/rogue/outdoors/beach)
 "suN" = (
 /obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "suY" = (
 /obj/structure/fluff/railing/border{
@@ -28647,6 +30852,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"svd" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "svx" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -28686,6 +30898,15 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"swT" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"swU" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "swX" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/cobblerock,
@@ -28701,29 +30922,23 @@
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"sxJ" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "sxM" = (
-/obj/structure/fluff/walldeco/painting/queen{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
 	icon_state = "barsbent";
-	layer = 2.81
+	layer = 2.81;
+	max_integrity = 99999
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -28853,10 +31068,10 @@
 /area/rogue/outdoors/town)
 "sDa" = (
 /obj/effect/decal/cobbleedge{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -29006,13 +31221,15 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -29043,6 +31260,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"sKt" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sKL" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -29069,9 +31296,18 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "sLc" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"sLu" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -29133,6 +31369,12 @@
 "sPu" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"sPD" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sPH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -29150,6 +31392,21 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"sPR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sPZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -29164,6 +31421,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"sQD" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -29186,6 +31448,14 @@
 /obj/item/reagent_containers/powder,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
+"sSu" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "sSC" = (
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -29311,6 +31581,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"sWc" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
@@ -29327,6 +31601,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"sWX" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "sXa" = (
 /obj/effect/landmark/start/hand{
 	dir = 8
@@ -29389,6 +31667,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"sZw" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -29403,10 +31689,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "tat" = (
 /obj/structure/fluff/railing/border{
@@ -29509,6 +31799,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tdz" = (
@@ -29575,13 +31866,9 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -29640,10 +31927,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/turf/closed/wall/mineral/rogue/decostone/end{
-	dir = 4
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -29685,6 +31971,12 @@
 /obj/item/rogueweapon/flail/sflail,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"tkn" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tkq" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -29739,9 +32031,7 @@
 /obj/structure/chair/bench/church{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "tlb" = (
 /obj/structure/roguewindow,
@@ -29754,9 +32044,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -29838,6 +32131,14 @@
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
+"tpi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29883,6 +32184,10 @@
 /obj/structure/roguemachine/money/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"tro" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "trv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "royal";
@@ -29921,6 +32226,13 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"tsI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -30051,10 +32363,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "twX" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "txa" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -30074,6 +32387,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"txm" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "txC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -30087,10 +32404,24 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"txD" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "txR" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"tyd" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tyl" = (
 /obj/structure/dye_bin,
 /turf/open/floor/rogue/ruinedwood,
@@ -30205,6 +32536,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tAL" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tAN" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/blocks,
@@ -30224,11 +32562,21 @@
 /obj/item/clothing/cloak/tabard/knight/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"tBm" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "tBA" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"tBC" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tBH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 8
@@ -30298,12 +32646,23 @@
 /obj/structure/mineral_door/secret/vault,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"tDc" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "tDf" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/outdoors/town/roofs)
 "tDl" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/under/town/basement)
+"tDm" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "tDo" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -30313,8 +32672,33 @@
 /area/rogue/outdoors/rtfield)
 "tDq" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"tDE" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "tDJ" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -30450,6 +32834,13 @@
 /obj/item/roguegem/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"tIc" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tIi" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -30487,13 +32878,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -30525,6 +32912,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"tLq" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -30662,6 +33055,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"tQZ" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -30674,6 +33073,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"tRt" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "tRV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -30694,6 +33099,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tSM" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "tTb" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0;
@@ -30734,12 +33143,14 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
 	},
-/turf/open/water/swamp,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
@@ -30748,9 +33159,16 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/item/candle/lit,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -30831,6 +33249,16 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"tYe" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -30884,16 +33312,24 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
-"uaj" = (
-/obj/structure/fluff/grindwheel,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"uac" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
+"uaj" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -31116,9 +33552,29 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"ujy" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ujO" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
+"ujT" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"ujU" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "ujX" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -31169,7 +33625,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "ulu" = (
-/obj/machinery/light/rogue/firebowl,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/seeds/sweetleaf,
+/obj/item/seeds/sweetleaf,
+/obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "ulY" = (
@@ -31210,6 +33672,12 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"uoi" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uot" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -31281,6 +33749,10 @@
 "uqe" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
+"uqf" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "uqs" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -31305,16 +33777,19 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
+"urG" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -31368,6 +33843,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"usp" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ust" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/tribalfort)
@@ -31468,11 +33953,21 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
-"uvu" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 8
+"uvj" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"uvu" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -31488,14 +33983,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
 "uwa" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "woodsm"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -31544,22 +34036,24 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/stairs{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/obj/item/candle,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -31609,11 +34103,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31684,8 +34179,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "uBv" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "uBE" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -31732,9 +34227,12 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -31745,6 +34243,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uDD" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "uDM" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -31755,6 +34261,13 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
+"uEk" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "uEG" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31769,16 +34282,29 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"uFz" = (
+/obj/structure/gate/bars{
+	gid = "viking1";
+	redstone_id = "viking1"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -31850,23 +34376,19 @@
 /area/rogue/indoors/town/church/chapel)
 "uHg" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHh" = (
 /obj/structure/feedinghole,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uHk" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -31902,6 +34424,10 @@
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
+"uKJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uKK" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -31984,6 +34510,13 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
+"uMi" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uMA" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow/lit,
@@ -32050,7 +34583,7 @@
 "uPa" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
@@ -32125,6 +34658,14 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"uRy" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -32139,14 +34680,17 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/rtfield)
 "uSx" = (
-/obj/structure/rack/rogue,
-/obj/item/storage/backpack/rogue/backpack/surgery,
-/obj/item/needle,
-/obj/item/rope,
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"uSF" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uSS" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
@@ -32167,6 +34711,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"uTo" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "uTH" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -32178,10 +34728,8 @@
 /area/rogue/indoors/town/dwarfin)
 "uTT" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -32247,6 +34795,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"uVR" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uVU" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
@@ -32270,7 +34824,7 @@
 	},
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "uXb" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -32368,10 +34922,6 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "uZD" = (
@@ -32461,6 +35011,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vcF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -32468,9 +35026,11 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "vdg" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -32498,6 +35058,13 @@
 "veg" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
+"veo" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vey" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/oat,
@@ -32545,9 +35112,30 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"vfg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -32571,6 +35159,11 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomright,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"vfT" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vfV" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -32580,6 +35173,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vgy" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vgz" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -32605,6 +35203,15 @@
 	},
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors)
+"vhx" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vhA" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -32660,11 +35267,12 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/obj/structure/mineral_door/wood/window{
-	lockid = "woodsm"
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors)
+/area/rogue/under/cave)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -32714,6 +35322,19 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"vlp" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "vlK" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
@@ -32736,6 +35357,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"vmi" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vmx" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/blocks,
@@ -32772,6 +35405,16 @@
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
+"vnH" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vnK" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/grown/log/tree/stick,
@@ -32792,6 +35435,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/tomb)
+"voh" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "voi" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -32811,11 +35458,16 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -32847,6 +35499,13 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
+"vpZ" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "vqc" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -32913,9 +35572,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -32954,6 +35618,16 @@
 "vtw" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church/chapel)
+"vtB" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vtE" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/item/grown/log/tree/small,
@@ -33066,6 +35740,11 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"vwm" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "vwJ" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
@@ -33253,9 +35932,7 @@
 /obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "vCs" = (
 /obj/effect/decal/cobbleedge{
@@ -33375,21 +36052,20 @@
 	},
 /area/rogue/outdoors/beach)
 "vFj" = (
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
@@ -33409,15 +36085,20 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "vGQ" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "vGT" = (
 /obj/structure/spacevine,
@@ -33429,9 +36110,15 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"vHi" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -33455,8 +36142,8 @@
 "vIX" = (
 /obj/structure/roguemachine/scomm/r,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
 "vJb" = (
@@ -33487,6 +36174,15 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"vKP" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vKQ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -33497,7 +36193,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/turf/open/floor/rogue/blocks,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "vLD" = (
 /obj/structure/rack/rogue,
@@ -33535,7 +36232,6 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "vMQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
 	dir = 4;
 	layer = 2.8;
@@ -33607,10 +36303,14 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/flora/roguegrass,
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -33652,9 +36352,11 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/metal,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -33698,8 +36400,13 @@
 	},
 /area/rogue/outdoors/bog)
 "vSM" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "vSQ" = (
 /obj/structure/stairs/stone{
@@ -33740,6 +36447,14 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"vTy" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "vTK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
@@ -33750,9 +36465,15 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -33761,6 +36482,15 @@
 "vUT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"vUV" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "vUX" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/shop)
@@ -33780,6 +36510,12 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vVX" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vWa" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -33828,19 +36564,28 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "vXm" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/blocks,
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	icon_state = "paving"
+	},
 /area/rogue/outdoors/town)
+"vXE" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "vXF" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -33884,6 +36629,14 @@
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"vZt" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "vZv" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/chaincoif,
@@ -33923,6 +36676,9 @@
 "wan" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
+"waz" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "waE" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -33965,6 +36721,17 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"wbx" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
+"wbF" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -34026,9 +36793,10 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
 "wew" = (
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "weB" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -34067,8 +36835,13 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
@@ -34094,6 +36867,11 @@
 "whb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
+"whe" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "whx" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -34149,6 +36927,10 @@
 "wlq" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
+"wlC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wlD" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
@@ -34169,12 +36951,29 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town)
+"wlO" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "wlU" = (
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"wlY" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wmj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -34208,6 +37007,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "wnv" = (
+/obj/structure/roguewindow,
 /obj/structure/bars,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
@@ -34226,14 +37026,16 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "wou" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -34261,9 +37063,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -34280,8 +37083,16 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
-/obj/structure/flora/roguetree,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "wqE" = (
 /obj/structure/fluff/traveltile{
@@ -34304,25 +37115,36 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"wqU" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wra" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
+"wru" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "wsR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34334,8 +37156,11 @@
 /area/rogue/outdoors/bog)
 "wte" = (
 /obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -34344,7 +37169,7 @@
 	dir = 8;
 	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "wty" = (
 /obj/effect/decal/cobbleedge,
@@ -34447,11 +37272,22 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"wxY" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "wxZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/bench,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"wyq" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "wyr" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -34461,16 +37297,9 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -34483,6 +37312,14 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"wza" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -34490,6 +37327,12 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"wzC" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "wzL" = (
 /obj/structure/fluff/railing/fence,
 /obj/structure/fluff/railing/fence{
@@ -34504,6 +37347,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"wzZ" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -34633,13 +37483,7 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
@@ -34647,9 +37491,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/well/fountain,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -34670,6 +37517,10 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"wEL" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "wER" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -34691,10 +37542,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -34756,13 +37605,21 @@
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "wIt" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
 	},
 /area/rogue/outdoors/bog)
+"wIH" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"wIU" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "wJm" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/dirt/road{
@@ -34814,6 +37671,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"wKi" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wKl" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
@@ -34858,6 +37722,12 @@
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
+"wLB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wLL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -34891,6 +37761,12 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
+"wMm" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "wMn" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/shirt/undershirt/random,
@@ -34910,6 +37786,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"wMG" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wNb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bog)
@@ -34931,6 +37811,13 @@
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"wNW" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "wOm" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/ruinedwood,
@@ -34938,6 +37825,16 @@
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
+"wOG" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -34973,6 +37870,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"wPo" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wPt" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw"
@@ -35025,7 +37926,8 @@
 /area/rogue/indoors)
 "wQn" = (
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
+	lockid = "church";
+	name = "Cathedral of Enigma"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
@@ -35033,6 +37935,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
+"wQC" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "wQD" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -35053,6 +37959,15 @@
 /obj/structure/roguemachine/vendor,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/shop)
+"wQW" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "wQY" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -35077,26 +37992,19 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "wSJ" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"wSN" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "wSO" = (
 /turf/open/floor/rogue/blocks{
 	icon_state = "paving"
@@ -35107,12 +38015,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -35134,11 +38039,24 @@
 "wTU" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
-"wUw" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+"wUh" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
 /area/rogue/indoors/town/church/chapel)
+"wUw" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -35180,6 +38098,19 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
+"wWL" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "wXf" = (
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -35226,13 +38157,14 @@
 	},
 /obj/effect/landmark/start/churchling,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -35271,12 +38203,14 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1;
-	pixel_y = -6
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -35290,12 +38224,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xbo" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/obj/structure/well/fountain,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xbr" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -35321,17 +38251,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -35380,28 +38302,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/structure/closet/crate/chest,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/natural/stone,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -35435,9 +38343,14 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/basement)
 "xfh" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
@@ -35476,6 +38389,10 @@
 /obj/item/burial_shroud,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"xgG" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xgL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -35507,6 +38424,20 @@
 "xhF" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"xhI" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "xhM" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/rtfield)
@@ -35564,6 +38495,13 @@
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"xiE" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "xiK" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/sewer,
@@ -35617,6 +38555,17 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"xjJ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xjP" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -35625,9 +38574,11 @@
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/obj/structure/bed/rogue,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -35655,6 +38606,23 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"xlg" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"xli" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "xll" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobblerock,
@@ -35683,6 +38651,16 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"xmB" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "xna" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -35710,8 +38688,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xnv" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -35773,6 +38753,12 @@
 "xou" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"xoQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "xoR" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -35816,7 +38802,15 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/rack/rogue,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "xqo" = (
 /obj/item/ingot/iron,
@@ -35855,14 +38849,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "xrf" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
+/obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xrg" = (
 /obj/structure/rack/rogue/shelf,
@@ -36034,15 +39024,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -36078,6 +39061,20 @@
 "xxa" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/shop)
+"xxe" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "xxp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -36104,6 +39101,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"xxS" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "xxT" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/churchrough,
@@ -36173,12 +39176,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -36319,6 +39322,13 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/beach)
+"xDd" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "xDi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
@@ -36362,16 +39372,19 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xET" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+"xEG" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/garrison)
+"xET" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -36444,18 +39457,18 @@
 /area/rogue/indoors/town/shop)
 "xGM" = (
 /obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "xGW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xHe" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36474,6 +39487,9 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
+"xHy" = (
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "xHC" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
@@ -36485,6 +39501,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"xHV" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "xHX" = (
 /obj/effect/landmark/start/vagrant,
 /obj/structure/bed/rogue/shit{
@@ -36512,9 +39536,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "xJe" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36579,6 +39603,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"xLH" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xLK" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -36598,6 +39630,11 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors)
+"xLV" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "xMn" = (
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/metal/barograte,
@@ -36644,6 +39681,14 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"xOf" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "xOt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -36686,6 +39731,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"xPf" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "xPu" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/herringbone,
@@ -36727,6 +39780,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"xQq" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xQK" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -36841,6 +39898,9 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"xTQ" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "xTU" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/wood,
@@ -36864,6 +39924,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"xUj" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xUl" = (
 /obj/structure/fluff/railing/border,
 /obj/effect/decal/cobbleedge{
@@ -36986,23 +40053,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
 "xXN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "xXQ" = (
@@ -37030,6 +40085,18 @@
 /obj/item/natural/poo/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"xZj" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "xZs" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -37140,11 +40207,14 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -37193,6 +40263,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"yeA" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "yeF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37321,12 +40397,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -37353,13 +40426,21 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"ykb" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "yke" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -37403,6 +40484,10 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"yla" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ylk" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -181003,13 +184088,13 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -181405,13 +184490,13 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+eoz
+ifg
+ifg
+men
+eoz
+dNL
 bpD
 bpD
 bpD
@@ -181807,17 +184892,17 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+ifg
+ifg
+men
+ifg
+wra
+dNL
+dNL
+dNL
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -182209,17 +185294,17 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+ovj
+gfE
+ifg
+ifg
+ifg
+ifg
+ifg
+dqi
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -182611,17 +185696,17 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+cRP
+cRP
+fJL
+tLq
+cLL
+ifg
+men
+dqi
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -183013,17 +186098,17 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+bLV
+cRP
+cRP
+ujT
+wlC
+ifg
+ifg
+ifg
+lOd
+dNL
 bpD
 bpD
 bpD
@@ -183415,17 +186500,17 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+daJ
+cRP
+cRP
+kwN
+wlC
+ifg
+ifg
+ifg
+lOd
+dNL
 bpD
 bpD
 bpD
@@ -183817,17 +186902,17 @@ sSS
 sSS
 sSS
 sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+cRP
+cRP
+cix
+ifg
+cLL
+ifg
+men
+dqi
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -184219,17 +187304,17 @@ sSS
 sSS
 sSS
 sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+eMR
+wKi
+ifg
+ifg
+ifg
+ifg
+ifg
+dqi
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -184621,17 +187706,17 @@ sSS
 sSS
 sSS
 sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+ifg
+ifg
+ifg
+ifg
+wra
+dNL
+dNL
+dNL
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -185023,13 +188108,13 @@ sSS
 sSS
 sSS
 sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+eoz
+ifg
+men
+men
+eoz
+dNL
 bpD
 bpD
 bpD
@@ -185425,13 +188510,13 @@ sSS
 sSS
 sSS
 sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
 bpD
 bpD
 bpD
@@ -223988,7 +227073,7 @@ eZy
 eLe
 eZy
 eZy
-eLe
+vuH
 eZy
 eZy
 fjX
@@ -224390,7 +227475,7 @@ acD
 acD
 fhw
 acD
-acD
+oud
 acD
 acD
 acD
@@ -224788,13 +227873,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
 acD
 acD
 acD
-vRu
-vRu
-vRu
+acD
+vuH
+vjs
+xAh
 acD
 azH
 azH
@@ -225190,13 +228275,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+xAh
+qgC
+vuH
+qgC
+qgC
 acD
 qgC
 qgC
@@ -225592,13 +228677,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+xAh
+qgC
+vjs
+vuH
+vjs
+xAh
 acD
 qgC
 qgC
@@ -225994,13 +229079,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+xAh
+qgC
+vuH
+vjs
+xAh
 acD
 qgC
 qgC
@@ -226396,13 +229481,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+xAh
+qgC
+qgC
+vuH
+vjs
+xAh
 acD
 qgC
 qgC
@@ -226798,14 +229883,14 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+gXa
+vuH
+vjs
+qgC
+acD
 vRu
 vRu
 vRu
@@ -227199,15 +230284,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
+acD
+acD
+nqe
+acD
+acD
+acD
 vRu
 vRu
 vRu
@@ -227601,15 +230686,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+qgC
+vuH
+ffw
+qgC
+qgC
+acD
 vRu
 vRu
 vRu
@@ -228003,15 +231088,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+xAh
+ikk
+vuH
+ffw
+qgC
+xAh
+acD
 vRu
 vRu
 vRu
@@ -228405,15 +231490,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+ikk
+qgC
+vuH
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -228807,15 +231892,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+xAh
+qgC
+ikk
+vuH
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -229209,15 +232294,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+qgC
+qgC
+vuH
+ffw
+qgC
+acD
 vRu
 vRu
 vRu
@@ -229611,15 +232696,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+wEL
+qgC
+wEL
+ffw
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -230013,15 +233098,15 @@ vRu
 vRu
 vRu
 vRu
+acD
+qgC
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+ikk
+vuH
+vuH
+vuH
+xAh
+acD
 vRu
 vRu
 vRu
@@ -230415,15 +233500,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
+acD
+acD
+vwm
+uqf
+acD
+acD
 vRu
 vRu
 vRu
@@ -230822,9 +233907,9 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
 vRu
 vRu
 vRu
@@ -277086,33 +280171,33 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -277488,61 +280573,61 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+xTQ
+xTQ
+xTQ
+xTQ
+xTQ
+xTQ
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
 hcW
 hcW
 hcW
@@ -277890,61 +280975,61 @@ uaL
 uaL
 uaL
 uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-uaL
-hcW
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
+dAf
+mQr
+qaq
+mwq
+mwq
+urG
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
 fxx
 fxx
-uaL
+fxx
+fxx
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+dAf
+kVc
+kVc
+kVc
+dAf
+kVc
+kVc
 wSn
-hcW
+wSn
+wSn
 hcW
 hcW
 hcW
@@ -278292,58 +281377,58 @@ wSn
 wSn
 uaL
 uaL
+dAf
+mQr
+wyA
+mwq
+mwq
+mwq
+nrw
+nrw
+tyd
+fDB
+fDB
+rRD
+rRD
+vfT
+nrw
+kzQ
+kFh
+kFh
+kFh
+kzQ
+tUR
+ogC
+ogC
+wQW
+rMj
+nrw
+mwq
+mwq
+fIB
 uaL
-uaL
-qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-iNT
-iNT
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-qvR
-qvR
-qvR
-uaL
-uaL
-uaL
-hcW
-uaL
-wSn
-wSn
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
+oYd
+paf
 qvR
 qvR
+bPv
 fxx
 fxx
+fxx
+fxx
+fxx
+dAf
+kVc
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
+wSn
+wSn
 wSn
 wSn
 wSn
@@ -278694,58 +281779,58 @@ wSn
 wSn
 tzK
 uaL
+dAf
+mQr
+iaM
+mwq
+mwq
+wxY
+nrw
+nrw
+wlY
+fDB
+mQA
+bCb
+bCb
+bCb
+nrw
+jlO
+kFh
+xiE
+kFh
+jlO
+tUR
+ogC
+ogC
+lyW
+vGN
+nrw
+mwq
+mwq
+fIB
 uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-tzK
-qvR
-uaL
-uaL
-uaL
-wSn
-uTf
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-wSn
+oYd
+paf
 qvR
 qvR
+bPv
 fxx
 fxx
+fxx
+fxx
+fxx
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
+wSn
+wSn
 wSn
 wSn
 wSn
@@ -279095,59 +282180,59 @@ wSn
 wSn
 uaL
 uaL
-tzK
 uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-uaL
-qvR
-uaL
-wSn
-wSn
-tzK
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
+dAf
+mQr
+dbH
+mwq
+mwq
+wxY
+nrw
+nrw
+jwj
+fDB
+fDB
+fDB
+fDB
+fDB
+rUr
+jlO
+kFh
+iEd
+wbF
+jlO
+evo
+hbc
+ogC
+bnU
+ogC
+nrw
+mwq
+mwq
+fIB
 uaL
 uaL
-uaL
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
+paf
 qvR
 qvR
-qvR
+bPv
 fxx
 fxx
+fxx
+fxx
+fxx
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
+wSn
+wSn
 wSn
 wSn
 wSn
@@ -279498,61 +282583,61 @@ wSn
 uaL
 uaL
 uaL
+dAf
+mQr
+mQr
+xwi
+xwi
+pYF
+mQr
+nrw
+wsR
+ezc
+mQA
+fDB
+mQA
+fDB
+rUr
+jlO
+kFh
+hgt
+kFh
+jlO
+nrw
+ogC
+ogC
+ogC
+ogC
+auL
+mwq
+mwq
+fIB
+uaL
+uaL
+eza
 uaL
 qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
+bPv
 fxx
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-qvR
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
+wSn
 uaL
 wSn
 wSn
 wSn
-uaL
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-hcW
-wSn
-qvR
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-uaL
-wSn
-uaL
 uaL
 wSn
 uaL
@@ -279900,68 +282985,68 @@ wSn
 wSn
 uaL
 uaL
+dAf
+mQr
+dbH
+xwi
+xwi
+pYF
+mQr
+nrw
+aym
+fDB
+fDB
+wSl
+wSl
+wSl
+nrw
+jlO
+kFh
+qWc
+kFh
+jlO
+nrw
+wYv
+ogC
+jWd
+mwq
+auL
+mwq
+mwq
+fIB
+ykt
+ykt
+ykt
 uaL
 qvR
-uaL
-uaL
-uaL
-uaL
+bPv
+fxx
+fxx
+fxx
+fxx
+fxx
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
-qvR
+uaL
 wSn
 wSn
 wSn
-qvR
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-wSn
-qvR
-uaL
-vRq
-qvR
-uaL
-fxx
-fxx
-qvR
-qvR
-uaL
 uaL
 wSn
 uaL
 uaL
 uaL
-uaL
-uaL
+dAf
+dAf
 hcW
 hcW
 uaL
@@ -280263,7 +283348,7 @@ cWT
 hcW
 hcW
 hcW
-uaL
+dUX
 wSn
 wSn
 wSn
@@ -280302,69 +283387,69 @@ uaL
 uaL
 uaL
 uaL
+dAf
+mQr
+qaq
+xwi
+xwi
+xwi
+fRO
+fDB
+fDB
+mQA
+vHi
+bCb
+bCb
+sQD
+nrw
+ajm
+kFh
+kFh
+kFh
+onl
+nrw
+hbc
+ogC
+jWd
+mwq
+auL
+qYw
+mwq
+fIB
+uaL
+uaL
+eza
 uaL
 qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-wSn
-wSn
-wSn
-wSn
-uaL
+bPv
 fxx
 fxx
 fxx
 fxx
 fxx
+dAf
+dAf
+dAf
+kVc
+kVc
 fxx
-fxx
-fxx
+kVc
+kVc
+kVc
+dAf
 qvR
 uaL
-wSn
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-wSn
 wSn
 wSn
 wSn
 uaL
 uaL
 uaL
-wSn
-qvR
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-uaL
-qvR
-uaL
-tzK
 uaL
 uaL
-uaL
-uaL
-uaL
-uaL
-uaL
+dAf
+dAf
+dAf
 uaL
 uaL
 wSn
@@ -280695,7 +283780,7 @@ uaL
 uaL
 uaL
 wSn
-tzK
+uaL
 uaL
 uaL
 hcW
@@ -280704,69 +283789,69 @@ hcW
 hcW
 uaL
 uaL
+dAf
+mQr
+wyA
+xwi
+xwi
+xwi
+mQr
+nrw
+rUr
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+onl
+txD
+jlO
+jlO
+nrw
+eTk
+ogC
+mwq
+mwq
+nrw
+tJC
+mwq
+fIB
+qcK
+uaL
+paf
 uaL
 qvR
+bPv
+fxx
+fxx
+fxx
+fxx
+fxx
+dAf
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
-uaL
-uaL
-uaL
 qvR
 wSn
 wSn
-uaL
-wSn
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-wSn
-wSn
-uaL
-fxx
-uaL
-qvR
-qvR
-qvR
-uaL
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-uaL
 wSn
 uaL
 uaL
-uaL
-uaL
-uaL
-uaL
-wSn
 qvR
 qvR
-uaL
-uaL
-uaL
-fxx
-fxx
-qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-qvR
-uaL
-wSn
-uaL
-qvR
+dAf
+dAf
+dAf
+kVc
 qvR
 wSn
 wSn
@@ -281106,81 +284191,81 @@ hcW
 hcW
 uaL
 uaL
+dAf
+mQr
+iaM
+mXz
+xwi
+xwi
+gfg
+mwq
+mwq
+jhf
+mwq
+mwq
+mwq
+mwq
+mwq
+nrw
+hOS
+nrw
+jlO
+jlO
+nrw
+cZP
+woq
+mwq
+jtc
+nrw
+qYw
+mwq
+fIB
+nfX
+uaL
+paf
 uaL
 qvR
+bPv
+fxx
+fxx
+fxx
+fxx
+fxx
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
-uaL
-uaL
 qvR
-uaL
-uaL
-uaL
-uaL
 wSn
 wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
 wSn
-mHb
-uaL
-uaL
-fxx
-fxx
-qvR
-qvR
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lcg
-oMa
-bdN
-bdN
-bdN
-bCb
-lcg
-fxx
-fxx
-qvR
-qvR
-qvR
 uaL
 pPy
 uaL
+dAf
+dAf
+dAf
+kVc
+kVc
 qvR
 qvR
+qvR
+uaL
 uaL
 qvR
 qvR
 qvR
 qvR
 qvR
-uaL
-uaL
 qvR
-qvR
-qvR
-qvR
-qvR
-qvR
-uTf
+wSn
 spp
 nzw
 qvR
@@ -281509,67 +284594,67 @@ hcW
 hcW
 uaL
 tzK
-qvR
-qvR
-uaL
-qvR
-qvR
-uaL
+mQr
+mQr
+mQr
+mQr
+nrw
+nrw
 mwq
-uaL
-wSn
-uaL
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-wSn
-uTf
-wSn
-wSn
-uaL
-gvi
-uaL
-uaL
-jlY
-uaL
-uaL
-lcg
-fxx
-fxx
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
+mwq
+mwq
+mwq
+jWd
+mwq
+mwq
+mwq
+mwq
+mwq
+nrw
+nhR
+nrw
+nrw
+nrw
+nrw
+sLu
+nrw
+nrw
+mwq
+mwq
+fIB
+lsD
+lsD
+oqj
 uaL
 qvR
+bPv
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+kVc
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
-iNT
+qvR
+wSn
+wSn
+wSn
+qvR
+uaL
+uaL
+dAf
+kVc
+kVc
+kVc
 uaL
 uaL
 uaL
@@ -281915,61 +285000,61 @@ qvR
 qvR
 qvR
 qvR
-uaL
-wSn
-uaL
-wSn
-wSn
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fTe
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
+evo
+nrw
+nrw
+arv
+arv
+jEB
+wqU
+itC
+itC
+itC
+lGI
+mwq
+nrw
+fDB
+gpZ
+jWX
 uvu
-uaL
-uaL
-uaL
-uaL
-uaL
-uwa
+voh
+qYw
+tJC
+qYw
+mwq
+mwq
+fIB
+rhD
+rhD
+rhD
+rhD
+rhD
+bPv
 fxx
 fxx
+fxx
+fxx
+fxx
+fxx
+kVc
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
-qvR
+uaL
+wSn
+wSn
+wSn
 uaL
 uaL
-uaL
-uaL
-aPF
-uaL
+dAf
+dAf
+kVc
 uaL
 uaL
 uaL
@@ -282295,7 +285380,7 @@ uaL
 wSn
 uaL
 uaL
-uTf
+wSn
 wSn
 wSn
 wSn
@@ -282315,63 +285400,63 @@ uaL
 uaL
 uaL
 qvR
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-gvi
-tev
-qwp
-uaL
-tev
-uaL
-lcg
-fxx
-fxx
 qvR
 qvR
+evo
+bMt
+tJC
+cbG
+cbG
+vfg
+lGI
+gPt
+wzZ
+xHV
+lGI
+jWd
+nrw
+fDB
+iWj
+fDB
+nhR
+mwq
+mwq
+qYw
+mwq
+mwq
+mwq
+xxS
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+kVc
+dAf
+kVc
+kVc
+dAf
+kVc
+kVc
+kVc
+dAf
+qvR
+wSn
+wSn
+wSn
 wSn
 uaL
 wSn
-uaL
-uaL
-uaL
+dAf
+dAf
+kVc
 uaL
 uaL
 uaL
@@ -282718,14 +285803,34 @@ uaL
 uaL
 qvR
 qvR
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
+gre
+evo
+kmo
+tJC
+cbG
+cbG
+jEB
+lGI
+xlg
+oGH
+dyu
+lGI
+mwq
+vnH
+fDB
+mQA
+fDB
+nhR
+mwq
+mwq
+mwq
+mwq
+mwq
+mwq
+xxS
+fxx
+fxx
+kcE
 fxx
 fxx
 fxx
@@ -282734,47 +285839,27 @@ fxx
 fxx
 fxx
 fxx
-uaL
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-pPy
-uaL
-qvR
-qvR
-uaL
-uaL
-lVe
-lVe
-cQY
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-fxx
-fxx
-qvR
+dAf
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 uaL
 wSn
-uaL
-uaL
-uaL
+wSn
+wSn
 wSn
 uaL
-tzK
+uaL
+dAf
+dAf
+kVc
+uaL
 wSn
 uaL
 tzK
@@ -283120,14 +286205,31 @@ uaL
 uaL
 qvR
 qvR
-uaL
-uaL
-uaL
-wSn
-qvR
-qvR
-qvR
-uaL
+gre
+evo
+evW
+tJC
+cbG
+cbG
+jEB
+lGI
+aLq
+tAL
+aBA
+lGI
+mwq
+nrw
+wLB
+rlG
+fDB
+nhR
+mwq
+mwq
+mwq
+mwq
+mwq
+mwq
+xxS
 fxx
 fxx
 fxx
@@ -283139,43 +286241,26 @@ fxx
 fxx
 fxx
 fxx
-uaL
-uaL
 fxx
-fxx
-fxx
-wSn
-wSn
-uTf
-wSn
-uaL
-uaL
-qvR
-lyL
-qvR
-uaL
-lVe
-jyE
-ooJ
-xHe
-lVe
-jCh
-jCh
-jCh
-gvx
-jCh
-jCh
-lVe
-fxx
-fxx
-qvR
+kVc
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
 wSn
 wSn
 wSn
 wSn
 wSn
-qvR
+wSn
+dAf
+dAf
+kVc
 qvR
 uaL
 uaL
@@ -283522,62 +286607,62 @@ uaL
 uaL
 qvR
 qvR
-uaL
+gre
+evo
+nrw
+nrw
+aYo
+aYo
+jEB
+lGI
+tlQ
+tlQ
+tlQ
+lGI
+jWd
+nrw
+fnW
+tIc
+fDB
+uvu
+mwq
+mwq
+qYw
+mwq
+mwq
+mwq
+fIB
+rhD
+rhD
+rhD
+rhD
+rhD
+bPv
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+kVc
+dAf
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
 qvR
-qvR
-qvR
-qvR
-qvR
-qvR
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-uaL
 wSn
 wSn
 wSn
-wSn
-wSn
-wSn
 qvR
-qvR
-uaL
-lVe
-upY
-ooJ
-azl
-lVe
-jCh
-jCh
-jCh
-gvx
-jCh
-jCh
-lVe
-fxx
-fxx
-uaL
-qvR
-qvR
-qvR
-iNT
-qvR
-qvR
-qvR
+dAf
+dAf
+dAf
+kVc
 qvR
 uaL
 uaL
@@ -283925,61 +287010,61 @@ uaL
 qvR
 qvR
 qvR
+evo
+nrw
+mwq
+mwq
+mwq
+mwq
+jWd
+mwq
+mwq
+mwq
+mwq
+mwq
+nrw
+nrw
+nrw
+blx
+nrw
+voh
+qYw
+tJC
+qYw
+mwq
+mwq
+fIB
+vpZ
 qvR
 qvR
-uaL
-tzK
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
 qvR
-rBC
-uaL
-uaL
+qvR
+bPv
 fxx
 fxx
-uaL
+fxx
+fxx
+fxx
+fxx
+kVc
+dAf
+dAf
+dAf
+kVc
+kVc
+dAf
+kVc
+dAf
+qvR
+qvR
 wSn
 wSn
 wSn
 uaL
-wSn
-wSn
-qvR
-lyL
-qvR
-lVe
-til
-ooJ
-ooJ
-lVe
-ifg
-ifg
-rgO
-vox
-jCh
-jCh
-lVe
-fxx
-fxx
-wSn
-qvR
-qvR
-uaL
-uaL
-qvR
-qvR
-uaL
+dAf
+kVc
+dAf
+kVc
 qvR
 qvR
 qvR
@@ -284327,61 +287412,61 @@ uaL
 uaL
 qvR
 qvR
-qvR
-qvR
-qvR
-qvR
+evo
+nrw
+qrI
+mwq
+fvP
+mwq
+mwq
+mwq
+mwq
+mwq
+nrw
+nrw
+nrw
+nrw
+lbA
+fDB
+nrw
+nrw
+ykb
+nrw
+nrw
+qYw
+mwq
+fIB
 uaL
 uaL
 uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
 uaL
 qvR
-qvR
-qvR
-uaL
+bPv
 fxx
 fxx
-uaL
-wSn
-uaL
-wSn
-wSn
-wSn
-rCL
-qvR
-qvR
-qvR
-lVe
-lLp
-ooJ
-tuw
-lVe
-kwN
+fxx
+fxx
+fxx
+fxx
+fxx
 dAf
-auL
-vox
-jCh
-jCh
-lVe
-fxx
-fxx
-wSn
-qvR
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
 qvR
 wSn
+wSn
+wSn
 qvR
-qvR
-uaL
+dAf
+dAf
+dAf
+kVc
 uaL
 wSn
 uaL
@@ -284727,63 +287812,63 @@ uaL
 uaL
 hcW
 uaL
-uaL
 qvR
 qvR
+evo
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+uEX
+uEX
+nrw
+lbA
+fDB
+lbA
+niJ
+nux
+rRD
+nrw
+tJC
+mwq
+fIB
+uaL
+uaL
+uaL
+uaL
 qvR
-wSn
-qvR
-uaL
-uaL
-rcr
-rcr
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
+bPv
 fxx
 fxx
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
-uaL
-lVe
-lVe
-vjs
-lVe
-lVe
-lVe
-nhR
-lVe
-lVe
-lVe
-lVe
-lVe
 fxx
 fxx
-uaL
+fxx
+fxx
+fxx
+kVc
+dAf
+dAf
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
 vRq
+wSn
+wSn
+wSn
 qvR
-lyL
-qvR
-qvR
-uaL
+dAf
+kVc
+kVc
+kVc
 uaL
 uaL
 qvR
@@ -285129,63 +288214,63 @@ hcW
 hcW
 hcW
 hcW
-uaL
-uaL
-uaL
-uaL
+hcW
+xTQ
+xTQ
+xTQ
+xTQ
+lbA
+lbA
+lbA
+uEX
+uEX
+lbA
+lbA
+lbA
+fDB
+qKU
+nrw
+aHI
+fDB
+mQA
+fDB
+iWj
+fDB
+aHA
+qYw
+mwq
+fIB
+qvR
+qvR
+qvR
+qvR
+qvR
+bPv
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+kVc
+dAf
+kVc
+dAf
+kVc
+kVc
+kVc
+dAf
+wSn
+qvR
 wSn
 wSn
 wSn
 uaL
-tzK
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uTf
-qvR
-uaL
-fxx
-fxx
-fxx
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
-uTf
-uaL
-uaL
-lVe
-afA
-ddv
-ddv
-lVe
-bqt
-wlD
-lVe
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-qvR
-uaL
-qvR
-qvR
-qvR
-qvR
+dAf
+kVc
+kVc
+kVc
 qvR
 qvR
 qvR
@@ -285218,7 +288303,7 @@ uaL
 uaL
 uaL
 qvR
-vHd
+qvR
 qvR
 qvR
 qvR
@@ -285532,61 +288617,61 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+xTQ
+iJR
+swU
+iGg
+fDB
+mdB
+qKU
+qKU
+mdB
+mdB
+qKU
+mdB
+mdB
+fDB
+kmo
+nux
+fDB
+fDB
+fDB
+mQA
+fDB
+uvu
+mwq
+mwq
+fIB
 uaL
 uaL
 uaL
 uaL
 qvR
-uaL
-uaL
-qvR
-uaL
-fxx
-fxx
-fxx
-qvR
-qzy
-wSn
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-cQY
-wlD
-ddv
-ddv
-wlD
-wlD
-wlD
-cQY
-fxx
-fQq
+bPv
 fxx
 fxx
 fxx
 fxx
-wSn
+fxx
+fxx
+fxx
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+dAf
 wSn
 oZH
+wSn
+wSn
+wSn
 qvR
-qvR
-qvR
-qvR
+dAf
+dAf
+kVc
 qvR
 lyL
 aPF
@@ -285934,61 +289019,61 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+xTQ
+iJR
+hsa
+iGg
+fDB
+mdB
+smn
+mpQ
+mdB
+qKU
+smn
+qKU
+qKU
+mQA
+nrw
+fDB
+fDB
+wSl
+wSl
+fDB
+fDB
+uvu
+mwq
+mwq
+fIB
 uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-wSn
 uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-qvR
-lyL
+bPv
 fxx
 fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+dAf
+kVc
+kVc
+kVc
+dAf
+kVc
+kVc
+dAf
 qvR
 qvR
 wSn
 wSn
-uaL
-uaL
-uTf
-uaL
 wSn
-uaL
-lVe
-wlD
-iim
-wlD
-wlD
-ddv
-wlD
-lVe
-gwN
-fxx
-fxx
-veW
-fxx
-fxx
-uaL
 qvR
-qvR
-qvR
-qvR
-qvR
-tzK
+dAf
+dAf
+kVc
 qvR
 qvR
 qvR
@@ -286336,61 +289421,61 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
+xTQ
+xTQ
+xTQ
+xTQ
+lbA
+lbA
+lbA
+lOh
+lOh
+lbA
+lbA
+lbA
+qKU
+fDB
+lNn
+fDB
+fDB
+uvj
+wPo
+wTs
+lbA
+nrw
+mwq
+mwq
+fIB
+bEu
 qvR
-uaL
-tzK
-uaL
 qvR
+qvR
+qvR
+bPv
 fxx
 fxx
-qvR
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-cQY
-wlD
-izm
-psH
-czI
-ddv
-wlD
-pdm
-jlY
-uaL
-uaL
-uaL
 fxx
 fxx
-uaL
+fxx
+fxx
+fxx
+dAf
+kVc
+dAf
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
-iNT
 qvR
+wSn
+wSn
+wSn
 qvR
-qvR
-uaL
+dAf
+dAf
+kVc
 qvR
 qvR
 qvR
@@ -286400,7 +289485,7 @@ uaL
 uaL
 wSn
 wSn
-qzy
+qvR
 qvR
 qvR
 spp
@@ -286741,58 +289826,58 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-fuA
-uaL
-uaL
-wSn
-uaL
-tzK
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-qvR
-qvR
+xTQ
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+evo
+evo
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
 fxx
 fxx
-wSn
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-lVe
-sFE
-mzk
-nQE
-wKh
-ddv
-wlD
-lVe
-uaL
-uaL
-vLS
-uaL
 fxx
 fxx
-uaL
+fxx
+fxx
+fxx
+kVc
+kVc
+dAf
+kVc
+kVc
+kVc
+kVc
+dAf
 qvR
 qvR
+wSn
+wSn
+wSn
 xis
-qvR
-qvR
-uaL
+dAf
+dAf
+kVc
 qvR
 uaL
 uaL
@@ -287144,57 +290229,57 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-fuA
+dTa
+dTa
+dTa
+dTa
+evo
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+qvR
+qvR
+qvR
 uaL
 uaL
 uaL
-tzK
-tzK
-uaL
-wSn
-mHb
-wSn
-wSn
-wSn
-lyL
-xis
+qvR
 fxx
 fxx
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-cQY
-wlD
-dlx
-dlx
-wlD
-ddv
-wlD
-cQY
-uaL
-vLS
-glM
-uaL
 fxx
 fxx
-uaL
+fxx
+fxx
+fxx
+fxx
+kVc
+kVc
+kVc
+dAf
+dAf
+dAf
+dAf
 qvR
 qvR
-qvR
-qvR
-qvR
-qvR
+wSn
+wSn
+wSn
+dAf
+dAf
+kVc
+kVc
 qvR
 qvR
 uaL
@@ -287546,56 +290631,56 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-lcg
-bdN
-oZE
-lcg
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
+dTa
+dTa
+evo
+evo
+evo
+dpZ
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+qvR
+qvR
+qvR
 qvR
 qvR
 fxx
 fxx
-uaL
-wSn
-uaL
-aPF
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lVe
-rGY
-wlD
-wlD
-uhe
-ddv
-afA
-lVe
-aok
-uaL
-uaL
-vLS
 fxx
 fxx
-uaL
-qvR
-qvR
-qvR
-qvR
-iNT
+fxx
+fxx
+fxx
+fxx
+fxx
+dAf
+fxx
+kVc
+kVc
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+dAf
+kVc
 qvR
 qvR
 qvR
@@ -287619,7 +290704,7 @@ qvR
 qvR
 ptV
 qvR
-wpm
+qvR
 qvR
 wSn
 rhD
@@ -287953,7 +291038,6 @@ hcW
 hLK
 vra
 fxx
-dpZ
 fxx
 fxx
 fxx
@@ -287968,35 +291052,36 @@ fxx
 fxx
 fxx
 fxx
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lVe
-lVe
-dbH
-lVe
-lVe
-cQY
-lVe
-lVe
-uaL
-uaL
-uaL
-uaL
 fxx
 fxx
-uaL
-wSn
-rBC
-qvR
-qvR
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+kVc
+ykt
+xKz
+bOK
+xKz
+bOK
+xKz
+bOK
+xKz
+ykt
 uaL
 qvR
 qvR
@@ -288363,15 +291448,6 @@ fxx
 fxx
 fxx
 fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
 fxx
 fxx
 fxx
@@ -288381,23 +291457,32 @@ fxx
 fxx
 fxx
 fxx
-lVe
-lVe
-lVe
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
 fxx
 fxx
 fxx
-uaL
-wSn
-wSn
-wSn
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+xDd
+wUw
+wUw
+wUw
+wUw
+wUw
+xDd
 wSn
 uaL
 uaL
@@ -288793,13 +291878,13 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+hMZ
+peN
+peN
+peN
+peN
+peN
+buQ
 fxx
 fxx
 fxx
@@ -289160,18 +292245,18 @@ hcW
 hcW
 hcW
 hcW
-fuA
-fuA
-fuA
-fuA
 uaL
-fuA
-uaL
-fuA
-fuA
-fDB
-fDB
-uaL
+ykt
+ykt
+ykt
+ykt
+ykt
+xKz
+xKz
+xKz
+jeb
+jeb
+xKz
 fxx
 fxx
 fxx
@@ -289195,13 +292280,13 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+wUw
+peN
+peN
+peN
+dPZ
+peN
+wUw
 fxx
 fxx
 fxx
@@ -289563,40 +292648,25 @@ hcW
 hcW
 hcW
 uaL
-uTf
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-fuA
-mjP
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
 wSn
 wSn
 wSn
 wSn
 wSn
+xKz
+qHJ
+kvj
+lLa
+xKz
+xKz
+lgX
+dyi
+vUV
+xKz
+jeb
+jeb
+xKz
+xKz
 uaL
 uaL
 uaL
@@ -289606,7 +292676,22 @@ uaL
 uaL
 uaL
 uaL
-uTf
+uaL
+wSn
+wSn
+wSn
+wSn
+wSn
+peN
+peN
+peN
+peN
+peN
+peN
+peN
+uaL
+uaL
+wSn
 uaL
 uaL
 uaL
@@ -289966,24 +293051,24 @@ hcW
 hcW
 uaL
 wSn
-uTf
 wSn
 wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fTe
-uaL
-uaL
-uaL
+wSn
+wSn
+xKz
+yiI
+iYQ
+fVQ
+uDi
+qpt
+sDa
+peN
+kIf
+emT
+uDi
+fVQ
+xjJ
+xKz
 qvR
 qvR
 qvR
@@ -289999,13 +293084,13 @@ wSn
 uaL
 fTe
 wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+niV
+wbx
+jQX
+jQX
+jQX
+wbx
+niV
 uaL
 uaL
 uaL
@@ -290367,28 +293452,28 @@ hcW
 hcW
 hcW
 uaL
-uTf
+wSn
 bHL
 wSn
-uaL
+wSn
+wSn
+xKz
+fNp
+kvj
+fVQ
+lLa
+qpt
+sDa
+peN
+kIf
+emT
+lLa
+fVQ
+uzT
+xKz
 qvR
-uaL
-uaL
-uaL
-qvR
-aPR
-uaL
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-lyL
 qvR
 qvR
-uaL
-uaL
 vRq
 qvR
 qvR
@@ -290401,14 +293486,14 @@ uaL
 uaL
 uaL
 uaL
+xKz
+bOK
+jeb
+qDn
+jeb
+bOK
+xKz
 uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-xqL
 uaL
 uaL
 uaL
@@ -290772,26 +293857,26 @@ uaL
 wSn
 wSn
 wSn
-qvR
-qvR
-tzK
-uaL
 wSn
 wSn
-qvR
-tAf
-fxx
-fxx
-fxx
-uaL
+xKz
+yiI
+iYQ
+fVQ
+kBS
+qpt
+sDa
+peN
+kIf
+emT
 hmU
-wSn
-wSn
-wSn
+fVQ
+uzT
+xKz
 qvR
 qvR
-uaL
-uTf
+qvR
+wSn
 lyL
 qvR
 uaL
@@ -290800,16 +293885,16 @@ uTf
 uaL
 uaL
 uaL
-tzK
 uaL
 uaL
 uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
+bOK
+tYP
+tYP
+pcC
+tYP
+tYP
+xKz
 uaL
 uaL
 wSn
@@ -291174,25 +294259,25 @@ uaL
 wSn
 uTf
 wSn
-qvR
-uaL
-uaL
-uaL
-uaL
 wSn
-qvR
-qvR
+wSn
+xKz
+fNp
+kvj
+fVQ
+jeb
+jeb
 sDa
-xxp
-rUr
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
+peN
+kIf
+jeb
+jeb
+fVQ
+uzT
+xKz
 qvR
 qvR
+uaL
 uaL
 xis
 qvR
@@ -291205,13 +294290,13 @@ uaL
 qvR
 qvR
 uaL
-wSn
-uaL
-xqL
-wSn
-wSn
-uaL
-uaL
+lXG
+tYP
+veo
+tYP
+qOe
+tYP
+xKz
 qvR
 qvR
 uaL
@@ -291575,26 +294660,26 @@ uaL
 wSn
 wSn
 wSn
-uTf
-qvR
-uaL
-uaL
-uaL
 wSn
 wSn
-tAf
-qvR
-wgn
-jXZ
+wSn
+xKz
+uaj
+iYQ
+fVQ
+fVQ
+jeb
+khc
+peN
 kIf
+jeb
+fVQ
+tYP
+bmL
+xKz
+qvR
+qvR
 uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-lyL
 qvR
 qvR
 qvR
@@ -291607,13 +294692,13 @@ qvR
 qvR
 uaL
 wSn
-wSn
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
+xKz
+lEz
+tYP
+tYP
+tYP
+tYP
+xKz
 qvR
 qvR
 qvR
@@ -291978,28 +295063,28 @@ wSn
 wSn
 wSn
 wSn
-qvR
-uaL
-uaL
-efg
 wSn
 wSn
-xqL
-tAf
-wgn
-jXZ
+xKz
+qVz
+lLa
+fVQ
+fVQ
+hZF
+sDa
+peN
 kIf
-aJj
-wSn
-wSn
-uTf
-wSn
-wSn
-wSn
-wSn
+hZF
+fVQ
+sCg
+qNR
+xKz
+qvR
+uaL
+uaL
 qvR
 qvR
-qzy
+qvR
 qvR
 wSn
 wSn
@@ -292009,14 +295094,14 @@ qvR
 aPF
 uaL
 wSn
-wSn
-wSn
-uaL
+bOK
+tYP
+mbt
+tYP
+sCg
+sWc
+xKz
 qvR
-uaL
-qvR
-qvR
-iNT
 qvR
 qvR
 qvR
@@ -292379,26 +295464,26 @@ uaL
 wSn
 jct
 wSn
-wSn
 xKz
 xKz
+xKz
+xKz
+qVz
+lLa
+fVQ
+fVQ
 jeb
-jeb
-jeb
-xKz
-xKz
-tUp
-wgn
-jXZ
+khc
+peN
 kIf
-aJj
-wSn
-wSn
-wSn
-wSn
-oxc
-wSn
-wSn
+jeb
+fVQ
+sCg
+qNR
+xKz
+qvR
+uaL
+qvR
 uaL
 qvR
 qvR
@@ -292411,18 +295496,18 @@ uaL
 uaL
 wSn
 wSn
-wSn
-wSn
-iNT
-qvR
-qvR
-qvR
-qvR
+xKz
+xKz
+xKz
+wou
+sCg
+qNR
+xKz
 qvR
 qvR
 qvR
 uaL
-tzK
+uaL
 uTf
 uaL
 qvR
@@ -292774,52 +295859,52 @@ uaL
 uaL
 uaL
 uaL
-tzK
-tzK
 uaL
 uaL
-wSn
+uaL
+uaL
 wSn
 wSn
 wSn
 xKz
-peN
-qGh
+xKz
 mDY
-qeY
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+jeb
+sDa
 peN
+kIf
+jeb
+fVQ
+tYP
+qNR
 xKz
-kIf
-wgn
-jXZ
-kIf
-aJj
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
 qvR
 qvR
-lyL
 qvR
-rCL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+wSn
+wSn
+xKz
+xKz
+xKz
+tYP
+sCg
+qNR
+xKz
 qvR
 qvR
 uaL
@@ -293183,26 +296268,26 @@ uaL
 wSn
 wSn
 wSn
-wSn
-jeb
+xKz
+xKz
 mDY
-goz
-cRP
-fIB
-qeY
-jeb
+fVQ
+fVQ
+lhd
+fVQ
+fVQ
+qpt
+sDa
+peN
 kIf
-wgn
-jXZ
-kIf
-aJj
-bmL
-wSn
+emT
+lLa
+fVQ
+clm
+xKz
+qvR
 uaL
-wSn
-uaL
-wSn
-uaL
+qvR
 uaL
 uaL
 wSn
@@ -293215,13 +296300,13 @@ uaL
 wSn
 uTf
 wSn
-wSn
-wSn
-qvR
-qvR
-qvR
-qvR
-qvR
+xKz
+xKz
+xKz
+wou
+sCg
+sWc
+xKz
 qvR
 uaL
 uaL
@@ -293243,7 +296328,7 @@ wOD
 qvR
 qvR
 qvR
-qzy
+qvR
 qvR
 fxx
 fxx
@@ -293585,26 +296670,26 @@ uaL
 xqL
 wSn
 wSn
-wSn
 xKz
-xNo
-jpw
-eoz
-itC
-xNo
+kZn
+gqa
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+qpt
+sDa
+peN
+kIf
+emT
+lLa
+fVQ
+qXo
 xKz
-iaX
-jXZ
-jXZ
-jXZ
-ykt
-ykt
-uTf
-wSn
-wSn
-uaL
-uaL
-uaL
+qvR
+qvR
+qvR
 uaL
 uaL
 tzK
@@ -293617,10 +296702,10 @@ uaL
 wSn
 wSn
 uaL
-uaL
-uaL
 xKz
 xKz
+xKz
+xmB
 xKz
 xKz
 xKz
@@ -293976,7 +297061,7 @@ aJj
 aJj
 aJj
 aJj
-khc
+aJj
 aJj
 aJj
 aJj
@@ -293987,27 +297072,27 @@ aJj
 aJj
 uaL
 qvR
-qvR
-jeb
+xKz
+yiI
 iYQ
-iME
-oRp
+lLa
+fVQ
 lhd
-uxV
-jeb
+fVQ
+fVQ
 qpt
-wgn
-jXZ
+sDa
+peN
 kIf
-wgn
-ykt
-wSn
-aJj
-aJj
+emT
+htf
+fVQ
+xEG
+xKz
+uaL
 uaL
 qvR
 qvR
-qvR
 uaL
 aJj
 aJj
@@ -294019,8 +297104,8 @@ uaL
 aJj
 aJj
 aJj
-aJj
-aJj
+xKz
+xKz
 xKz
 waI
 kyo
@@ -294389,40 +297474,40 @@ evo
 evo
 evo
 evo
-evo
 xKz
-bOK
+uaj
+kvj
 kds
-szV
-uxV
-peN
-vFz
-kIf
+xUj
+xKz
+kBS
+fVQ
+xKz
 wgn
-jXZ
-kIf
-wgn
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
+eAG
+iJu
+ekK
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
 xKz
 cWG
 bOK
@@ -294747,7 +297832,7 @@ uaL
 wSn
 wSn
 wSn
-iNT
+qvR
 qvR
 qvR
 wSn
@@ -294799,31 +297884,31 @@ xKz
 xKz
 xKz
 xKz
-oAn
+xKz
 uWL
-wjB
-wjB
-oAn
-evo
-xAi
-xAi
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-cVN
-cVN
-dCV
-dCV
-xAi
-xAi
-xAi
-xAi
-dCV
-dCV
-dCV
+tRt
+tRt
+xKz
+xKz
+jIP
+jIP
+cwd
+cwd
+cwd
+cwd
+cwd
+cwd
+jlY
+jlY
+cwd
+cwd
+jIP
+jIP
+jIP
+jIP
+cwd
+cwd
+cwd
 axq
 dnx
 axl
@@ -295149,7 +298234,7 @@ qvR
 uaL
 uaL
 wSn
-iNT
+qvR
 qvR
 qvR
 iNT
@@ -296039,7 +299124,7 @@ uaL
 uaL
 uaL
 qvR
-iNT
+qvR
 qvR
 uaL
 uaL
@@ -301267,7 +304352,7 @@ uaL
 uaL
 wSn
 wSn
-uDi
+wSn
 rCL
 qvR
 qvR
@@ -301284,7 +304369,7 @@ mcm
 qvR
 fxx
 fxx
-qvR
+wBx
 okF
 okF
 okF
@@ -301687,7 +304772,7 @@ qvR
 fxx
 fxx
 qvR
-qzy
+qvR
 gex
 qvR
 rhD
@@ -302038,7 +305123,7 @@ xKz
 wVI
 wbg
 wbg
-wbg
+qCT
 wbg
 wbg
 wbg
@@ -302394,7 +305479,7 @@ mcK
 nBW
 mOY
 nBW
-nBW
+sWX
 nBW
 wtF
 wbg
@@ -302476,7 +305561,7 @@ uaL
 uaL
 qvR
 qvR
-iNT
+qvR
 qvR
 jJx
 sTr
@@ -304008,7 +307093,7 @@ wtF
 wbg
 wbg
 wbg
-wbg
+qCT
 wbg
 wbg
 wbg
@@ -304486,12 +307571,12 @@ uaL
 uaL
 qvR
 qvR
-iNT
+qvR
 qvR
 eOg
 uAZ
 xzN
-rNg
+lgC
 lOo
 rNg
 nuD
@@ -305693,7 +308778,7 @@ qvR
 qvR
 qvR
 qvR
-vHd
+qvR
 qvR
 eXH
 efS
@@ -306091,7 +309176,7 @@ olN
 uaL
 qvR
 uaL
-iNT
+qvR
 qvR
 qvR
 qvR
@@ -306133,7 +309218,7 @@ bwS
 lVe
 hHF
 goK
-wlD
+bgT
 sux
 pYf
 pYf
@@ -306518,7 +309603,7 @@ uaL
 uaL
 qvR
 xis
-qvR
+wBx
 fxx
 wSn
 wSn
@@ -307268,12 +310353,12 @@ wbg
 wbg
 wVI
 wVI
-wVI
+dbt
 nHz
 wVI
 wVI
 wVI
-nHz
+nnt
 wVI
 wVI
 tUw
@@ -307310,7 +310395,7 @@ fxx
 fxx
 fxx
 fxx
-fxx
+rch
 fxx
 boU
 fxx
@@ -307328,13 +310413,13 @@ qvR
 wSn
 cyr
 hHF
-enD
+fks
 wlD
 sIG
 wlD
 wlD
 wlD
-wlD
+bgT
 wlD
 sIG
 wlD
@@ -307608,7 +310693,7 @@ sqd
 miX
 wxB
 wxB
-wxB
+miX
 wxB
 wxB
 wxB
@@ -307635,7 +310720,7 @@ wbg
 xXq
 yhZ
 yhZ
-yhZ
+jWZ
 yhZ
 yhZ
 xXq
@@ -307649,7 +310734,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
+qCT
 wbg
 wbg
 wbg
@@ -308102,7 +311187,7 @@ fxx
 fxx
 fxx
 fxx
-fxx
+rch
 fxx
 fxx
 fxx
@@ -308127,7 +311212,7 @@ mHb
 wSn
 wSn
 wSn
-dNL
+qvR
 wSn
 wSn
 cyr
@@ -308478,7 +311563,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
+qCT
 wbg
 wbg
 wbg
@@ -308861,7 +311946,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 qcm
 cZg
 fRa
@@ -309263,7 +312348,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 heo
 rJX
 pUl
@@ -309665,7 +312750,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 urH
 pUl
 pUl
@@ -309677,17 +312762,17 @@ wbg
 wbg
 wbg
 wbg
-wbg
+qzH
 hUt
 vFj
 qzH
 wbg
-jIP
-mwE
-mwE
+wbg
+wbg
+qzH
 xGM
-rfO
-wsR
+qzH
+adK
 ukb
 wvE
 rLt
@@ -309708,7 +312793,7 @@ uaL
 uaL
 uaL
 uaL
-tzK
+uaL
 qvR
 qvR
 qvR
@@ -309728,7 +312813,7 @@ trG
 ryI
 fZw
 fxx
-fxx
+rch
 rhD
 qvR
 qvR
@@ -310067,7 +313152,7 @@ tJx
 wVI
 wbg
 wbg
-wVI
+wbg
 jbj
 pUl
 dkf
@@ -310078,18 +313163,18 @@ guP
 vce
 wbg
 wbg
-wbg
 qtV
-wJq
-vPA
+iPY
+iPY
+iPY
 wew
-aOv
+wxZ
 nRo
 bQf
-mwE
-qDn
-mwE
-wsR
+vKP
+iPY
+puf
+adK
 ukb
 wvE
 wvE
@@ -310112,7 +313197,7 @@ wSn
 wSn
 uaL
 uaL
-uEX
+wSn
 wSn
 wSn
 uaL
@@ -310443,7 +313528,7 @@ aOn
 aOn
 lpa
 nCh
-wbg
+qCT
 wbg
 wbg
 hOh
@@ -310469,28 +313554,28 @@ xdq
 vka
 qqW
 wbg
-wVI
+wbg
 tnv
 pUl
 pUl
 rJX
 tCr
 guP
+lmZ
 guP
-guP
-teR
-wbg
+tsI
 wbg
 qtV
-mwE
-yjP
+iPY
+iPY
+iPY
+wew
 wVI
+weX
 wVI
-wSl
-bQf
-mwE
-pKQ
-mwE
+vKP
+iPY
+puf
 adK
 xMr
 yho
@@ -310871,28 +313956,28 @@ xdq
 vka
 qqW
 wbg
-wVI
+wbg
 hmk
 pUl
 rJX
 eai
 tCr
 guP
-guP
+wWL
 guP
 iGf
 viq
-wbg
 qtV
-uFp
-vWY
-weX
+iPY
+iPY
+iPY
+wew
 wxZ
-wYv
-mwE
-ueX
-mwE
-mwE
+wVI
+bQf
+gDl
+nXd
+jAT
 adK
 dHZ
 xww
@@ -310912,7 +313997,6 @@ qvR
 qvR
 spp
 qvR
-qzy
 qvR
 qvR
 qvR
@@ -310921,7 +314005,8 @@ qvR
 qvR
 qvR
 qvR
-wpm
+qvR
+qvR
 bzI
 fxx
 fxx
@@ -311273,27 +314358,27 @@ wan
 xdq
 oAn
 wbg
-wVI
+wbg
 ufu
 pUl
 pUl
-hGr
+pUl
 fQm
 guP
 guP
 guP
-guP
+mgR
 uTQ
-wbg
-wbg
-wbg
-wbg
-ybh
-wDZ
-utL
-jEB
-aOn
-mwE
+qtV
+nXd
+nXd
+nXd
+aWR
+wVI
+wVI
+wVI
+wVI
+wVI
 rmJ
 adK
 pht
@@ -311352,7 +314437,7 @@ lVe
 uxL
 sZI
 xlx
-usw
+tDc
 iTv
 cXU
 iTv
@@ -311630,7 +314715,7 @@ uOL
 jxy
 vbO
 oif
-oif
+wIU
 oif
 uJk
 tOz
@@ -311675,7 +314760,7 @@ iqY
 tYm
 oAn
 wbg
-wVI
+wbg
 wKT
 wKT
 hpJ
@@ -311685,18 +314770,18 @@ sxR
 sxR
 sxR
 sxR
-wKT
+abh
 wbg
-wbg
-wbg
+uFp
+uFp
 aSH
-fRN
-pkK
-mwE
-jEB
-mwE
-qKU
-mwE
+uFp
+wVI
+wVI
+wVI
+wVI
+wVI
+dFU
 oUn
 xMr
 vwQ
@@ -311739,7 +314824,7 @@ hLK
 nht
 fxx
 fxx
-wxd
+uFz
 wxd
 wSn
 wSn
@@ -312077,28 +315162,28 @@ iqY
 tYm
 oAn
 wbg
-wVI
-wKT
+wbg
+xPf
 dTB
 tVP
 tVP
 jLX
-tVP
+tCG
 tVP
 tVP
 tCG
-wKT
+kkT
 wbg
-wbg
-fRN
-aOn
-mwE
-mwE
-mwE
-nPQ
-auT
-qRp
-mwE
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+rZY
 ejJ
 xMr
 wCE
@@ -312479,7 +315564,7 @@ dWG
 xdq
 xAu
 wbg
-wVI
+wbg
 wKT
 sSW
 tVP
@@ -312489,19 +315574,19 @@ tVP
 tVP
 tVP
 tVP
-wKT
-wbg
+xdw
 qtV
-mwE
-eSt
-aOn
-pKQ
+aSD
+rZY
+wVI
+wxZ
+wVI
 xbo
-aOn
-auT
-qKU
-uHk
-uHk
+wVI
+bQf
+wVI
+wVI
+rZY
 dHZ
 xMr
 xMr
@@ -312879,31 +315964,31 @@ pAS
 sZN
 sZN
 xdq
-wVI
+aok
 wbg
-wVI
-wKT
+wbg
+xPf
 rJC
 tVP
+paK
 tVP
 tVP
-tZZ
-tZZ
-tZZ
+dqD
 tVP
-wKT
-wVI
+tVP
+xdw
 qtV
-hOh
-aOn
-aOn
-mwE
-mwE
-mwE
-mwE
-xEB
-wJq
-gaq
+aSD
+rZY
+wVI
+wxZ
+wVI
+wVI
+wVI
+bQf
+wVI
+rZY
+uMi
 kjH
 kjH
 kjH
@@ -313281,31 +316366,31 @@ sZN
 sZN
 sZN
 xdq
-wVI
+wew
 wbg
-wVI
+wbg
 wKT
 kFS
 tVP
+oyI
+jpF
+qdu
+whe
 tVP
-tVP
-tVP
-tVP
-tVP
-xaD
-abh
-wVI
+tCG
+xdw
 wbg
-xEB
-gDe
-aOn
-uFp
-mwE
-gSp
-nZQ
-mwE
-mwE
-aOn
+wbg
+wVI
+suC
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
 oVI
 bmi
 hyR
@@ -313633,7 +316718,7 @@ oif
 oif
 oif
 oif
-eUJ
+tiH
 eUJ
 eUJ
 jxy
@@ -313683,31 +316768,31 @@ sZN
 sZN
 lzC
 xdq
-wVI
+aok
 wbg
-wVI
+wbg
 wKT
 eWj
 yfY
-yfY
-tVP
+ijS
+mmb
 tZZ
 vGQ
-vGQ
-tVP
+yfY
+yfY
 wKT
 onR
-wbg
-hOh
+qEa
 vXm
-wjB
-wjB
-wjB
-quL
-mwE
-mwE
-mwE
-aOn
+vXm
+vXm
+xxe
+wyq
+wVI
+wVI
+wVI
+rZY
+wVI
 kjH
 bmi
 bmi
@@ -314085,7 +317170,7 @@ sZN
 sZN
 lzC
 xdq
-wVI
+qls
 wbg
 aNQ
 wKT
@@ -314100,16 +317185,16 @@ yfY
 wKT
 eur
 wbg
-ddH
-wVI
 uqe
 ewM
 uqe
-wra
-auT
-aOn
-mwE
-mwE
+coP
+wew
+wVI
+wVI
+rZY
+xhI
+rZY
 jXw
 xgi
 rYE
@@ -314487,9 +317572,9 @@ pDy
 sZN
 sZN
 xdq
-wVI
+aok
 wbg
-wVI
+wbg
 cCQ
 yfY
 yfY
@@ -314499,19 +317584,19 @@ yfY
 yfY
 yfY
 yfY
-wKT
+ycz
+wbg
+fLK
+uqe
+uqe
+uqe
+tDm
+wew
+weX
 wVI
-wbg
-wbg
-pMn
-uqe
-uqe
-uqe
-wra
-mwE
-mwE
-mwE
-mwE
+rZY
+sbF
+rZY
 jXw
 xgi
 rYE
@@ -314552,7 +317637,7 @@ gkv
 hLK
 njv
 fxx
-fxx
+rch
 wxd
 wxd
 wSn
@@ -314858,7 +317943,7 @@ wrj
 jDm
 jDm
 mwE
-mwE
+tro
 mwE
 wbg
 wbg
@@ -314889,31 +317974,31 @@ pAS
 sZN
 sZN
 xdq
-wVI
+wew
 wbg
-wVI
+wbg
 cJz
 yfY
-ijS
+bpA
 kfr
-mmb
-uaj
-mmb
-kfr
-ijS
+lUn
+vGQ
+tZZ
+xpM
+pFy
 wKT
 cIh
 wbg
-wbg
-wVI
 uqe
 ewM
 uqe
-wra
-mwE
-mwE
-aOn
-mwE
+tDm
+wew
+wVI
+wVI
+wVI
+rZY
+wVI
 kjH
 gDi
 bmi
@@ -315291,12 +318376,11 @@ ygF
 ygF
 uDv
 xdq
-wVI
+aok
 wbg
-wVI
+wbg
 wKT
 eyJ
-cJz
 wKT
 wKT
 wKT
@@ -315304,17 +318388,18 @@ wKT
 wKT
 wKT
 wKT
-haB
-wbg
-wbg
-vXm
+wKT
+asE
+qEa
 gGZ
 gGZ
 gGZ
-xdw
-mwE
-mwE
-aOn
+tDE
+aWR
+wqq
+wqq
+wqq
+wqq
 wqq
 kjH
 kjH
@@ -315693,32 +318778,32 @@ ygF
 ygF
 uDv
 xdq
-wVI
+qls
 wbg
-wVI
+wbg
 wKT
-viq
-viq
-ksK
+jpw
+fCr
+urF
 qRm
-hbc
-vQV
-bPv
-xbW
+urF
+qRm
+urF
+qRm
 wKT
-wVI
 wbg
 wbg
 wbg
 wbg
-aOn
-mwE
-qEa
-mwE
-mwE
-aOn
-auT
-wVI
+wbg
+wbg
+wbg
+wbg
+vJU
+wbg
+vJU
+vJU
+qPD
 wVI
 wVI
 wVI
@@ -316095,9 +319180,9 @@ kaA
 wan
 vka
 xdq
-wVI
+qls
 wbg
-wVI
+wbg
 wKT
 iov
 viq
@@ -316108,18 +319193,18 @@ viq
 viq
 viq
 wKT
-wVI
+wbg
 wbg
 wbg
 wbg
 wbg
 rEo
-aOn
-mwE
-qCT
-mwE
-gaq
-mwE
+wbg
+wbg
+wbg
+wbg
+wbg
+wbg
 wbg
 wbg
 wbg
@@ -316497,31 +319582,31 @@ pMj
 pPI
 xdq
 xdq
-wVI
+aok
 wbg
-wVI
+wbg
 wKT
 rRB
 iQe
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+viq
+viq
+viq
+viq
+viq
+viq
 wKT
-wVI
+wbg
 wbg
 usR
 ncb
 ncb
-vgA
+tpi
 wbg
-mwE
-mwE
-mwE
-mwE
-gaq
+wVI
+wVI
+wVI
+wVI
+uKJ
 wVI
 wVI
 wbg
@@ -316899,20 +319984,20 @@ pOs
 pRW
 xdq
 qls
+jTZ
 wbg
 wbg
-wVI
 wKT
 wKT
 jCs
-ovj
+urF
 rHj
 urF
-wFp
-wTs
-xwi
+rHj
+urF
+rHj
 wKT
-wVI
+wbg
 wbg
 usR
 xAt
@@ -317300,10 +320385,10 @@ xdq
 xdq
 xdq
 xdq
+dKn
 wbg
 wbg
 wbg
-wVI
 wKT
 wKT
 wKT
@@ -317314,11 +320399,11 @@ wKT
 wKT
 wKT
 wKT
-wVI
+wbg
 wbg
 vAB
 bnQ
-ihW
+agj
 nWM
 wbg
 kjH
@@ -317702,21 +320787,21 @@ xMr
 xMr
 xMr
 xMr
+wew
 wbg
 wbg
 wbg
-wVI
-wVI
+wbg
 fBF
-wVI
-wVI
-wVI
-wVI
-wVI
-wVI
+wbg
+wbg
+wbg
+wbg
+wbg
+wbg
 fBF
-wVI
-wVI
+wbg
+wbg
 wbg
 wbg
 iOq
@@ -318104,6 +321189,7 @@ dCV
 csA
 dCV
 hXf
+aok
 wbg
 wbg
 wbg
@@ -318119,8 +321205,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
-aoD
+wEd
 wEd
 wEd
 wbg
@@ -318506,7 +321591,7 @@ dCV
 dCV
 dCV
 qee
-wbg
+jTZ
 wbg
 wbg
 wbg
@@ -318908,7 +321993,7 @@ oTD
 csA
 dCV
 hXf
-wbg
+jHc
 wbg
 wbg
 wbg
@@ -319312,11 +322397,11 @@ xMr
 xMr
 gGZ
 qCy
-wbg
-wbg
-wbg
-wbg
-wbg
+isO
+wVI
+weX
+wVI
+spD
 wbg
 ekQ
 qDx
@@ -319713,12 +322798,12 @@ bmi
 mgx
 xMr
 xAt
-qCy
+gvi
 wbg
-wbg
-wbg
-wbg
-wbg
+wVI
+wVI
+wVI
+wVI
 wbg
 hOh
 qDx
@@ -320116,11 +323201,11 @@ oVp
 xMr
 qnO
 oZC
-wbg
-wbg
-wbg
-wbg
-wbg
+ikM
+wVI
+xbo
+wVI
+spD
 wbg
 hOh
 qDx
@@ -320518,11 +323603,11 @@ nTe
 qhC
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+ikM
+wVI
+wVI
+wVI
+spD
 wbg
 hOh
 qDx
@@ -320918,13 +324003,13 @@ oXn
 oXn
 oXn
 xMr
-asE
+vtB
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
+wVI
+wVI
+wVI
+wVI
 wbg
 ekQ
 qDx
@@ -321320,13 +324405,13 @@ paz
 bmi
 bmi
 xMr
+dKn
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+isO
+wVI
+weX
+wVI
+spD
 wbg
 lHf
 rfx
@@ -321722,7 +324807,7 @@ gVS
 gVS
 bmi
 xMr
-wbg
+aok
 wbg
 wbg
 wbg
@@ -322124,7 +325209,7 @@ poR
 pPs
 bmi
 qhR
-wbg
+dKn
 wbg
 wbg
 wbg
@@ -322526,7 +325611,7 @@ ppo
 ssG
 bmi
 qkl
-wbg
+qls
 wbg
 wbg
 wbg
@@ -322928,7 +326013,7 @@ orY
 orY
 bmi
 xMr
-wbg
+aok
 wbg
 wbg
 wbg
@@ -322951,7 +326036,7 @@ ewt
 cEF
 wbg
 xll
-utL
+obE
 aOn
 jHc
 mwE
@@ -323330,7 +326415,7 @@ bmi
 mou
 bmi
 xMr
-wbg
+aok
 wbg
 wbg
 wbg
@@ -323732,7 +326817,7 @@ xMr
 xMr
 xMr
 xMr
-wbg
+wew
 wbg
 wbg
 wbg
@@ -324527,7 +327612,7 @@ xAt
 xAt
 xAt
 xAt
-fXg
+xAt
 xAt
 xAt
 xrd
@@ -325727,24 +328812,24 @@ ujh
 xAt
 xAt
 vtw
-wOR
-wOR
-wOR
-wOR
 vtw
 vtw
 vtw
 vtw
 vtw
 vtw
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
 vtw
 wOR
 wOR
@@ -326134,17 +329219,17 @@ vtw
 vtw
 vtw
 vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 vtw
 vtw
 vtw
@@ -326530,20 +329615,20 @@ qvR
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xET
+hpK
+rcr
+xKF
+xKF
+xKF
+xKF
 xKF
 xKF
 xKF
@@ -326932,22 +330017,22 @@ qvR
 uaL
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-iSJ
-iuo
+xKF
+jVi
+xHe
+xHe
+xbW
+xKF
+xKF
+eBN
+eBN
+eBN
 mGn
-iug
-ejY
+mGn
+vVX
 trI
-uHj
-uHj
+wDz
+wDz
 hcp
 tkZ
 xKF
@@ -327334,23 +330419,23 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-obq
+xKF
+jfQ
+xHe
+xHe
+xbW
+xKF
+xKF
+ejY
+eBN
+eBN
+mGn
+mGn
+ejY
+trI
+wDz
 rTm
-uHj
+wDz
 obL
 xKF
 vtw
@@ -327736,23 +330821,23 @@ uTf
 afX
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-ogC
-yiI
-uHj
-uHj
-uHj
+xKF
+vXE
+xHe
+xHe
+xbW
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+wDz
+wDz
+wDz
 oiC
 xKF
 vtw
@@ -327776,7 +330861,7 @@ uJF
 mzZ
 gGe
 ddH
-aOv
+beQ
 mwE
 nZQ
 oXE
@@ -328138,23 +331223,23 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-iuo
-uHj
-uHj
-uHj
+xKF
+mrE
+xHe
+xHe
+bhY
+xKF
+xKF
+xKF
+xKF
+tQZ
+ofq
+eBN
+wDz
+suN
+wDz
 bok
-uHj
+wDz
 tkZ
 xKF
 vtw
@@ -328540,21 +331625,21 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xKF
+goz
+xHe
+xHe
+lWe
+xKF
+xKF
 iuo
 wVy
 ofq
 ofq
-iuo
+eBN
 bok
 suN
-uHj
+wDz
 nrx
 idG
 obL
@@ -328942,21 +332027,21 @@ aJj
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xKF
+fUW
+xHe
+tBm
+uoi
+xKF
+xKF
 iuo
 wVy
 ofq
 ofq
-iuo
-uHj
-uHj
-uHj
+eBN
+wDz
+suN
+wDz
 iIl
 xKF
 xKF
@@ -329344,24 +332429,24 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
+eEh
+oyU
+xKF
+wMm
 xKF
 xKF
 xKF
 xKF
 xKF
 ofq
-ofq
-iuo
+eBN
 bok
 suN
-uHj
+wDz
 tkZ
 xKF
-xKF
+vtw
 vtw
 vtw
 wOR
@@ -329746,21 +332831,21 @@ uaL
 afX
 xAt
 xAt
-vtw
-lAs
-lAs
-xKF
+oMa
+fCM
+fCM
+cNo
 twX
-dsW
-oIv
+cNo
+vmi
 eeO
+omS
 xKF
-ccY
-iuo
-iuo
-uHj
-uHj
-uHj
+eBN
+eBN
+wDz
+suN
+wDz
 vCr
 xKF
 vtw
@@ -330148,21 +333233,21 @@ uaL
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-xKF
+oMa
+fCM
+fCM
+fCM
+fCM
+fVN
+wNW
 dsW
-oIv
-oIv
-dsW
-vSM
-oIv
-oIv
-aem
-oIv
-cdn
-dsW
+sKd
+xgL
+wDz
+wDz
+wDz
+wDz
+nrx
 obL
 xKF
 vtw
@@ -330550,22 +333635,22 @@ afX
 uaL
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-oIv
-oIv
-oIv
-oIv
+iSJ
+iuo
+iuo
+iuo
+fVN
+wPC
+dsW
+sKd
 xgL
-rRA
 oIv
-oIv
-oIv
-oIv
-oIv
-uHj
+wDz
+wDz
+wDz
+wDz
+wDz
 xKF
 vtw
 vWe
@@ -330952,22 +334037,22 @@ afX
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-oIv
-oIv
-oIv
-oIv
+uTo
+uTo
+uTo
+iuo
+fCM
+sKd
+sKd
 vSM
-oIv
-oIv
+lJr
+wDz
 wDz
 wIl
 dXw
 uHg
-oIv
+wDz
 xKF
 vtw
 vWe
@@ -330978,7 +334063,7 @@ vtw
 qZh
 ltk
 mwE
-mwE
+tro
 mwE
 mwE
 aOv
@@ -331354,23 +334439,23 @@ tzK
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-bzl
-oIv
-dsW
-oIv
+kLB
+nNy
+loE
+iuo
+eiY
+sKd
+sKd
 xKF
 xKF
+lma
 lma
 xKF
 xKF
 xKF
-xKF
 jMf
-vtw
+xKF
 vtw
 vtw
 feY
@@ -331757,8 +334842,6 @@ pOO
 xAt
 xAt
 vtw
-lAs
-lAs
 xKF
 xKF
 xKF
@@ -331766,13 +334849,15 @@ xKF
 xKF
 xKF
 xKF
+xKF
+ihj
 eCn
-xKF
+eCn
 xKF
 wWK
 iuo
 iuo
-vtw
+xKF
 vtw
 vtw
 vtw
@@ -332149,11 +335234,11 @@ hcW
 uaL
 hcW
 hcW
+hcW
 uaL
 uaL
 uaL
-wSn
-wSn
+uaL
 uaL
 paf
 xAt
@@ -332169,12 +335254,12 @@ afz
 aHN
 sLc
 eCn
-xKF
+eCn
 xKF
 awJ
 iuo
 iuo
-vtw
+xKF
 iuo
 iuo
 vtw
@@ -332551,13 +335636,13 @@ hcW
 hcW
 hcW
 hcW
-sjP
-sjP
+hcW
 hcW
 uaL
-wSn
 uaL
 uaL
+uaL
+paf
 xAt
 xAt
 vtw
@@ -332571,12 +335656,12 @@ eCn
 eCn
 eCn
 eCn
-xKF
+eCn
 xKF
 gqN
 iuo
 iuo
-vtw
+xKF
 iuo
 iuo
 vtw
@@ -332952,13 +336037,13 @@ hcW
 hcW
 hcW
 hcW
-fVM
-sjP
-jXZ
+hcW
+hcW
 hcW
 uaL
-wSn
-wSn
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -332973,15 +336058,15 @@ eCn
 vxf
 xSG
 eCn
-xKF
+eCn
 xKF
 xKF
 xKF
 jNF
-vtw
+xKF
 kPZ
-vtw
-vtw
+xKF
+xKF
 jMf
 ofb
 vtw
@@ -333355,12 +336440,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
-wSn
-wSn
+uaL
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -333375,15 +336460,15 @@ eCn
 eCn
 eCn
 eCn
-xKF
+eCn
 euo
 oOU
 oOU
 smO
 buj
 smO
-vtw
-vtw
+vZt
+kSh
 sKd
 uHb
 vtw
@@ -333757,12 +336842,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-sjP
 hcW
 hcW
-wSn
-wSn
+hcW
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -333777,7 +336862,7 @@ kAT
 aee
 sLc
 eCn
-lma
+eCn
 mty
 smO
 smO
@@ -333785,7 +336870,7 @@ smO
 nXv
 smO
 hnd
-kSh
+sKd
 sKd
 sKd
 vtw
@@ -334159,13 +337244,13 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
-wSn
-nZj
+uaL
+uaL
+uaL
+paf
 xAt
 xAt
 vtw
@@ -334179,12 +337264,12 @@ xKF
 xKF
 xKF
 jMf
-xKF
+vtw
 vtw
 wnv
-tlQ
 vtw
 vtw
+jMf
 jMf
 vtw
 bJs
@@ -334561,11 +337646,11 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
+uaL
+uaL
 uaL
 paf
 xAt
@@ -334581,12 +337666,12 @@ oSY
 szN
 szN
 sKd
-abZ
 vtw
 iuo
 iuo
 fXv
 vtw
+wOR
 wOR
 vtw
 alk
@@ -334963,13 +338048,13 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
-hcW
-hcW
+uaL
+uaL
+uaL
+uaL
 xAt
 xAt
 vtw
@@ -334983,12 +338068,12 @@ bau
 sKd
 sKd
 sKd
-sKd
 clr
 iuo
 aFS
 iuo
 clr
+wOR
 wOR
 rKn
 sKd
@@ -335365,8 +338450,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -335385,12 +338470,12 @@ lel
 szN
 szN
 sKd
-wPC
 vtw
 bEo
 iuo
 iuo
 vtw
+wOR
 wOR
 rKn
 sKd
@@ -335767,8 +338852,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -335787,12 +338872,12 @@ iuo
 iuo
 iuo
 sKd
-mQA
 vtw
 vtw
 clr
 vtw
 vtw
+wOR
 wOR
 vtw
 mfd
@@ -336169,8 +339254,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -336191,10 +339276,10 @@ iuo
 sKd
 wPC
 vtw
-qHe
 wOR
 azQ
 qHe
+wOR
 wOR
 hnd
 sKd
@@ -336570,9 +339655,9 @@ hcW
 hcW
 hcW
 hcW
-fVM
-jXZ
-jXZ
+hcW
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -336973,12 +340058,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
-jXZ
-jXZ
-btl
-qbG
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 hcW
 xAt
 xAt
@@ -337375,12 +340460,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
-jXZ
-cwO
-btl
-qbG
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 hcW
 xAt
 xAt
@@ -379659,7 +382744,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -380001,67 +383086,67 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -380402,6 +383487,31 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+qeY
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
 erZ
 erZ
 erZ
@@ -380415,6 +383525,8 @@ erZ
 erZ
 erZ
 erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -380428,42 +383540,15 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -380804,6 +383889,46 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+qeY
+seC
+rST
+eEY
+nBf
+nBf
+seC
+nBf
+nBf
+seC
+bPL
+qeY
+cyK
+qeY
+irw
+qeY
+qeY
+quL
+qeY
+qeY
+vLA
+veW
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -380818,54 +383943,14 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -381206,6 +384291,31 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+qeY
+seC
+rST
+uDD
+nBf
+nBf
+seC
+nBf
+nBf
+seC
+bPz
+qeY
+qeY
+bPz
+seC
+qeY
+qeY
+seC
+mGL
+qeY
+eGn
+veW
 erZ
 erZ
 erZ
@@ -381220,6 +384330,8 @@ erZ
 erZ
 erZ
 erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -381233,41 +384345,14 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -381608,6 +384693,47 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+qeY
+seC
+seC
+seC
+chY
+nBf
+seC
+nBf
+nBf
+seC
+rgO
+fRS
+qeY
+aPR
+seC
+fIp
+qeY
+seC
+cWr
+kpI
+txm
+veW
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -381625,51 +384751,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
 vIa
 erZ
 erZ
@@ -382010,6 +385095,47 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+qeY
+seC
+seC
+seC
+chY
+nBf
+seC
+nBf
+nBf
+seC
+ebb
+qeY
+qeY
+pdm
+seC
+qeY
+qeY
+seC
+seC
+seC
+seC
+seC
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -382028,50 +385154,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -382412,6 +385497,47 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+qeY
+seC
+seC
+seC
+guw
+nBf
+seC
+nBf
+nBf
+seC
+ebb
+qeY
+fIp
+pdm
+seC
+qeY
+fIp
+seC
+seC
+seC
+seC
+seC
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -382430,50 +385556,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
+bqt
+bqt
+aUc
 vIa
 erZ
 erZ
@@ -382814,6 +385899,47 @@ erZ
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+seC
+seC
+seC
+seC
+seC
+qhQ
+seC
+seC
+seC
+seC
+qzy
+nuH
+qeY
+bNW
+seC
+qeY
+fIp
+quL
+qeY
+eGn
+vLA
+veW
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -382832,50 +385958,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -383216,6 +386301,47 @@ vIa
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+seC
+mWP
+nBf
+nBf
+nBf
+nBf
+peB
+seC
+iYF
+qeY
+qeY
+fIp
+qeY
+bPz
+seC
+qeY
+qeY
+seC
+qeY
+qeY
+qeY
+veW
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -383233,51 +386359,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -383618,6 +386703,47 @@ vIa
 erZ
 erZ
 erZ
+qeY
+qeY
+qeY
+seC
+sxJ
+nBf
+nBf
+nBf
+nBf
+bVJ
+seC
+iYF
+qeY
+dBs
+qeY
+jzd
+bPz
+seC
+qeY
+qeY
+seC
+btb
+ebe
+txm
+veW
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -383634,52 +386760,11 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -384020,6 +387105,47 @@ vIa
 vIa
 erZ
 erZ
+qeY
+qeY
+qeY
+seC
+yla
+nBf
+nBf
+nBf
+nBf
+bVJ
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+usp
+usp
+seC
+seC
+seC
+seC
+seC
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
 erZ
 erZ
 erZ
@@ -384036,51 +387162,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -384425,6 +387510,24 @@ erZ
 erZ
 erZ
 erZ
+seC
+lVo
+nBf
+nBf
+nBf
+nBf
+peB
+seC
+wMG
+hAf
+aBY
+bUi
+aBY
+hAf
+sPD
+nBf
+nBf
+cjJ
 erZ
 erZ
 erZ
@@ -384444,6 +387547,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -384459,28 +387563,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -384827,6 +387912,24 @@ erZ
 erZ
 erZ
 erZ
+seC
+lxc
+nBf
+nBf
+nBf
+nBf
+tBC
+seC
+nBf
+xkF
+xkF
+nBf
+mvg
+mvg
+nBf
+uHj
+nBf
+cjJ
 erZ
 erZ
 erZ
@@ -384846,6 +387949,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -384861,28 +387965,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -385229,51 +388314,23 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ryI
-nqU
-oJO
-nqU
-nqU
-ryI
-nqU
-oJO
-nqU
-nqU
+seC
+rOi
+nBf
+nBf
+nBf
+nBf
+oaX
+xLH
+nBf
+nBf
+nBf
+uHj
+nBf
+nBf
+uHj
+nBf
+nBf
 cjJ
 erZ
 erZ
@@ -385285,6 +388342,34 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -385631,6 +388716,24 @@ erZ
 erZ
 erZ
 erZ
+seC
+iDe
+nBf
+nBf
+nBf
+nBf
+tBC
+seC
+nBf
+mcY
+mcY
+nBf
+nBf
+eSD
+eSD
+uHj
+nBf
+cjJ
 erZ
 erZ
 erZ
@@ -385650,6 +388753,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -385665,28 +388769,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-nqU
-bUi
-xbD
-xbD
-dwO
-nqU
-dTa
-xbD
-bUi
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386033,52 +389118,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-ikM
-xbD
-xbD
+seC
+ett
 nBf
-nqU
-kvj
-xbD
-ikM
-nqU
-ebb
+nBf
+nBf
+nBf
+prC
+seC
+wMG
+aBY
+aBY
+sPD
+nBf
+nBf
+eEY
+ezK
+nBf
+cjJ
 erZ
 erZ
 erZ
@@ -386089,6 +389146,34 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386435,6 +389520,24 @@ erZ
 erZ
 erZ
 erZ
+seC
+xQq
+nBf
+nBf
+nBf
+nBf
+prC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+wru
+wru
+seC
 erZ
 erZ
 erZ
@@ -386454,6 +389557,8 @@ erZ
 erZ
 erZ
 erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386467,30 +389572,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-cwd
-xbD
-xbD
-xkF
-nqU
-bVa
-xbD
-xbD
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -386837,6 +389922,28 @@ erZ
 erZ
 erZ
 erZ
+seC
+iDe
+nBf
+nBf
+nBf
+nBf
+oOf
+seC
+wlO
+nEA
+uac
+gTE
+uac
+nEA
+gTE
+ezK
+nBf
+seC
+seC
+seC
+seC
+seC
 erZ
 erZ
 erZ
@@ -386853,6 +389960,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -386866,33 +389974,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-nuH
-xbD
-xbD
-vdg
-nqU
-vdg
-xbD
-xbD
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -387236,7 +390321,31 @@ erZ
 erZ
 erZ
 erZ
-vIa
+aUc
+erZ
+seC
+seC
+chY
+nBf
+nBf
+nBf
+nBf
+kTt
+seC
+nBf
+uHj
+nBf
+nBf
+nBf
+nBf
+uHj
+nBf
+nBf
+quL
+qeY
+qeY
+vLA
+veW
 erZ
 erZ
 erZ
@@ -387253,6 +390362,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -387266,35 +390376,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-ryI
-cld
-skP
-kHC
-nqU
-nqU
-nqU
-cld
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -387638,8 +390723,31 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
+seC
+seC
+chY
+nBf
+nBf
+nBf
+nBf
+oaX
+seC
+xgG
+nBf
+nBf
+uHj
+uHj
+nBf
+nBf
+nBf
+nBf
+seC
+nEp
+qeY
+qeY
+veW
 erZ
 erZ
 erZ
@@ -387656,36 +390764,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-woq
-xbD
 bqt
-jCh
-nqU
-xbD
-xbD
-xbD
-nqU
 erZ
 erZ
 erZ
@@ -387697,6 +390776,12 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -388040,54 +391125,31 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
+aUc
+aUc
 jCr
-xbD
-ebe
-ebe
-xbD
-xbD
 jCr
-xbD
-nqU
+chY
+oIb
+oaX
+nBf
+nBf
+nBf
+kxz
+nBf
+nBf
+nBf
+uHj
+uHj
+nBf
+nBf
+nBf
+nBf
+seC
+mGL
+qeY
+qeY
+veW
 erZ
 erZ
 erZ
@@ -388098,6 +391160,29 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -388444,10 +391529,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+jCr
+jCr
+jCr
+oaX
+oaX
+nBf
+nBf
+vcF
+aHF
+uHj
+nBf
+nBf
+nBf
+nBf
+uHj
+nBf
+nBf
+seC
+oje
+qeY
+qeY
+veW
 erZ
 erZ
 erZ
@@ -388464,6 +391568,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -388477,29 +391582,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-ryI
-cld
-skP
-kHC
-nqU
-nqU
-nqU
-nqU
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -388847,10 +391932,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+jCr
+jCr
+oaX
+oaX
+oaX
+seC
+seC
+vsg
+vsg
+nLB
+vsg
+ezK
+nBf
+nBf
+nBf
+seC
+ldc
+txm
+xLV
+veW
 erZ
 erZ
 erZ
@@ -388867,6 +391970,7 @@ erZ
 erZ
 erZ
 erZ
+bqt
 erZ
 erZ
 erZ
@@ -388880,28 +391984,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-ebb
-nqU
-xbD
-xbD
-xbD
-cMs
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389250,11 +392335,27 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+jCr
+jCr
+jCr
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+uSF
+uSF
+uSF
+uSF
+seC
+seC
+seC
+seC
+seC
 erZ
 erZ
 erZ
@@ -389271,6 +392372,8 @@ erZ
 erZ
 erZ
 erZ
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389283,27 +392386,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-nqU
-qYw
-kFh
-mVz
-xbD
-lGI
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389653,11 +392738,12 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+bqt
 erZ
 erZ
 erZ
@@ -389685,14 +392771,12 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ryI
-nqU
-nqU
-nqU
-nqU
-ryI
-ebb
+erZ
+erZ
+erZ
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -389703,9 +392787,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -390087,26 +393172,26 @@ erZ
 erZ
 erZ
 erZ
-ebb
-vLA
-vLA
-vLA
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -390489,14 +393574,6 @@ erZ
 erZ
 erZ
 erZ
-ebb
-vLA
-erZ
-vLA
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -390507,7 +393584,15 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -390892,9 +393977,6 @@ erZ
 erZ
 erZ
 erZ
-vLA
-vLA
-vLA
 erZ
 erZ
 erZ
@@ -390905,10 +393987,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+cMs
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -391279,6 +394364,14 @@ erZ
 erZ
 erZ
 erZ
+jeb
+jeb
+jeb
+jeb
+jeb
+jeb
+jeb
+xKz
 erZ
 erZ
 erZ
@@ -391296,21 +394389,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+iME
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -391674,6 +394759,21 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+lxB
+aKy
+hSF
+hXE
+qKr
+oJO
+xKz
 erZ
 erZ
 erZ
@@ -391691,28 +394791,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+cMs
+gip
+cMs
+tSM
+gip
+vWY
 erZ
 erZ
 erZ
@@ -392076,6 +395161,26 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+ewj
+vPA
+vPA
+aem
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+jeb
+jeb
+jeb
+jeb
+jeb
 erZ
 erZ
 erZ
@@ -392088,33 +395193,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+gip
+gip
+iME
+cMs
+gip
+vWY
 erZ
 erZ
 erZ
@@ -392478,6 +395563,26 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+lLa
+lLa
+lLa
+lLa
+xKz
+fVQ
+fVQ
+jeb
+mZy
+fVQ
+rQE
+xKz
+fVQ
+bvN
+tYP
+jzv
+jeb
 erZ
 erZ
 erZ
@@ -392490,33 +395595,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+gip
+gip
+cMs
+tSM
+gip
+vWY
 erZ
 erZ
 erZ
@@ -392880,6 +395965,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+xKz
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+tUp
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+tUp
+fVQ
+bvN
+tYP
+vFz
+jeb
 erZ
 erZ
 erZ
@@ -392892,33 +395997,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+cMs
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -393282,6 +396367,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+sIE
+vdg
+fVQ
+fVQ
+lLa
+rZn
+jeb
+oey
+jgm
+vhx
+qQR
+fVQ
+lLa
+xKz
+fVQ
+tYP
+tYP
+jER
+jeb
 erZ
 erZ
 erZ
@@ -393294,33 +396399,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+iME
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -393684,6 +396769,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+oRp
+vdg
+fVQ
+fVQ
+lLa
+rZn
+jeb
+xKz
+xKz
+xKz
+xKz
+nGw
+xKz
+xKz
+fVQ
+tYP
+tYP
+abZ
+jeb
 erZ
 erZ
 erZ
@@ -393696,33 +396801,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+cMs
+gip
+cMs
+tSM
+gip
+vWY
 erZ
 erZ
 erZ
@@ -394086,6 +397171,26 @@ erZ
 erZ
 erZ
 erZ
+xKz
+ajl
+vdg
+fVQ
+fVQ
+fVQ
+fVQ
+tUp
+fVQ
+hCt
+wOG
+qGh
+fVQ
+bYK
+xKz
+fVQ
+bvN
+tYP
+jzv
+jeb
 erZ
 erZ
 erZ
@@ -394098,33 +397203,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+gip
+gip
+iME
+cMs
+gip
+vWY
 erZ
 erZ
 erZ
@@ -394488,6 +397573,26 @@ erZ
 erZ
 erZ
 erZ
+xKz
+qGb
+vdg
+fVQ
+tkn
+fVQ
+fVQ
+jeb
+krZ
+fVQ
+fVQ
+fVQ
+fVQ
+gYB
+xKz
+fVQ
+bvN
+tYP
+vFz
+jeb
 erZ
 erZ
 erZ
@@ -394500,33 +397605,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+cMs
+gip
+cMs
+tSM
+gip
+vWY
 erZ
 erZ
 erZ
@@ -394890,14 +397975,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
 xKz
-jeb
-jeb
 xKz
-jeb
-jeb
 xKz
+xKz
+xKz
+nUr
+xKz
+xKz
+yeA
+fVQ
+jeb
+mZy
+fVQ
+qwp
+xKz
+fVQ
+tYP
+tYP
+jER
+jeb
 erZ
 erZ
 erZ
@@ -394910,25 +398007,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+iME
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -395292,13 +398377,25 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
+utx
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+hXt
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
+xKz
+fVQ
+tYP
+tYP
+abZ
 jeb
 erZ
 erZ
@@ -395312,25 +398409,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+cMs
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -395694,13 +398779,25 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
-fVQ
+utx
 lLa
 vZP
 lLa
 fVQ
+xKz
+cjy
+sKt
+fhc
+qpX
+fVQ
+htF
+xKz
+fVQ
+lhd
+tYP
+jzv
 jeb
 erZ
 erZ
@@ -395714,25 +398811,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+gip
+gip
+gip
+gip
+gip
+vWY
 erZ
 erZ
 erZ
@@ -396096,42 +399181,42 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 xKz
 fVQ
 lLa
 noC
 lLa
+rQE
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
 fVQ
+lhd
+fVQ
+fVQ
+jeb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+wSN
+gip
 xKz
-jeb
-jeb
-xKz
-jeb
-jeb
-xKz
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-xKz
-jeb
+ilf
 bOK
 jeb
 xKz
@@ -396498,20 +399583,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
 kHs
 tat
 xAL
 tat
 nIo
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+xKz
+nUr
+xKz
+xKz
+xKz
 jeb
-ufd
-ufd
-ufd
-ufd
-ufd
-jeb
 erZ
 erZ
 erZ
@@ -396524,14 +399615,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+wSN
+gip
 jeb
 fVQ
 ugK
@@ -396908,12 +399993,18 @@ bOK
 rOt
 fVQ
 kdM
-ufd
-ufd
-ufd
-ufd
-ufd
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 kdM
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 pty
 pty
 pty
@@ -396927,13 +400018,7 @@ pty
 pty
 pty
 pty
-pty
-pty
-pty
-pty
-pty
-pty
-pty
+rsd
 bOK
 kHs
 gGH
@@ -397312,16 +400397,16 @@ vES
 xKz
 xKz
 kBs
-peN
-peN
+jeb
+jeb
 xKz
 xKz
 evw
-rsd
-rsd
-rsd
-rsd
-rsd
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 rsd
 rsd
 rsd
@@ -428646,8 +431731,8 @@ wAm
 wAm
 wAm
 wAm
-wAm
-qLF
+uxZ
+uxZ
 wAm
 wAm
 wAm
@@ -428659,12 +431744,12 @@ wAm
 wAm
 wAm
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -429048,25 +432133,25 @@ rwH
 uSx
 teW
 kqc
-wAm
-wAm
-wAm
+iqo
+jjS
+bei
 vMQ
 vsf
-sIE
+rwH
 nKu
-nSr
-sIE
+jiv
+rwH
 teW
-hqI
-fUr
+vox
+hpV
 wte
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -429447,28 +432532,28 @@ teW
 dvD
 jiv
 jiv
-uSx
+rGY
 teW
-nSr
+wDZ
+bVa
 jiv
-jjS
 jiv
-nSr
-nSr
-nSr
+jiv
+jiv
+jiv
 bEL
 jiv
 jjS
 teW
 hqI
-hqI
+xHy
 uGf
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -429849,28 +432934,28 @@ teW
 yhF
 jiv
 jiv
-uSx
 teW
-nSr
+teW
+vMQ
+bVa
 jiv
 jiv
 jiv
-nSr
-nSr
-nSr
+jiv
+jiv
 nKu
-nSr
+jiv
 vIX
 teW
-fUr
 hqI
-wUw
+xHy
+uGf
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430248,12 +433333,12 @@ erZ
 fZJ
 fZJ
 teW
-yhF
+cBG
 jiv
 jiv
-teW
-teW
-sxM
+hcx
+cfw
+jiv
 jiv
 jiv
 jiv
@@ -430265,14 +433350,14 @@ wAm
 wAm
 wAm
 jGT
-hqI
-bPz
+xHy
+uGf
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430655,26 +433740,26 @@ jiv
 jiv
 hcx
 cfw
-nSr
-nSr
 jiv
-nSr
-nSr
-nSr
-nSr
+xSI
+jiv
+jiv
+dJj
+ujU
+htU
 teW
 ael
-cLL
-iRN
-fUr
 hqI
+hqI
+hqI
+xHy
 uGf
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431052,31 +434137,31 @@ erZ
 fZJ
 fZJ
 teW
-mrE
+cBG
 vAK
 xSI
 tML
 tML
-qpX
-teW
-fnF
-teW
-teW
-uzT
-fnF
+tML
+rRA
+rRA
+tML
+aGb
+tML
+aGb
 teW
 pDA
 hqI
-aac
 hqI
-gdJ
+hqI
+xHy
 uGf
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431461,24 +434546,24 @@ wAm
 tML
 teW
 nyc
-swm
-gbA
+ntK
+ntK
 cAe
-ybm
-swm
+djR
+oda
 teW
 ulu
 hqI
 fVE
-hqI
-hqI
-wUw
+xHy
+xHy
+uGf
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431858,29 +434943,29 @@ fZJ
 teW
 tML
 sdb
-ntK
+aur
 swm
 lPt
-ntK
-bkD
-vUf
-tak
-tak
-tak
 swm
+nyc
+ntK
+ntK
+tak
+xrf
+xrf
 teW
 uNz
 hqI
 hqI
-hqI
-hqI
+xHy
+lKp
 ojc
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432263,26 +435348,26 @@ tsB
 aur
 swm
 pLs
-ntK
-bkD
-vUf
-rSg
-rSg
-rSg
 swm
+nyc
+ntK
+ntK
+rSg
+yjP
+yjP
 teW
 ajj
 lLK
-hqI
+lLK
 uPa
 tML
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432666,12 +435751,12 @@ aur
 rVB
 vrG
 wtl
-wtl
-vUf
+ntK
+ntK
+ntK
 lYl
-lYl
-xrf
-swm
+gLV
+gLV
 ohA
 bcN
 bcN
@@ -432679,12 +435764,12 @@ bcN
 vWe
 ffv
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433067,12 +436152,12 @@ uKB
 oBU
 sUQ
 xXs
-swm
-swm
-swm
+ntK
+ntK
+ntK
+ntK
 uTT
-uTT
-uTT
+swm
 swm
 wQn
 bcN
@@ -433081,12 +436166,12 @@ bcN
 vWe
 ffv
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433469,13 +436554,13 @@ uKB
 aur
 uZa
 cPw
+qzB
+ntK
+ntK
+ntK
+sep
 ybm
 ybm
-vUf
-tak
-tak
-tak
-swm
 ohA
 bcN
 bcN
@@ -433483,12 +436568,12 @@ bcN
 vWe
 ffv
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433871,26 +436956,26 @@ sUb
 aur
 swm
 pLs
-ntK
-bkD
-vUf
-rSg
-rSg
-rSg
 swm
+nyc
+ntK
+ntK
+cAe
+oda
+oda
 teW
 eYI
 uZC
-vGN
+uZC
 tML
 tML
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434063,7 +437148,7 @@ uuE
 uuE
 uuE
 nqU
-tJC
+xkK
 lAB
 mKZ
 edk
@@ -434270,29 +437355,29 @@ fZJ
 teW
 gGI
 wYt
-ntK
+aur
 swm
 oyP
-ntK
-bkD
-vUf
-lYl
-lYl
-xrf
 swm
+nyc
+ntK
+ntK
+tak
+xrf
+xrf
 tML
-wAm
-wAm
-wAm
+eSt
+eSt
+eSt
 wAm
 tML
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434675,26 +437760,26 @@ wAm
 tML
 wAm
 tML
-rRD
 aXE
-swm
-swm
-lDq
-swm
-swm
+nyc
+ntK
+ntK
+vlp
+gJo
+chs
 tML
-rMM
-rMM
-wAm
+aac
+aac
+aac
 wAm
 hKU
 hKU
 lug
 tML
-tWY
-tWY
-tWY
-tWY
+teW
+squ
+squ
+squ
 squ
 squ
 squ
@@ -434702,7 +437787,7 @@ squ
 squ
 squ
 rTC
-rTC
+kIt
 squ
 squ
 squ
@@ -435064,7 +438149,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -435078,33 +438163,33 @@ tML
 teW
 tML
 tML
-tML
+bAs
 fnF
 tML
+aGb
 tML
-ycz
 aGb
 tML
 cfY
 cfY
 cfY
 wpe
-eCn
+fQd
 eCn
 sNY
+ess
 teW
 teW
 teW
 teW
 teW
-squ
 squ
 squ
 squ
 squ
 squ
 rTC
-rTC
+kIt
 rTC
 rTC
 rTC
@@ -435466,7 +438551,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -435479,34 +438564,34 @@ tML
 tML
 teW
 btc
-tUR
 bkD
 swm
-owz
-rMM
+swm
+fbf
+cfY
 cfY
 cfY
 vTd
 cfY
 cfY
 cfY
-teW
-aTF
+alk
 eCn
-sNY
-teW
+eCn
+eCn
+eCn
 teW
 aor
 xfh
+wUh
 teW
-squ
 squ
 squ
 squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -435868,8 +438953,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -435881,24 +438966,25 @@ tML
 tML
 teW
 wVs
-ntK
 ujc
+swm
 swm
 fbf
 cfY
 cfY
-uZy
-uZy
-uZy
-uZy
 cfY
-alk
-eCn
-eCn
-eCn
-fQd
+cfY
+cfY
+cfY
+cfY
 teW
-htf
+aTF
+oqk
+mVz
+eCn
+mYi
+gbX
+gbX
 gbX
 teW
 squ
@@ -435906,9 +438992,8 @@ squ
 squ
 squ
 squ
-squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -436271,7 +439356,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -436283,24 +439368,25 @@ wAm
 wAm
 teW
 btc
-tUR
 bkD
+swm
 swm
 owz
 rMM
 cfY
-idu
-xAh
-lIc
-sNp
 cfY
-teW
+uZy
+uZy
+uZy
+cfY
+alk
 eCn
+uRy
+eCx
 eCn
-eCn
-eCn
-teW
-xET
+mYi
+gbX
+gbX
 gbX
 teW
 squ
@@ -436308,9 +439394,8 @@ squ
 squ
 squ
 squ
-squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -436673,46 +439758,46 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 fZJ
 fZJ
 rxp
+wzC
 uKB
-nTR
 uBv
 tML
 tML
 tML
 xnv
-fnF
+vTy
 tML
 rMM
 cfY
-fPg
-pcQ
-nJX
-cpY
 cfY
-alk
+idu
+lIc
+sNp
+cfY
+teW
+aTF
 eCn
 eCn
-fLK
 eCn
-mYi
-gbX
-gbX
+teW
+eRE
+xli
+iRN
 teW
 squ
 squ
 squ
 squ
 squ
-squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -437075,17 +440160,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 fZJ
 fZJ
 rxp
 uKB
-nTR
-ntK
-bHX
+uKB
+uKB
+uKB
 kNs
 htZ
 swm
@@ -437093,28 +440178,28 @@ swm
 tML
 tML
 lQT
-tcW
-tcW
-tcW
-tcW
 cfY
-teW
-sbF
+fPg
+nJX
+cpY
+cfY
+wpe
+qcC
+qcC
 eCn
-uxZ
 eCn
 teW
-wyA
-seC
 teW
-squ
+teW
+teW
+teW
 squ
 squ
 squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -437477,18 +440562,18 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+erZ
+erZ
+erZ
+erZ
 fZJ
 fZJ
 rxp
 uKB
-nTR
-ntK
-ntK
-ntK
+uKB
+cld
+pcQ
+uKB
 nIr
 swm
 swm
@@ -437496,18 +440581,18 @@ jlM
 pzU
 cfY
 cfY
+tcW
+tcW
+tcW
 cfY
-cfY
-cfY
-cfY
-alk
+teW
 eCn
 eCn
-loE
-aym
 teW
+mYi
 teW
-teW
+lMZ
+lMZ
 teW
 squ
 squ
@@ -437516,7 +440601,7 @@ squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -437881,35 +440966,35 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
+teW
+teW
+teW
 teW
 rou
-nTR
-cCS
-nJy
-ntK
+uKB
+uKB
+uKB
+uKB
 nIr
 swm
 swm
 swm
 pzU
 cfY
-uZy
-uZy
-uZy
-uZy
+cfY
+cfY
+cfY
+cfY
 cfY
 teW
-aTF
-eCn
-tfp
+teW
+teW
+teW
 eCn
 teW
-lAs
-lAs
+lMZ
+lMZ
 teW
 squ
 squ
@@ -437918,7 +441003,7 @@ squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -438283,35 +441368,35 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-pur
+qtA
+teW
+uKB
+uKB
+ixl
+mMB
+gEJ
+nJy
 tML
-tML
-ydR
-tML
-cbQ
 swm
 swm
 lDq
 pzU
 cfY
-idu
-lIc
-sct
-sNp
 cfY
-alk
+uZy
+uZy
+uZy
+cfY
+mYi
 eCn
 eCn
+fQd
 eCn
-grk
 teW
-lAs
-lAs
+lMZ
+lMZ
 teW
 eQa
 rTC
@@ -438320,7 +441405,7 @@ rTC
 rTC
 rTC
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -438685,44 +441770,44 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-uKB
-cgD
+aoB
+teW
+dPE
+kRw
 tML
-gdJ
 tML
-pjB
+ydR
+tML
+cbQ
 swm
 swm
 tML
 tML
 lQT
-bWq
-iMA
-iMA
-pxR
 cfY
-wpe
-qcC
-qcC
-qcC
-tiH
+idu
+sct
+sNp
+cfY
+xOf
+dKL
+hVn
+cPr
+eCn
 teW
-lAs
-lAs
-lAs
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+lMZ
+lMZ
+lMZ
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -439087,34 +442172,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
 uKB
-tdJ
+hIC
+uKB
+uKB
+cgD
 tML
-gdJ
+hqI
 tML
-vaa
-lDq
-iWj
+pjB
+swm
+swm
 tML
-rMM
+fVM
 cfY
-tcW
-tcW
-tcW
-tcW
 cfY
+bWq
+iMA
+pxR
+cfY
+xOf
+bzz
+pvC
+lmP
+eCn
 teW
-eCn
-eCn
-eCn
-tiH
-teW
-lAs
+lMZ
 lAs
 lAs
 vIa
@@ -439489,34 +442574,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-nMd
-xeO
+uKB
+uKB
+uKB
+uKB
+tdJ
 tML
+gdJ
 tML
+vaa
+swm
+swm
 tML
-wAm
-wAm
-wAm
-wAm
-teW
+rMM
 eVa
-cfY
-cfY
-cfY
-cfY
+bKg
+tcW
+tcW
+tcW
 eVa
+sSu
+bGf
+gaA
+dwO
+eCn
 teW
-teW
-teW
-teW
-teW
-lAs
-lAs
+lMZ
 lAs
 lAs
 vIa
@@ -439891,34 +442976,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
+aUc
+teW
+jaB
+nMd
+uKB
+uKB
+xeO
 tML
 tML
 tML
-tML
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+wAm
+vTy
+wAm
+wAm
 teW
 teW
 wAm
 wAm
-aSD
+wAm
 wAm
 wAm
 teW
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aTF
+eCn
+grk
+eCn
+teW
+lMZ
 lAs
 lAs
 vIa
@@ -440293,34 +443378,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
 teW
-vsg
-xJe
-eBN
-xJe
-wAm
-wAm
-wAm
 teW
-lAs
-lAs
-lAs
-lAs
+teW
+pcQ
+uKB
+uKB
+fQq
+iYx
+pqm
+uHk
+uHk
+teW
+iYx
+iYx
+iYx
+iYx
+lMZ
+lMZ
+lMZ
+teW
+teW
+teW
+teW
+teW
+teW
+teW
+lMZ
 lAs
 lAs
 vIa
@@ -440695,34 +443780,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
+aUc
 lMZ
-eBN
-eBN
-eBN
-eBN
-eBN
 lMZ
 teW
-lAs
-lAs
-lAs
-lAs
+pcQ
+uKB
+uKB
+ggX
+iYx
+vaa
+uHk
+vQV
+teW
+xaD
+jBO
+oiq
+iYx
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
+lMZ
 lAs
 lAs
 vIa
@@ -441098,29 +444183,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-fZJ
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+lMZ
 teW
-mQr
-eBN
-eBN
-eBN
-eBN
-eBN
-dbt
+pcQ
+uKB
+uKB
+cCS
+iYx
+xoQ
+uHk
+uHk
 teW
+guL
+uHk
+uHk
+iYx
+lMZ
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -441500,29 +444585,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
 lMZ
 teW
+swT
+uKB
+uKB
+ohY
+iYx
+ftd
+uHk
+uHk
+qin
+uHk
+uHk
+dQz
+iYx
+lMZ
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -441902,29 +444987,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+lMZ
 teW
-dbt
-eBN
-dbt
-eza
-dbt
-eBN
-dbt
 teW
+teW
+teW
+teW
+iYx
+pKQ
+uHk
+iwf
+iYx
+vgy
+bzl
+bbl
+iYx
+lMZ
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -442304,29 +445389,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-gip
 lMZ
-eBN
 lMZ
-eBN
 lMZ
-eBN
+iYx
+iYx
+iYx
+iYx
+pqm
+uHk
+caC
+iYx
+iYx
+iYx
+iYx
+iYx
 lMZ
-teW
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -442706,29 +445791,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+lMZ
+iYx
+caC
+iug
+iYx
+iYx
+uHk
+iwf
+iYx
+xaD
+jBO
+oiq
+iYx
+lMZ
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-mQr
-eBN
-dbt
-eBN
-dbt
-eBN
-dbt
-teW
 lAs
 lAs
 lAs
@@ -443108,29 +446193,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
 lMZ
-eBN
+iYx
+guL
+uHk
+bAs
+uHk
+uHk
+uHk
+iYx
+guL
+uHk
+uHk
+iYx
 lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -443510,29 +446595,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+lMZ
+iYx
+uHk
+uHk
+iYx
+uHk
+uHk
+uHk
+qin
+uHk
+uHk
+dQz
+iYx
+lMZ
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-dbt
-ejY
-dbt
-ejY
-dbt
-wou
-dbt
-teW
 lAs
 lAs
 lAs
@@ -443912,29 +446997,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+lMZ
+iYx
+rjQ
+bbl
+iYx
+uHk
+lku
+hsD
+iYx
+vgy
+bzl
+bbl
+iYx
+lMZ
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-teW
 lAs
 lAs
 lAs
@@ -444317,20 +447402,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+inf
+iYx
+iYx
+iYx
+lft
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
+inf
+aUc
 vIa
 vIa
 vIa
@@ -444719,20 +447804,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+iYx
+iYx
+bkC
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+lMZ
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -445122,17 +448207,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+nYQ
+bSF
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+lMZ
 vIa
 vIa
 vIa
@@ -445524,17 +448609,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+wIH
+bSF
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+lMZ
 vIa
 vIa
 vIa
@@ -445926,17 +449011,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+aKi
+wQC
+uZC
+uZC
+uZC
+iYx
+iYx
+iYx
+lMZ
 vIa
 vIa
 vIa
@@ -446328,17 +449413,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+iYx
+iYx
+elO
+elO
+qBr
+iYx
+lMZ
+lMZ
+lMZ
 vIa
 vIa
 vIa
@@ -446731,13 +449816,13 @@ aUc
 aUc
 aUc
 aUc
-aUc
-aUc
-aUc
-aUc
-aUc
-aUc
-aUc
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
 aUc
 aUc
 aUc
@@ -482503,68 +485588,68 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 eSw
 wQD
+aUc
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -482905,9 +485990,39 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+seC
+bUD
 erZ
 erZ
 erZ
@@ -482936,38 +486051,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -483307,9 +486392,39 @@ vIa
 vIa
 vIa
 vIa
-erZ
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+qeY
+uwa
+seC
+seC
+seC
+qeY
+qeY
+qeY
+qeY
+qeY
+quL
+qeY
+seC
+eTX
+jZi
+ojM
+gOY
+wpm
+gOY
+mZp
 erZ
 erZ
 erZ
@@ -483339,37 +486454,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -483709,9 +486794,39 @@ vIa
 erZ
 erZ
 erZ
-erZ
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+qeY
+rce
+seC
+seC
+seC
+qeY
+qeY
+mZu
+uEk
+uEk
+seC
+qeY
+qUQ
+wpm
+wpm
+wpm
+wpm
+wpm
+wpm
+tYe
 erZ
 erZ
 erZ
@@ -483731,36 +486846,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -484111,9 +487196,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+qeY
+qeY
+pdm
+seC
+rgO
+pMn
+obq
+vUf
+seC
+seC
+seC
+quL
+seC
+mjP
+wpm
+wpm
+wpm
+wpm
+wpm
+lBN
 erZ
 erZ
 erZ
@@ -484132,36 +487247,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -484513,9 +487598,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+qeY
+qeY
+pdm
+seC
+nTR
+qeY
+qeY
+xJe
+seC
+oje
+qeY
+qeY
+seC
+pDm
+hAe
+ujy
+wpm
+wpm
+wpm
+mZp
 erZ
 erZ
 erZ
@@ -484534,36 +487649,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -484915,9 +488000,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+quL
+seC
+seC
+seC
+nTR
+qeY
+qeY
+xJe
+seC
+cxS
+qeY
+qeY
+bUD
+uxV
+aLR
+ppb
+dcE
+wpm
+wpm
+tYe
 erZ
 erZ
 erZ
@@ -484936,36 +488051,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -485317,9 +488402,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+seC
+ksK
+ksK
+cdn
+seC
+rgO
+nuH
+qeY
+aPR
+seC
+qeY
+obq
+qeY
+bUD
+wQI
+eIm
+wQI
+sPR
+wpm
+wpm
+lBN
 erZ
 erZ
 erZ
@@ -485328,36 +488443,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -485719,11 +488804,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bqt
 fIL
 wQD
-vIa
-vIa
+aUc
+aUc
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+rgO
+nuH
+qeY
+vUf
+seC
+nTR
+obq
+obq
+xJe
+seC
+qeY
+qeY
+qeY
+bUD
+wQI
+wQI
+wQI
+gbA
+wpm
+wpm
+mZp
 erZ
 erZ
 erZ
@@ -485731,34 +488844,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -486121,39 +489206,39 @@ erZ
 erZ
 erZ
 vIa
-vIa
+aUc
 eNY
 hby
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+aUc
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+nTR
+qeY
+qeY
+xJe
+seC
+nTR
+qeY
+qeY
+xJe
+seC
+cxS
+qeY
+cxS
+bUD
+bHX
+wQI
+bHX
+jme
+wpm
+wpm
+tYe
 erZ
 erZ
 erZ
@@ -486523,39 +489608,39 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 eDN
 twI
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+aUc
+aUc
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+ebb
+qeY
+ksK
+pdm
+seC
+rgO
+nuH
+qeY
+aPR
+seC
+oje
+qeY
+obq
+seC
+seC
+seC
+seC
+hAe
+hAe
+hAe
+xZj
 erZ
 erZ
 erZ
@@ -486925,35 +490010,35 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 twI
 twI
 twI
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+elE
+nuH
+qeY
+mZu
+seC
+ebb
+qeY
+qeY
+pdm
+seC
+qeY
+obq
+qeY
+vHd
+qeY
+cxS
+kqt
 erZ
 erZ
 erZ
@@ -487327,35 +490412,35 @@ erZ
 erZ
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 xGC
 oWI
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+svd
+nuH
+qeY
+vUf
+seC
+nTR
+qeY
+qeY
+xJe
+seC
+vHd
+qeY
+qeY
+qeY
+eIA
+klm
+wza
 erZ
 erZ
 erZ
@@ -487730,57 +490815,57 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 uXW
 oRe
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
 ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+ksK
+qeY
+xJe
+seC
+rgO
+nuH
+qeY
+aPR
+seC
+cxS
+qeY
+obq
+qeY
+rfO
+qNq
+pwO
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -488131,10 +491216,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+nTR
+qeY
+qeY
+pdm
+seC
+pdm
+obq
+obq
+xJe
+seC
+oje
+vHd
+qeY
+qeY
+rfO
+waz
+mst
 erZ
 erZ
 erZ
@@ -488158,31 +491268,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -488533,10 +491618,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+rgO
+nuH
+qeY
+uVR
+uVR
+uVR
+qeY
+qeY
+uVR
+uVR
+obq
+qeY
+vHd
+vHd
+rfO
+waz
+mst
 erZ
 erZ
 erZ
@@ -488560,31 +491670,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -488935,10 +492020,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+nTR
+ksK
+qeY
+kdb
+seC
+qzy
+nuH
+qeY
+bNW
+seC
+oje
+obq
+qeY
+cxS
+jEU
+jEU
+sZw
 erZ
 erZ
 erZ
@@ -488962,31 +492072,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -489337,10 +492422,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+bqt
 uXW
 oRe
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+nTR
+qeY
+ksK
+qeY
+quL
+qeY
+qeY
+qeY
+seC
+seC
+seC
+seC
+seC
+oje
+qeY
+qeY
+uLh
+uLh
+qsb
+tfp
+uLh
 erZ
 erZ
 erZ
@@ -489360,35 +492474,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -489739,45 +492824,40 @@ erZ
 erZ
 erZ
 erZ
-erZ
-lgg
+bQB
+bqt
 uXW
 oRe
-erZ
-erZ
-erZ
-erZ
-sri
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+dte
+nuH
+qeY
+pqI
+seC
+seC
+seC
+seC
+seC
+seC
+bqt
+bqt
+seC
+qeY
+qeY
+cxS
+uLh
+izB
+wFp
+fmh
+uLh
+sxM
 erZ
 erZ
 erZ
@@ -489785,12 +492865,17 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -490136,21 +493221,46 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-lgg
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 hqA
 pCW
-lgg
-lgg
-lgg
-lgg
-lgg
-sri
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+seC
+seC
+seC
+seC
+seC
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+cxS
+qeY
+qeY
+aFP
+wFp
+wFp
+jfz
+tfp
+wFp
+wFp
 erZ
 erZ
 erZ
@@ -490168,31 +493278,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -490533,13 +493618,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 lgg
 lgg
 lgg
@@ -490551,12 +493636,33 @@ lgg
 lgg
 lgg
 lgg
-lgg
-sri
-sri
-sri
-sri
-sri
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+seC
+seC
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+cxS
+qeY
+qeY
+aFP
+wFp
+wFp
+wFp
+aFP
+wFp
+wFp
 erZ
 erZ
 erZ
@@ -490574,27 +493680,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -490931,13 +494016,13 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
 lgg
 lgg
 lgg
@@ -490957,10 +494042,29 @@ lgg
 lgg
 vIa
 vIa
-sri
-sri
-sri
-sri
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+oje
+qeY
+qeY
+aFP
+wFp
+wFp
+wFp
+tfp
+wFp
+wFp
 erZ
 erZ
 erZ
@@ -490978,25 +494082,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -491362,8 +494447,25 @@ vIa
 vIa
 vIa
 vIa
-sri
-sri
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+seC
+jaR
+qeY
+qeY
+uLh
+oZt
+wFp
+wFp
+uLh
+sxM
 erZ
 erZ
 erZ
@@ -491382,23 +494484,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -491765,8 +494850,23 @@ vIa
 vIa
 vIa
 vIa
-vIa
-sri
+aUc
+bqt
+seC
+qRp
+qRp
+qRp
+qRp
+qRp
+qRp
+qRp
+dBA
+dBA
+uLh
+uLh
+hGr
+hGr
+pCe
 erZ
 erZ
 erZ
@@ -491786,21 +494886,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -492168,8 +495253,8 @@ vIa
 vIa
 vIa
 vIa
-sri
-sri
+bqt
+bqt
 erZ
 erZ
 erZ
@@ -492197,12 +495282,12 @@ erZ
 erZ
 erZ
 erZ
-ebb
-mdB
-ebb
-ebb
-ebb
-ebb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -500261,7 +503346,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bQB
 erZ
 erZ
 erZ
@@ -538380,7 +541465,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+rbn
 erZ
 erZ
 erZ
@@ -539994,7 +543079,7 @@ vIa
 vIa
 fZJ
 fZJ
-uwn
+lAs
 woj
 qPA
 qPA
@@ -540394,9 +543479,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cmp
+cmp
+lAs
 woj
 qPA
 qPA
@@ -540796,9 +543881,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cmp
+cmp
+lAs
 woj
 qPA
 qPA
@@ -541198,9 +544283,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cmp
+cmp
+lAs
 woj
 qPA
 qPA
@@ -541600,9 +544685,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cmp
+cmp
+lAs
 eJN
 bHY
 bHY
@@ -542002,27 +545087,27 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
+cmp
+cmp
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 pYj
 pYj
 pYj
@@ -542404,7 +545489,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cmp
 vIa
 vIa
 vIa
@@ -542806,7 +545891,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cmp
 vIa
 vIa
 vIa
@@ -543208,7 +546293,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cmp
 vIa
 vIa
 vIa
@@ -543610,7 +546695,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+pYj
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,11 +7,13 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -501,11 +503,8 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -982,19 +981,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"adJ" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "adK" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "adL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -1152,13 +1144,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "aev" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1176,6 +1167,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"afj" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "afp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/library{
@@ -1235,18 +1236,14 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"agJ" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "agL" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"agR" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "agS" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
@@ -1268,15 +1265,6 @@
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"ahV" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
@@ -1343,10 +1331,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"ale" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "alk" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -1355,12 +1339,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"alx" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "alL" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -1395,6 +1373,10 @@
 /obj/structure/table/church,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
+"amz" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "ans" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "tavern"
@@ -1415,14 +1397,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "aok" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh1";
-	aportalid = "wh2";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = -14
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1451,10 +1430,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"aoY" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "apc" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fermenting_barrel,
@@ -1490,32 +1465,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"ark" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"arA" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"arG" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1527,6 +1476,13 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"arY" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "arZ" = (
 /obj/structure/floordoor/gatehatch/outer{
 	redstone_id = "gatelava"
@@ -1543,10 +1499,6 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"asZ" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "atx" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/church,
@@ -1597,9 +1549,10 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/lava{
+	name = "an actual pit of lava"
+	},
+/area/rogue/under/cave)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1612,12 +1565,26 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"auZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"avf" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "avh" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"avA" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "avQ" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -1709,9 +1676,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1794,23 +1761,6 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
-"aBP" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"aCd" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1900,9 +1850,21 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"aFj" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"aFE" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aFS" = (
 /obj/structure/chair/wood/rogue,
 /obj/item/rogueweapon/whip,
@@ -1943,14 +1905,17 @@
 /obj/effect/landmark/map_load_mark/sewers_bottom,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"aHj" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "aHo" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"aHq" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "aHs" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1974,11 +1939,6 @@
 /obj/item/clothing/neck/roguetown/psicross/pestra,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"aHY" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "aIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/kitchen/spoon/plastic,
@@ -1990,20 +1950,10 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"aIk" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+"aIo" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "aIx" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/closet/crate/roguecloset,
@@ -2060,6 +2010,10 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"aJm" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "aJz" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -2193,6 +2147,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"aOa" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "aOn" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -2239,8 +2199,13 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2285,14 +2250,6 @@
 /obj/structure/roguemachine/steward,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"aRp" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aRA" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
@@ -2307,12 +2264,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"aRR" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "aRU" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2329,8 +2280,14 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2357,6 +2314,13 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"aTr" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aTE" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2387,14 +2351,6 @@
 "aUc" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/mountains)
-"aUo" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "aUE" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -2403,6 +2359,16 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"aUN" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "aUO" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2425,17 +2391,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"aVp" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "aVv" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -2453,28 +2408,14 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"aWb" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+"aVI" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"aWy" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "aWO" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -2486,15 +2427,6 @@
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"aXe" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "aXh" = (
 /turf/open/floor/grass/snow,
 /area/rogue/outdoors/bog)
@@ -2508,6 +2440,19 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
+"aXr" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
+"aXt" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "aXx" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/spacevine,
@@ -2548,22 +2493,21 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"aZf" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aZj" = (
 /obj/structure/table/vtable,
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
-"aZv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+"aZp" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "aZG" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/blocks,
@@ -2611,11 +2555,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
-"bbY" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bcj" = (
 /obj/structure/timeddoor/sixtyminute,
 /obj/structure/timeddoor/sixtyminute,
@@ -2628,6 +2567,13 @@
 "bcN" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/church/chapel)
+"bds" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bdu" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -2680,17 +2626,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"beK" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "beQ" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
@@ -2742,21 +2677,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"bgT" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "bgW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -2764,10 +2684,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"bgY" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "bhg" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2777,14 +2693,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
-"bhu" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "bhy" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -2803,10 +2711,6 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"bif" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2821,12 +2725,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"biR" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "bjd" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -2835,20 +2733,12 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"bje" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+"bjq" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"bjo" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "bjx" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/ruinedwood{
@@ -2866,10 +2756,6 @@
 /obj/item/rogueweapon/tongs,
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
-"bjK" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "bjO" = (
 /obj/structure/lever/wall{
@@ -2914,6 +2800,10 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bkT" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -2967,9 +2857,8 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -3024,11 +2913,6 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"bob" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "boh" = (
 /obj/effect/landmark/start/villager{
 	dir = 4
@@ -3043,18 +2927,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
-"bos" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "bow" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -3091,27 +2963,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"bpi" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "bpn" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"bpt" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "bpx" = (
 /obj/structure/table/vtable/v2,
 /obj/item/reagent_containers/glass/mortar,
@@ -3166,8 +3021,14 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3245,6 +3106,11 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"bsy" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "bsC" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/churchmarble,
@@ -3321,11 +3187,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"bux" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "buL" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -3436,6 +3297,10 @@
 /obj/item/roguegem/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"bxw" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "bxC" = (
 /obj/structure/stairs{
 	dir = 8
@@ -3448,6 +3313,16 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"bxG" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "bxR" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -3508,6 +3383,10 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -3561,10 +3440,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"bBh" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3574,13 +3449,6 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"bBL" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bBQ" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -3588,11 +3456,11 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/stairs/stone{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3630,13 +3498,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
-"bEm" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "bEo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -3668,14 +3529,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"bFq" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "bFr" = (
 /obj/structure/stairs{
 	dir = 4
@@ -3724,10 +3577,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"bHc" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bHt" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -3751,8 +3600,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3789,10 +3642,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"bIR" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bIZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -3854,18 +3703,22 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"bLp" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bLD" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"bLM" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "bMh" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/dirt,
@@ -3947,26 +3800,25 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"bPv" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/loom,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
-"bPy" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
-"bPz" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4";
-	pixel_x = 13
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
+"bPs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
+"bPv" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"bPz" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -4024,6 +3876,13 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"bRt" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bRu" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -4036,12 +3895,6 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
-"bRM" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "bSm" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -4113,12 +3966,28 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
+"bUq" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "bVa" = (
-/turf/open/floor/carpet/inn,
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "bVw" = (
 /turf/open/water/river{
@@ -4136,24 +4005,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bVP" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "Nelly";
-	health = "1000"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"bVT" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"bVY" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "bWj" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -4184,12 +4035,6 @@
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
-"bWv" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "bWK" = (
 /obj/structure/chair/wood/rogue,
@@ -4280,15 +4125,6 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"caK" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4354,6 +4190,14 @@
 /obj/structure/statue/saints/lady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"ccy" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ccK" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -4377,8 +4221,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4389,16 +4234,6 @@
 /obj/structure/table/vtable/v2,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
-"cel" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cev" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/ruinedwood{
@@ -4438,6 +4273,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"cfK" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "cfY" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
@@ -4489,12 +4330,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"che" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "chg" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -4584,11 +4419,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "cjJ" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
-	},
-/turf/open/floor/rogue/cobble,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4641,12 +4474,28 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"clh" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"clj" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4662,16 +4511,6 @@
 /obj/item/roguekey/nightmaiden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"clV" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "clY" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/poo,
@@ -4685,12 +4524,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"cmf" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/sword/long,
-/obj/item/rogueweapon/mace/steel,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "cmB" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/shop)
@@ -4740,20 +4573,6 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/outdoors/town)
-"cnX" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "cod" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -4807,11 +4626,6 @@
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"cpS" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "cpY" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -4893,30 +4707,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
-"csB" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4949,15 +4739,6 @@
 "ctS" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
-"cuc" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"cud" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "cue" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
@@ -4996,23 +4777,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"cvC" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "cvN" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road{
@@ -5020,8 +4784,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -5077,12 +4846,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"cxa" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "cxb" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors/town/manor)
@@ -5194,10 +4957,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"czM" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "czO" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
@@ -5235,28 +4994,10 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"cAC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "cAE" = (
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"cAW" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "cBb" = (
 /obj/effect/landmark/start/nightmaiden{
 	dir = 8
@@ -5298,11 +5039,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/tribalfort)
@@ -5338,9 +5077,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5396,6 +5138,13 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"cFo" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "cFF" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -5425,13 +5174,6 @@
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"cGb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "cGc" = (
 /obj/structure/chair/wood/rogue,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -5448,14 +5190,6 @@
 	icon_state = "glyph1"
 	},
 /area/rogue/indoors/town/vault)
-"cGA" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "cGD" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -5543,12 +5277,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"cJt" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
 "cJz" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -5606,9 +5334,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5626,12 +5353,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/under/cave)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5671,6 +5398,11 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"cNt" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "cNx" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
@@ -5686,6 +5418,13 @@
 "cNY" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
+"cOw" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cOz" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -5698,6 +5437,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"cOK" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -5726,6 +5472,14 @@
 	},
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"cPD" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
@@ -5783,8 +5537,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5808,6 +5565,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"cSc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cSk" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
@@ -5862,15 +5626,6 @@
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"cUb" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "cUh" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt/road{
@@ -5908,24 +5663,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"cVb" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "cVc" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"cVk" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "cVm" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -6038,13 +5779,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"cYN" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "cYR" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/twig,
@@ -6138,15 +5872,27 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
-"dbH" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"dbH" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
+"dbK" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -6173,6 +5919,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"dck" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "dcw" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/churchrough,
@@ -6201,10 +5953,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"dcO" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "dcP" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -6291,6 +6039,14 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"dfG" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "dfK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -6302,6 +6058,25 @@
 /obj/item/quiver/bolts,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"dgh" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "dgn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6358,13 +6133,6 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"dht" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "dhH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -6440,10 +6208,6 @@
 /obj/item/candle/skull/lit,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
-"djJ" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "djX" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -6474,12 +6238,6 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"dkx" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "dkI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -6489,6 +6247,14 @@
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"dkV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "dld" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/town/roofs)
@@ -6559,13 +6325,6 @@
 "dmK" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/manor)
-"dmR" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "dmS" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/woodturned,
@@ -6573,12 +6332,6 @@
 "dnf" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
 /area/rogue/indoors/town/manor)
-"dnh" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "dnx" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -6587,25 +6340,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"dnV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "dnZ" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -6653,18 +6387,6 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"dpx" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
-"dpF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "dpL" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -6677,13 +6399,6 @@
 "dpP" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/under/cavewet/bogcaves)
-"dpQ" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "dpT" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/guardsman,
@@ -6767,8 +6482,11 @@
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
 "dsW" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "dth" = (
 /obj/structure/fluff/railing/border,
@@ -6841,20 +6559,6 @@
 /obj/effect/decal/remains/bigrat,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"dwk" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "dwl" = (
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
@@ -6871,10 +6575,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6927,14 +6629,6 @@
 "dzb" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
-"dzf" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "dzx" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith2,
 /turf/open/floor/rogue/grass,
@@ -6953,17 +6647,22 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dAf" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
+"dzW" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"dAf" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6992,6 +6691,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"dBS" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6999,6 +6704,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"dBW" = (
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -7018,14 +6727,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
-"dCZ" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "dDf" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -7053,6 +6754,18 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"dDU" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"dEe" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "dEA" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet,
@@ -7066,6 +6779,21 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"dET" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"dFp" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -7176,6 +6904,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"dJl" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "dJr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7248,13 +6983,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
-"dME" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dMN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7282,11 +7010,14 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7339,6 +7070,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"dPf" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dPp" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -7420,15 +7156,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
-"dQX" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "dQY" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/concrete,
@@ -7450,12 +7177,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"dRd" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dRl" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -7518,11 +7239,10 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7581,12 +7301,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dUC" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -7645,9 +7359,6 @@
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"dXt" = (
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/town)
 "dXw" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -7684,10 +7395,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
-"dYw" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dYP" = (
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
@@ -7736,6 +7443,15 @@
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"eaH" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eaO" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -7743,23 +7459,11 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"ebe" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
+/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/mountains)
+"ebe" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7785,13 +7489,6 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"ebJ" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "ebR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7913,17 +7610,15 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"eef" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "eeu" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"eeC" = (
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "eeD" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -7986,12 +7681,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town)
-"efv" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "efw" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
@@ -8033,9 +7722,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
-"egz" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
 "egU" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
@@ -8072,13 +7758,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"eib" = (
-/obj/item/paper{
-	name = "HIT THINE BELL";
-	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+"ehZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "eit" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -8145,6 +7832,13 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
+"ekl" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ekI" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/shop)
@@ -8181,6 +7875,10 @@
 "els" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"eml" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "emp" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road{
@@ -8215,6 +7913,12 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"emT" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "emX" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -8295,9 +7999,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -8312,13 +8016,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
-"epL" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "epQ" = (
 /obj/structure/mineral_door/wood{
 	desc = "I shouldn't go in here...";
@@ -8336,16 +8033,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"eqo" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "eqt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -8433,6 +8120,10 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"esE" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "esF" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
@@ -8470,10 +8161,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"etM" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "etS" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -8571,16 +8258,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"evB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "evJ" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
@@ -8634,16 +8311,6 @@
 /obj/item/rogue/instrument/drum,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"eyb" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "eyq" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = -32
@@ -8671,11 +8338,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8686,6 +8356,12 @@
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
+"ezG" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "eAh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
@@ -8695,6 +8371,16 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"eAz" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eAW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8750,6 +8436,23 @@
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"eCq" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
+"eCt" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "eCK" = (
 /obj/structure/flora/rogueshroom2,
 /turf/open/floor/rogue/grass,
@@ -8795,17 +8498,15 @@
 /obj/structure/well,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
-"eEA" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "eEC" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"eEQ" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
+"eEG" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "eEU" = (
 /obj/structure/fluff/statue{
@@ -8947,6 +8648,15 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
+"eIW" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "eIY" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/dirt/road{
@@ -8988,13 +8698,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
-"eJO" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "eJP" = (
 /obj/structure/statue/saints/lady_l,
 /turf/open/floor/rogue/blocks,
@@ -9003,6 +8706,13 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"eKd" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "eKe" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -9028,6 +8738,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"eLp" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "eLr" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -9048,10 +8765,6 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
-"eMs" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/mountains)
 "eMz" = (
 /obj/structure/flora/rock,
@@ -9076,10 +8789,6 @@
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"eNu" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "eNB" = (
 /obj/structure/table/church{
 	dir = 1
@@ -9116,18 +8825,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"ePh" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ePQ" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = 1
@@ -9155,6 +8852,30 @@
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"eQM" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "eQW" = (
 /obj/structure/spacevine,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
@@ -9208,9 +8929,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9245,27 +8966,6 @@
 	dir = 1
 	},
 /area/rogue/indoors)
-"eTQ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"eTW" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"eTZ" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "eUb" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/town)
@@ -9369,6 +9069,8 @@
 	lockid = "priest"
 	},
 /obj/item/book/rogue/bibble,
+/obj/item/listenstone,
+/obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "eWj" = (
@@ -9404,18 +9106,31 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"eXp" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
+"eXr" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/churchrough,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "eXH" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
+"eYu" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "eYI" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora1";
@@ -9429,6 +9144,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"eYO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "eZc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -9477,12 +9199,34 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"faa" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"fap" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "faE" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fbe" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "fbf" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -9583,10 +9327,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"fdU" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "fel" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9602,6 +9342,20 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"feB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "feE" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/bookcase/random,
@@ -9702,6 +9456,13 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"fic" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fiF" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/purple,
@@ -9780,16 +9541,6 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"fla" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "flA" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -9824,10 +9575,15 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
-"flY" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"flR" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "fmm" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -9889,6 +9645,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fnP" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9904,10 +9664,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"foH" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "foS" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomiv{
@@ -9956,21 +9712,6 @@
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
-"fqF" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "fqW" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/wood,
@@ -9979,14 +9720,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
-"frx" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "frB" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/exposed)
@@ -10071,12 +9804,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"fua" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "fuu" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -10097,6 +9824,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fuG" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "fuY" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/bookcase/random,
@@ -10242,6 +9977,19 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fAg" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "fAs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -10316,6 +10064,12 @@
 "fBT" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"fBY" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fCh" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/woodturned,
@@ -10350,10 +10104,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"fDi" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "fDw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -10370,11 +10120,9 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
@@ -10407,12 +10155,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"fEv" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+"fED" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "fEF" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/church,
@@ -10426,10 +10173,21 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"fEQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fFH" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fGF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -10442,12 +10200,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"fGT" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "fHi" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -10489,12 +10241,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"fHV" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "fId" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
@@ -10529,11 +10275,8 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fID" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -10568,6 +10311,25 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fJp" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"fJG" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -10616,12 +10378,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2";
-	pixel_x = 16
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"fLX" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
@@ -10634,6 +10396,20 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"fMq" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"fMS" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fNa" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/honey,
@@ -10649,10 +10425,18 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"fNu" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
 "fNw" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"fNW" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fOo" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -10739,14 +10523,12 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10803,6 +10585,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"fRO" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -10860,6 +10646,17 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"fTS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "fUc" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10924,23 +10721,13 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"fVY" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "fWh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -11006,6 +10793,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fYr" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "fYH" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/dirt/road{
@@ -11068,21 +10863,14 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
-"gbD" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
+/obj/structure/fluff/walldeco/church/line{
 	dir = 1;
-	icon_state = "wooden_floor2"
+	icon_state = "churchslate"
 	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "gbN" = (
 /obj/structure/statue/saints/knight2,
@@ -11140,6 +10928,15 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"gec" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "gei" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/hexstone,
@@ -11179,6 +10976,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"geZ" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "gfc" = (
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
@@ -11219,21 +11025,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"ggU" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"ghi" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/ruinedwood{
@@ -11255,12 +11046,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6";
-	pixel_x = 9
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "giR" = (
 /obj/structure/table/wood,
@@ -11294,6 +11081,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"gjq" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gjB" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -11303,6 +11096,15 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"gjV" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gke" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -11324,12 +11126,6 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"gkL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "gkO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/storage/pill_bottle/dice,
@@ -11429,22 +11225,41 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
+"gnX" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "goa" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
+"goh" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
+"goD" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "goK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -11465,6 +11280,13 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
+"gpK" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "gpP" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -11488,6 +11310,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
+"gqz" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -11509,10 +11335,29 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"grg" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"grr" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "grQ" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood{
@@ -11594,6 +11439,14 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"gue" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "gut" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -11604,15 +11457,34 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"guK" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "gvi" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"gvj" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11633,10 +11505,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"gvV" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "gwd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -11650,23 +11518,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
-"gwf" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"gwt" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11832,13 +11683,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"gBI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "gBZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -11912,6 +11756,15 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gFF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gFQ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/window/plasma/reinforced/spawner{
@@ -12049,10 +11902,11 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"gJk" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
+"gJj" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "gJs" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -12077,6 +11931,13 @@
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"gKo" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "gKq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/fluff/statue/who,
@@ -12130,16 +11991,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"gLG" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+"gLI" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gLO" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
@@ -12150,14 +12005,6 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"gMb" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "gMg" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -12165,6 +12012,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"gMo" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gMs" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -12209,6 +12064,16 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"gNh" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gNw" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -12320,16 +12185,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"gRm" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "gRz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -12349,12 +12204,6 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"gRJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "gRU" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -12410,12 +12259,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"gSO" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "gSP" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12451,6 +12294,11 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"gUA" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "gUD" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
 	max_integrity = 99999
@@ -12499,6 +12347,13 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"gWf" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -12517,18 +12372,15 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
+"gWE" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gWL" = (
 /obj/effect/landmark/start/shophand,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"gWR" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "gWX" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -12621,6 +12473,16 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"haw" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "hax" = (
 /obj/structure/mineral_door/wood{
 	lockid = "roomi";
@@ -12628,19 +12490,17 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"hay" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "haB" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"haC" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "haF" = (
 /obj/structure/bars/passage/shutter{
 	desc = "Extremely strong. I don't think I can easily get through this with brute force. Where might the way to open it be?";
@@ -12668,8 +12528,14 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
+"hbg" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/church/chapel)
 "hby" = (
 /obj/structure/stairs{
@@ -12687,6 +12553,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"hbO" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"hbR" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "hbS" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/glass/bowl,
@@ -12698,6 +12573,14 @@
 "hcg" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/mountains)
+"hci" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "hcm" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -12743,14 +12626,6 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"hcQ" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hcR" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -12777,12 +12652,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"hdk" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "hdm" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	lockid = "farm"
@@ -12821,16 +12690,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"hdO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hdR" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -12848,6 +12707,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"hej" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "heo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -12866,16 +12732,17 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"hes" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"heJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -12984,19 +12851,6 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"hhq" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "hhw" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -13016,18 +12870,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hhU" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"hiq" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "hiz" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -13045,14 +12887,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hiK" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "hiL" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
@@ -13080,8 +12914,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
@@ -13121,13 +12956,6 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"hln" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "hlo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -13285,6 +13113,22 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"hom" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hox" = (
 /obj/structure/fluff/psycross,
 /obj/item/rogueweapon/woodstaff/aries,
@@ -13305,16 +13149,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"hoM" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hoR" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood,
@@ -13380,6 +13214,15 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"hqw" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "hqA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -13449,13 +13292,23 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"htp" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "htA" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
@@ -13464,6 +13317,13 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"htH" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "htU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -13503,16 +13363,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hvh" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "hvi" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -13648,16 +13498,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
-"hAD" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "hAN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -13680,34 +13520,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"hBU" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hCu" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"hCF" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "hCL" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -13732,14 +13550,6 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"hDv" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hDP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "velder"
@@ -13833,15 +13643,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"hGP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "hGU" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -13898,14 +13699,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"hIG" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "hIN" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/churchbrick,
@@ -14101,19 +13894,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
-"hPo" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "hPx" = (
 /obj/structure/fluff/statue/answer{
 	color = null;
@@ -14125,13 +13905,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"hQd" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "hQe" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14152,6 +13925,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"hQm" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hQE" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -14185,6 +13968,16 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"hRg" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "hRl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -14209,10 +14002,6 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"hRF" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "hRK" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -14230,6 +14019,21 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town)
+"hSx" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
+"hSy" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "hSz" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14241,17 +14045,33 @@
 	dir = 1
 	},
 /area/rogue/outdoors/bog)
-"hSF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "hSK" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"hSO" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"hTc" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"hTo" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hTz" = (
 /obj/item/natural/rock,
 /turf/open/water/swamp,
@@ -14307,15 +14127,15 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"hVW" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "hVZ" = (
 /turf/open/floor/rogue/tile/checkeralt{
 	max_integrity = 99999
 	},
 /area/rogue/indoors/town/shop)
+"hWj" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hWm" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14323,6 +14143,13 @@
 /obj/item/dice,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"hWp" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hWK" = (
 /obj/structure/fluff/statue/knight/interior,
 /obj/structure/spacevine,
@@ -14465,21 +14292,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"ibe" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"ibh" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "ibW" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -14488,11 +14300,17 @@
 /obj/item/natural/bundle/bone/full,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"ibY" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
+"ica" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "icc" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -14591,18 +14409,16 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ieI" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "ieL" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"ieP" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ieR" = (
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
@@ -14621,13 +14437,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14660,6 +14476,10 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"igV" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iho" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -14702,6 +14522,13 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"iiG" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "iiH" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/cobble/mossy,
@@ -14710,6 +14537,15 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ijs" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ijS" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -14719,9 +14555,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -14750,8 +14588,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -14783,10 +14624,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"ilD" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14804,12 +14641,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"ilT" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "ime" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -14839,15 +14670,15 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"inE" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+"inx" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14863,11 +14694,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"ioM" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "ioU" = (
 /obj/structure/fermenting_barrel/water,
 /obj/structure/fermenting_barrel/water,
@@ -14926,10 +14752,10 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"iqW" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+"iqH" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iqY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14979,8 +14805,12 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -14988,9 +14818,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -15015,13 +14847,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"iuz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "iuE" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -15034,6 +14859,11 @@
 	dir = 4
 	},
 /area/rogue/indoors)
+"iuK" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "iuL" = (
 /obj/structure/statue/saints/noble3_r,
 /turf/open/floor/rogue/blocks,
@@ -15053,29 +14883,11 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ivi" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
 	},
 /area/rogue/outdoors/town)
-"ivM" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "ivO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -15116,6 +14928,16 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ixi" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "ixt" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -15134,12 +14956,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"ixN" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "iyd" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/church/chapel)
@@ -15157,6 +14973,25 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"iys" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"iyt" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iyy" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -15222,6 +15057,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"izq" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "izL" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobblerock,
@@ -15265,6 +15106,18 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"iBj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "iBA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -15376,6 +15229,13 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
+"iEv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -15405,6 +15265,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"iFj" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "iFm" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "manor";
@@ -15501,10 +15365,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
-"iIR" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "iJC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -15622,8 +15482,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -15643,12 +15506,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"iNc" = (
-/obj/machinery/light/rogue/lanternpost{
-	pixel_x = 15
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "iNk" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/effect/landmark/start/vampthrall,
@@ -15676,11 +15533,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"iNC" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "iNE" = (
 /obj/machinery/anomalous_crystal,
 /turf/open/floor/rogue/grass,
@@ -15708,13 +15560,52 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iOB" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "iOI" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"iOL" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iPg" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
+"iPk" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "iPn" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -15746,11 +15637,6 @@
 /obj/item/rogueweapon/sword/iron,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"iPA" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "iPB" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -15790,22 +15676,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"iRc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "iRe" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
@@ -15817,14 +15687,15 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1";
-	pixel_x = 9
+/obj/structure/chair/bench/church/r{
+	dir = 1
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15851,6 +15722,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"iSf" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "iSs" = (
 /turf/open/water/river{
 	dir = 8;
@@ -15858,14 +15733,27 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
+/turf/closed/mineral/rogue,
 /area/rogue/outdoors/town/roofs)
+"iSS" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"iTh" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15888,6 +15776,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"iUg" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "iUY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/neck/roguetown/gorget,
@@ -15898,10 +15791,6 @@
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"iVf" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "iVi" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -15931,19 +15820,16 @@
 /obj/item/kitchen/spoon/plastic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"iVt" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/composter/full,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "iVM" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"iVX" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iWh" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/veteran{
@@ -15952,12 +15838,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -16002,6 +15890,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"iXP" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "iXT" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -16044,6 +15938,16 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iYE" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -16078,6 +15982,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
+"iZS" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "jad" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -16133,11 +16043,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"jbu" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "jbv" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16157,6 +16062,12 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"jck" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "jct" = (
 /obj/structure/flora/roguetree/stump/burnt,
 /turf/open/floor/rogue/dirt,
@@ -16209,6 +16120,11 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"jdO" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "jdW" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/metal/barograte,
@@ -16218,6 +16134,10 @@
 	icon_state = "stonewindow"
 	},
 /area/rogue/indoors/town/garrison)
+"jec" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "jem" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/river{
@@ -16248,6 +16168,9 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"jfl" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "jfq" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -16259,6 +16182,15 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"jfJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "jfK" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/wallfire/candle/l{
@@ -16285,13 +16217,6 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"jgg" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "jgh" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
@@ -16305,6 +16230,11 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"jgn" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jgs" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
@@ -16312,6 +16242,29 @@
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
+"jhu" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"jhv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"jhP" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16342,6 +16295,11 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"jiL" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jiS" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks,
@@ -16349,6 +16307,13 @@
 "jiT" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"jiW" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jiZ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -16356,6 +16321,22 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"jju" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -16380,14 +16361,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"jkx" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "jkz" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -16404,20 +16377,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"jkQ" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
-"jkU" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "jlf" = (
 /obj/structure/stairs{
 	dir = 1
@@ -16444,29 +16403,15 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
-"jmo" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jmv" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -16496,6 +16441,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"jnd" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jnl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -16551,7 +16500,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
+	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "jpH" = (
@@ -16564,6 +16516,13 @@
 /obj/structure/roguemachine/camera,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jpM" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jpS" = (
 /obj/structure/glowshroom,
 /turf/open/water/river{
@@ -16576,10 +16535,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"jqk" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "jqA" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
@@ -16604,11 +16559,6 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"jrP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jrZ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -16640,6 +16590,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"jti" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jtj" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16679,6 +16636,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"juM" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -16745,13 +16706,6 @@
 "jxy" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/manor)
-"jxM" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "jxP" = (
 /obj/structure/table/wood,
 /obj/item/restraints/legcuffs/beartrap,
@@ -16810,31 +16764,11 @@
 /obj/structure/closet/crate/chest/reward,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"jzh" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "jzy" = (
 /obj/structure/fluff/statue/tdummy,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"jzB" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "jzK" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -16858,19 +16792,20 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jAI" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "jAN" = (
 /obj/effect/landmark/start/farmer{
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"jAQ" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "jAV" = (
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
@@ -16885,6 +16820,13 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jBE" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -16893,11 +16835,15 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "jCs" = (
 /obj/structure/fluff/railing/border{
@@ -16931,6 +16877,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"jCH" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jCW" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -16989,11 +16941,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "jEB" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -17015,11 +16967,9 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
 "jFn" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "jFF" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/blocks,
@@ -17068,6 +17018,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
+"jHv" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "jHz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
@@ -17104,9 +17058,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -17125,21 +17080,17 @@
 /obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"jJZ" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
-"jKS" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "jKW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -17149,18 +17100,6 @@
 "jKY" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/town)
-"jLr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "jLs" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -17195,11 +17134,16 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -17228,6 +17172,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"jMQ" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "jMT" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/concrete,
@@ -17245,16 +17193,37 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jNc" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"jNp" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jNC" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17414,10 +17383,6 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"jSc" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "jSp" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/church/chapel)
@@ -17466,15 +17431,6 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
-"jUP" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -17483,16 +17439,35 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"jVq" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+"jVt" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
 	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
+"jWb" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17502,14 +17477,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"jWA" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "jWH" = (
 /obj/item/rogueweapon/tongs,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -17593,6 +17560,10 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"jYZ" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jZd" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/magician)
@@ -17618,18 +17589,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"jZP" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kad" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "kan" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/mineral_door/bars{
@@ -17746,6 +17709,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"keJ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "keO" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -17804,12 +17777,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"kfX" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "kgj" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
@@ -17835,15 +17802,20 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
+"kgK" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kha" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/stairs{
+	dir = 4
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "khC" = (
 /obj/structure/flora/newtree,
@@ -17878,6 +17850,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"kiE" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "kiR" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -17933,10 +17910,6 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"kkN" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
 "kld" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/concrete,
@@ -17949,6 +17922,20 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"klx" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"kmo" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "kms" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper,
@@ -17997,6 +17984,21 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"kpy" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
+"kpU" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kpZ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -18020,16 +18022,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kqv" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kqI" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree,
@@ -18103,8 +18095,13 @@
 	dir = 1;
 	icon_state = "longtable_mid"
 	},
+/obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"kss" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "kst" = (
 /obj/structure/spider/stickyweb,
 /turf/open/water/swamp,
@@ -18136,9 +18133,16 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -18229,8 +18233,17 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -18271,16 +18284,12 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
 	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18317,6 +18326,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/under/town/basement)
+"kya" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "kym" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -18407,18 +18422,6 @@
 "kBd" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/tavern)
-"kBg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "kBk" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat/goatlet,
 /turf/open/floor/rogue/dirt,
@@ -18512,13 +18515,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"kEc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "kEd" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -18536,13 +18532,6 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"kEv" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "kEB" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -18558,15 +18547,25 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"kEU" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "kFc" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 8
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18618,10 +18617,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"kHd" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "kHs" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -18647,17 +18642,28 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"kHO" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "kHR" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "kIf" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/closed,
 /area/rogue/indoors/town/garrison)
 "kIu" = (
 /obj/structure/stairs,
@@ -18688,10 +18694,6 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"kJm" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "kJq" = (
 /obj/structure/fluff/statue/gargoyle/candles{
 	pixel_y = -7
@@ -18718,6 +18720,12 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"kKj" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kKr" = (
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
@@ -18761,6 +18769,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kLD" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -18941,15 +18954,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"kQl" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "kQN" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
@@ -18965,6 +18969,16 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"kRd" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kRA" = (
 /obj/effect/landmark/start/mercenary{
 	dir = 4
@@ -18996,18 +19010,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"kSq" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "kSz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -19045,12 +19047,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"kTm" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "kTn" = (
 /obj/structure/roguemachine/atm{
 	pixel_x = 32;
@@ -19092,6 +19088,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
+"kVv" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kVH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -19125,6 +19130,22 @@
 "kWa" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs)
+"kWA" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kWT" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -19179,6 +19200,24 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"kZl" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "kZr" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
@@ -19240,16 +19279,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"lav" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "lay" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /obj/structure/flora/newleaf,
@@ -19289,14 +19318,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lcJ" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "ldf" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -19332,12 +19353,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"leR" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bull,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "leV" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -19351,10 +19366,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"lfb" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -19405,10 +19416,6 @@
 "lgp" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/bog)
-"lgr" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "lgA" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road{
@@ -19439,9 +19446,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -19553,10 +19562,20 @@
 "lkM" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"lkQ" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+"lkV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lli" = (
 /obj/structure/rogue/trophy/deer,
 /obj/item/natural/rock,
@@ -19628,6 +19647,14 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lnw" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "lnL" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -19657,8 +19684,15 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -19695,24 +19729,18 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"lpB" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "lpC" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"lpD" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH";
-	pixel_x = 19
-	},
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh2";
-	aportalid = "wh1";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = 18
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "lpG" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/blocks,
@@ -19733,16 +19761,10 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"lqf" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+"lqv" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -19752,6 +19774,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"lqG" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -19764,13 +19792,6 @@
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"lsb" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "lsc" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -19785,6 +19806,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"lsK" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "lsX" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -19847,19 +19875,17 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"luS" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "luV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"luX" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "lvr" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19868,21 +19894,14 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"lvM" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "lvO" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"lwa" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lwu" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/cobweb,
@@ -19928,6 +19947,15 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"lyJ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "lyK" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -19936,6 +19964,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"lyP" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -19992,19 +20029,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"lzR" = (
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lAb" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/manor)
-"lAg" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "lAs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/church/chapel)
@@ -20035,6 +20067,16 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"lBD" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "lBK" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -20171,10 +20213,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "lGI" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
@@ -20226,12 +20266,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"lIF" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "lIH" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile{
@@ -20262,20 +20296,6 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
-"lJI" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"lJL" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
 /area/rogue/indoors/town/garrison)
 "lJO" = (
 /obj/structure/table/wood{
@@ -20315,14 +20335,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"lKw" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
@@ -20358,18 +20370,19 @@
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
+"lLV" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"lMg" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"lMr" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lMD" = (
 /obj/item/natural/rock,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -20440,15 +20453,6 @@
 "lPu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"lPz" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lPQ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20478,6 +20482,17 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
+"lRC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "lRJ" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
@@ -20501,6 +20516,12 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
+/area/rogue/outdoors/rtfield)
+"lSX" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "lTj" = (
 /obj/structure/spacevine,
@@ -20578,6 +20599,15 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"lWV" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
@@ -20606,6 +20636,10 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"lXK" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lXN" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -20616,20 +20650,9 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
-"lYb" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
-"lYi" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lYl" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -20690,27 +20713,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"lZw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"lZG" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+"lZz" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "mab" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
@@ -20729,10 +20735,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/mountains)
-"maz" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "maA" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/carpet,
@@ -20744,23 +20746,22 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"maO" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"mbd" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mbm" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mbA" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -20770,22 +20771,13 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"mbZ" = (
-/obj/effect/decal/cobbleedge{
+"mbO" = (
+/obj/structure/roguewindow/openclose{
 	dir = 1
 	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
-"mck" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "mcm" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter)
@@ -20834,14 +20826,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20902,6 +20889,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"meQ" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "meV" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/structure/table/wood{
@@ -21025,11 +21016,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -21081,21 +21070,9 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"mlp" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "mlJ" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
-"mma" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "mmb" = (
 /obj/machinery/anvil,
@@ -21116,14 +21093,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"mnP" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
+"mmw" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21208,15 +21182,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"mpG" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "mpP" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -21290,18 +21255,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"msY" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21321,14 +21274,16 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
+"mtG" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "mtR" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"mua" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "mun" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -21372,6 +21327,10 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"mvI" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "mwd" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/grass,
@@ -21457,13 +21416,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"mzc" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "mzk" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -21472,18 +21424,17 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"mzo" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "mzq" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"mzs" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "mzx" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -21492,16 +21443,6 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"mzL" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "mzM" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf/big,
@@ -21510,16 +21451,6 @@
 "mzZ" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"mAD" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mAM" = (
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -21575,6 +21506,20 @@
 	},
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"mDR" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "mDY" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21621,12 +21566,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"mFB" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/clothing/ring/dragon_ring,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "mFC" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -21662,17 +21601,19 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "mGn" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mGS" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "mHb" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -21690,6 +21631,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
+"mHp" = (
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "mHD" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -21699,34 +21644,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"mHT" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"mJj" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -21737,6 +21654,13 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"mJO" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mJS" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -21786,29 +21710,21 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"mLH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"mMp" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mMv" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"mMD" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mMJ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -21926,35 +21842,29 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"mQd" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"mQo" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mQq" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
-"mQA" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/mountains)
-"mQF" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
+"mQA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -21973,12 +21883,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"mRU" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"mRR" = (
+/obj/structure/mineral_door/wood{
+	dir = 4;
+	locked = 1;
+	lockid = "garrison"
 	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "mRW" = (
 /obj/structure/fluff/railing/wood{
@@ -21986,10 +21900,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"mSn" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "mSs" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks,
@@ -22005,15 +21915,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"mSE" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "mSG" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/chair/bench{
@@ -22049,6 +21950,12 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"mUg" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mUi" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -22062,16 +21969,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"mUt" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mUB" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -22088,15 +21985,6 @@
 "mVa" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"mVd" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mVe" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/grass,
@@ -22107,16 +21995,8 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -22138,10 +22018,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
-"mWk" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mWx" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -22152,6 +22028,17 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"mWP" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "mWV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -22220,6 +22107,25 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"mYV" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"mZl" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "mZo" = (
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
@@ -22239,6 +22145,13 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"mZH" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "mZV" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/tile/checkeralt,
@@ -22304,6 +22217,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"nbA" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22389,17 +22306,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"nep" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
 "ner" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/tile{
@@ -22427,21 +22333,13 @@
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"nfI" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+"nfO" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
 	},
-/area/rogue/outdoors/rtfield)
-"nfY" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22455,13 +22353,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"nhm" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "nht" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/cobblerock,
@@ -22472,12 +22363,9 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
-"nhT" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22511,6 +22399,14 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"njj" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "njq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -22528,6 +22424,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"nku" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22553,14 +22453,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"nlx" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "nlG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -22614,6 +22506,14 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"nnm" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nnz" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -22629,10 +22529,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"nnZ" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "noi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22651,6 +22547,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"npd" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "npm" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -22672,6 +22575,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"npZ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "nqf" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/blocks,
@@ -22710,6 +22617,13 @@
 "nqU" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors)
+"nre" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nrn" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/closet/crate/roguecloset/inn/south{
@@ -22725,16 +22639,31 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"nrw" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
-"nrx" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
+"nru" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"nrv" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
+"nrw" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
+"nrx" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "nrD" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/cobble,
@@ -22792,13 +22721,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"nuC" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "nuD" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
@@ -22818,8 +22740,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -22833,6 +22755,10 @@
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"nvC" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "nvF" = (
 /obj/structure/stairs{
 	dir = 4
@@ -22854,13 +22780,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"nwk" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nwo" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/cobble,
@@ -22915,10 +22834,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"nxo" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "nxr" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder/c,
@@ -23030,6 +22945,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town/roofs)
+"nzV" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "nzW" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23040,14 +22961,14 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"nAQ" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+"nAu" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nAS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -23063,22 +22984,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"nBk" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -23108,6 +23016,10 @@
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"nBX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
@@ -23133,6 +23045,11 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"nDR" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nEd" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/garrison)
@@ -23146,6 +23063,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"nEs" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "nFg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shield/wood,
@@ -23188,12 +23112,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"nGi" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "nGw" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -23225,12 +23143,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"nGT" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "nGV" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
@@ -23255,6 +23167,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"nIh" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nIk" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -23262,12 +23180,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"nIl" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "nIo" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -23300,14 +23212,6 @@
 /obj/structure/bars/tough,
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
-"nIN" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nIQ" = (
 /obj/effect/landmark/start/mercenary{
 	dir = 4
@@ -23321,10 +23225,24 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"nIW" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nJy" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
 	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
+"nJL" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
@@ -23364,6 +23282,19 @@
 "nKx" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
+"nKI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "nLy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -23413,21 +23344,22 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"nMD" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "nMS" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"nNF" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nNJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -23471,6 +23403,13 @@
 /obj/structure/fluff/littlebanners/bluewhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"nOE" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "nOX" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23483,13 +23422,31 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
+"nPv" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "nPP" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/mountains)
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23576,16 +23533,17 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"nRE" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nRF" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/magelady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"nRG" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "nRW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -23598,17 +23556,11 @@
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"nSg" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "nSr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
@@ -23618,12 +23570,6 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"nSL" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nSS" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -23654,9 +23600,17 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23717,12 +23671,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"nVG" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "nVU" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -23745,6 +23693,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"nWL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "nWM" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -23829,6 +23783,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"nYg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nYp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -23872,31 +23833,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"nZq" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nZt" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/spear/billhook,
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"nZy" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "nZQ" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -23921,8 +23863,12 @@
 /area/rogue/indoors)
 "obq" = (
 /obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23959,6 +23905,9 @@
 "och" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"ocK" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "ocM" = (
 /obj/structure/floordoor/gatehatch/outer{
 	redstone_id = "gatelava"
@@ -24068,17 +24017,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"ofT" = (
-/obj/structure/mineral_door/wood{
-	dir = 4;
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "ogh" = (
 /obj/structure/flora/newtree,
 /turf/closed/mineral/rogue/salt,
@@ -24100,18 +24038,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"ogB" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "The Erlking";
-	health = 1500
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ogC" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -24177,10 +24109,6 @@
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"oiw" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oiC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
@@ -24190,9 +24118,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24296,6 +24228,16 @@
 /obj/item/clothing/neck/roguetown/psicross/astrata,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"omp" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
@@ -24318,6 +24260,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"onQ" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "onR" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
@@ -24339,6 +24285,13 @@
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"ooA" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ooJ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
@@ -24359,21 +24312,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"opC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "opG" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/carpet/lord/right,
@@ -24390,6 +24328,10 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"oqr" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -24512,16 +24454,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"oum" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "ous" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -24535,10 +24467,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
 	},
-/turf/open/water/cleanshallow,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "ovn" = (
 /turf/open/transparent/openspace,
@@ -24599,16 +24531,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"oxe" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "oxk" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -24731,6 +24653,11 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"oAj" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "oAl" = (
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
@@ -24783,6 +24710,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"oBH" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"oBL" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -24806,6 +24747,13 @@
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"oCD" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oCL" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24822,11 +24770,35 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"oDc" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "oDj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"oDr" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "oDx" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -24892,12 +24864,6 @@
 /obj/effect/decal/remains/bigrat,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"oFQ" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "oFR" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/hexstone,
@@ -24915,16 +24881,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"oGl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "oGv" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/effect/landmark/start/tribalcook,
@@ -24932,19 +24888,18 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"oGC" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "oGI" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
-"oGN" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "oGU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/closed/mineral/rogue,
@@ -24968,6 +24923,18 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"oHc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "oHg" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
@@ -24999,8 +24966,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -25029,10 +24996,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "oJO" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
@@ -25041,10 +25010,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"oKh" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "oKo" = (
 /obj/item/roguecoin/copper,
 /turf/open/water/swamp,
@@ -25080,9 +25045,10 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -25132,6 +25098,15 @@
 "oNE" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
+"oOf" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "oOh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -25159,11 +25134,21 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"oOv" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "oOx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"oON" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "oOQ" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -25180,28 +25165,23 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
+"oOY" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
+"oPc" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "oPi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
-"oPr" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "oPv" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -25239,17 +25219,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
-"oQC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "oQZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/closed/mineral/rogue,
@@ -25277,11 +25246,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -25294,6 +25264,14 @@
 /obj/structure/statue/saints/father,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"oRP" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oRQ" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 0;
@@ -25311,11 +25289,6 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"oRV" = (
-/obj/structure/fluff/wallclock/r,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "oSb" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood,
@@ -25326,9 +25299,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"oSm" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/basement)
 "oSy" = (
 /obj/structure/rack/rogue,
 /obj/item/ingot/iron,
@@ -25339,6 +25309,10 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"oSN" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "oSV" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25386,13 +25360,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"oUF" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "oUS" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -25687,16 +25654,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"pcn" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "pct" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -25733,16 +25690,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"pcO" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "pcQ" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -25756,11 +25709,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -25831,10 +25784,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"pfz" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "pfA" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/blocks/stonered,
@@ -25868,24 +25817,12 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"pgU" = (
-/obj/item/cooking/pan,
+"phe" = (
 /obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"pgX" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "phk" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguegem/green,
@@ -25895,11 +25832,13 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"phJ" = (
-/obj/structure/fluff/wallclock/l,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+"phB" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "phR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -25915,6 +25854,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"pik" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "pil" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph5"
@@ -25963,14 +25908,9 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "pjB" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pjC" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -26032,29 +25972,12 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"pmC" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
-"pmE" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "pmF" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/mince,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"pnd" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
 "pnl" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/bog,
@@ -26089,18 +26012,12 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"pnp" = (
-/obj/machinery/anvil{
-	pixel_x = -1
+"pnq" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"pns" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "pnD" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -26123,6 +26040,17 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"poU" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"ppc" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ppi" = (
 /obj/structure/stairs{
 	dir = 1
@@ -26153,6 +26081,19 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"ppy" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ppD" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/spear,
@@ -26242,14 +26183,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"prX" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "prZ" = (
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
@@ -26261,10 +26194,6 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"psB" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "psH" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26294,13 +26223,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"ptC" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ptK" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
@@ -26310,10 +26232,6 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors)
-"ptS" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "ptT" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -26345,6 +26263,13 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"pva" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -26442,11 +26367,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"pxZ" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "pyh" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -26497,16 +26417,6 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"pzt" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "pzu" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -26572,13 +26482,6 @@
 "pAV" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
-"pAX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "pBj" = (
 /mob/living/carbon/human/species/halforc/orc_raider/savage_orc/ambush,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26587,11 +26490,27 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"pBp" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pBx" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"pBE" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "pBJ" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26611,11 +26530,28 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"pCo" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "pCw" = (
 /obj/structure/chair/bench/church/mid,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"pCS" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "pCW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -26682,6 +26618,12 @@
 "pDZ" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/bog)
+"pEb" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "pEf" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -26699,10 +26641,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"pFL" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26725,6 +26663,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"pGU" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pHa" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -26745,16 +26689,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
-"pHA" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "pHI" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile{
@@ -26814,6 +26748,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"pKn" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "pKw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -26830,23 +26772,18 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"pKE" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
-"pKQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
+"pKC" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
+"pKQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -26901,14 +26838,13 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/stairs{
+	dir = 4
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
@@ -27057,33 +26993,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"pQO" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+"pQL" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
-"pQS" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "pRj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -27094,13 +27009,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"pRL" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "pRO" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -27324,21 +27232,19 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"pYB" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/obj/item/listenstone,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "pYO" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"pYU" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "pZq" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -27446,6 +27352,10 @@
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/dwarfin)
+"qcq" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "qcC" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/tile,
@@ -27458,10 +27368,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"qcZ" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
 "qda" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -27524,8 +27430,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -27578,6 +27484,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"qgP" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qhg" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -27630,22 +27545,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"qir" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -27674,11 +27573,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"qjb" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qjd" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -27686,6 +27580,36 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/shop)
+"qjg" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
+"qji" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"qjk" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "qjp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -27770,13 +27694,6 @@
 /obj/item/roguekey/garrison,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"qlL" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "qlO" = (
 /obj/structure/stairs{
 	dir = 4
@@ -27787,10 +27704,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qmh" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "qmx" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
@@ -27817,6 +27730,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qnL" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "qnO" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -27867,6 +27786,13 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"qoP" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27885,14 +27811,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"qpp" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qpt" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
 	},
-/turf/closed,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qpJ" = (
 /obj/structure/stairs/fancy/l{
 	dir = 1
@@ -27913,16 +27843,23 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
+/obj/structure/lever/wall{
 	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -27933,10 +27870,21 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"qqd" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "qqm" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"qqn" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qqp" = (
 /obj/structure/stairs{
 	dir = 1
@@ -27952,6 +27900,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"qqB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qqD" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -28017,12 +27970,13 @@
 "qrN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"qrV" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
+"qrZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qse" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/remains/human,
@@ -28034,18 +27988,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"qsC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qsI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -28096,6 +28038,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qtZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qub" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile{
@@ -28120,18 +28069,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
-"quP" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -28162,10 +28101,6 @@
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"qvs" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "qvt" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -28191,15 +28126,18 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qwd" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "qwp" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
 	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -28230,13 +28168,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"qxn" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "qxH" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/structure/spider/stickyweb,
@@ -28258,6 +28189,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qza" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -28280,16 +28217,34 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"qzp" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qzy" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -28299,6 +28254,27 @@
 	icon_state = "tablewood2"
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"qzY" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"qAh" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "qAj" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
@@ -28327,6 +28303,15 @@
 "qBu" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
+"qBB" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "qBF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8;
@@ -28349,10 +28334,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qCM" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qCN" = (
 /obj/structure/stairs{
 	dir = 1
@@ -28360,20 +28341,29 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"qDb" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -28422,9 +28412,13 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -28465,6 +28459,17 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"qHY" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "qIi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/villager,
@@ -28536,9 +28541,16 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28588,12 +28600,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"qMC" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
@@ -28663,16 +28669,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"qQb" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qQd" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -28701,16 +28697,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"qRp" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
+"qRp" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -28720,13 +28715,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qRW" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "qSc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/churchmarble,
@@ -28770,12 +28758,16 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"qTw" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
+"qTE" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qTL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "archive"
@@ -28786,22 +28778,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"qUi" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "qUE" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -28859,14 +28835,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"qXw" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+"qWL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
+/turf/closed,
 /area/rogue/indoors/town)
 "qXx" = (
 /obj/structure/fluff/railing/border{
@@ -28891,22 +28864,6 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/bog)
-"qYf" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
-"qYi" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qYl" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
@@ -28928,12 +28885,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -28953,6 +28910,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"qZg" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qZh" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
@@ -28975,12 +28942,28 @@
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
+"raG" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "raL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"raQ" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "rbk" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -29037,6 +29020,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"rcn" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -29044,24 +29037,15 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"rcS" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rcU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -29088,6 +29072,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"rdi" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rdq" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -29130,12 +29120,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"reg" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ret" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"reD" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "reI" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
@@ -29159,6 +29160,26 @@
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"rff" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
+"rfk" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "rfl" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/bog)
@@ -29201,11 +29222,8 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -29226,10 +29244,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"rhx" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "rhD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -29239,12 +29253,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"rhI" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "rhJ" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/tile{
@@ -29257,6 +29265,21 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"rhY" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"rik" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "rio" = (
 /obj/structure/winch{
 	gid = "forestgate1";
@@ -29327,14 +29350,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"rkK" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rkT" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -29384,6 +29399,10 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
+"rmE" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "rmJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5;
@@ -29397,10 +29416,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"rmO" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rnf" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "lord";
@@ -29501,13 +29516,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"rqw" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
 "rqP" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29552,14 +29560,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"rrL" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "rrP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -29613,15 +29613,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"rsS" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "rta" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -29657,16 +29648,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"ruC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "ruI" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -29677,10 +29658,6 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"rvY" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29719,6 +29696,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"rwx" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "rwH" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -29774,6 +29755,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"rxu" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rxx" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -29837,6 +29824,14 @@
 "rAz" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
+"rBd" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rBh" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -29902,15 +29897,19 @@
 /obj/structure/fluff/walldeco/bigpainting,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"rDp" = (
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"rDI" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -29971,6 +29970,14 @@
 /obj/structure/roguewindow,
 /turf/closed,
 /area/rogue/indoors/town/church/chapel)
+"rFg" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "rFy" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/water/cleanshallow,
@@ -29991,6 +29998,12 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"rFS" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rGm" = (
 /obj/structure/closet/crate/chest,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -30005,34 +30018,19 @@
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
-"rGS" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
 "rGY" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"rHJ" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -30043,15 +30041,6 @@
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"rIj" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "rIl" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 8
@@ -30124,24 +30113,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"rKB" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
-"rKK" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "rKQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -30192,6 +30163,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"rMH" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rMM" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/blocks/stonered,
@@ -30255,14 +30230,6 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/indoors/town/church/chapel)
-"rPa" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "rPE" = (
 /obj/effect/decal/cobbleedge{
@@ -30330,9 +30297,19 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30346,20 +30323,32 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"rRF" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/r{
 	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -30368,6 +30357,10 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rSz" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rSC" = (
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
@@ -30407,10 +30400,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"rSZ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rTm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/fluff/statue/tdummy,
@@ -30423,6 +30412,27 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"rTw" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"rTx" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "rTA" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -30509,13 +30519,6 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"rWb" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "rWj" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -30545,6 +30548,22 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"rXa" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "rXl" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -30565,19 +30584,18 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"rXq" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
 "rXE" = (
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rXP" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rXZ" = (
 /obj/item/rogueweapon/mace/wsword,
 /obj/item/rogueweapon/mace/wsword,
@@ -30672,6 +30690,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"sah" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sao" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
@@ -30682,10 +30705,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"saN" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "saS" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -30705,12 +30724,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/under/cave)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30742,6 +30761,11 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"scS" = (
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "scT" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -30821,17 +30845,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -30921,14 +30939,6 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
-"shH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "shV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -30973,14 +30983,6 @@
 /obj/structure/bars/tough,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
-"sjf" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5";
-	pixel_x = 17
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sjo" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -31046,6 +31048,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"slQ" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "slS" = (
 /obj/item/clothing/shoes/roguetown/boots/armoriron,
 /turf/open/floor/rogue/dirt/road{
@@ -31090,6 +31100,15 @@
 "smO" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
+	},
+/area/rogue/indoors/town/church/chapel)
+"smV" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/church/chapel)
 "sna" = (
@@ -31246,6 +31265,18 @@
 "sqW" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/mountains)
+"sqX" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"sqZ" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sri" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
@@ -31301,13 +31332,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/outdoors/beach)
-"ste" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "stv" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31350,13 +31374,8 @@
 	},
 /area/rogue/outdoors/beach)
 "suN" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "suY" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -31365,17 +31384,18 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"svk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "svx" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
 	},
 /area/rogue/outdoors/town)
+"svA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "svE" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
@@ -31426,10 +31446,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -31471,6 +31490,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"syR" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "syY" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -31498,6 +31524,13 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"sAb" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
+"sAj" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sAl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/long_sleep,
@@ -31551,26 +31584,18 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"sCc" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sCg" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"sCh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "sCJ" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"sCQ" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "sCU" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -31652,6 +31677,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"sFQ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sGj" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -31681,6 +31713,12 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"sGW" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "sHe" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/chair/wood/rogue{
@@ -31699,6 +31737,12 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
+"sHB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sHG" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pick,
@@ -31730,16 +31774,8 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -31755,10 +31791,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"sJs" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "sJZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -31805,6 +31837,16 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"sLx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31859,11 +31901,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
-"sOE" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
 "sPj" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt,
@@ -31902,10 +31939,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"sQb" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -31919,6 +31952,12 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sRY" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -31928,10 +31967,6 @@
 /obj/item/reagent_containers/powder,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
-"sSB" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "sSC" = (
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -32060,12 +32095,6 @@
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sWs" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "sWL" = (
 /obj/effect/landmark/start/squire{
 	dir = 4
@@ -32087,10 +32116,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"sXe" = (
-/obj/structure/closet/crate/chest,
+"sXc" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
@@ -32110,10 +32142,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
-"sYk" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "sYw" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
@@ -32156,14 +32184,6 @@
 "sZN" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"sZX" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "tag" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -32171,8 +32191,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -32229,6 +32249,10 @@
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
+"tbb" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "tbc" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -32348,15 +32372,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -32376,6 +32396,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"tgc" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tgZ" = (
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
@@ -32407,11 +32431,6 @@
 	dir = 10
 	},
 /area/rogue/outdoors/town/roofs)
-"tiv" = (
-/obj/structure/table/vtable/v2,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "tiB" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -32420,14 +32439,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -32441,6 +32455,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"tjf" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "tjg" = (
 /obj/item/roguestatue/iron,
 /turf/open/floor/rogue/concrete,
@@ -32462,6 +32482,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"tjL" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "tjU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/flail/sflail,
@@ -32529,13 +32553,19 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
-"tli" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+"tle" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
+"tlq" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -32543,8 +32573,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32626,19 +32659,16 @@
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
-"tpw" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
+"tpg" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32655,6 +32685,17 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"tqu" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"tqx" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "tqA" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/dirt/road{
@@ -32680,10 +32721,33 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"tqI" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tqJ" = (
 /obj/structure/roguemachine/money/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"trg" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "trv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "royal";
@@ -32722,6 +32786,13 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"tsE" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32742,6 +32813,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"tub" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -32817,6 +32897,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"twy" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "twA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32869,10 +32956,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"txe" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "txg" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /obj/structure/flora/roguegrass/water,
@@ -32880,14 +32963,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"txq" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3";
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "txC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -32901,37 +32976,28 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"txG" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"txH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
-"txK" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "txR" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"txS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "tyl" = (
 /obj/structure/dye_bin,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"typ" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tys" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/closet/crate/chest,
@@ -32961,6 +33027,15 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"tyI" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "tyK" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -33118,8 +33193,10 @@
 	},
 /area/rogue/outdoors/beach)
 "tCz" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
@@ -33161,6 +33238,12 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"tDO" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "tEs" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -33195,14 +33278,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tET" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tEU" = (
 /obj/structure/fluff/walldeco/stone{
 	pixel_y = 32
@@ -33219,16 +33294,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"tFE" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "tFH" = (
 /obj/item/dice,
 /obj/structure/table/wood{
@@ -33251,6 +33316,8 @@
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
+/obj/item/listenstone,
+/obj/item/scomstone,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tGg" = (
@@ -33278,10 +33345,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"tHM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
 "tHN" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 1;
@@ -33347,18 +33410,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"tJT" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "tKu" = (
 /obj/structure/fluff/railing/border{
@@ -33385,10 +33445,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"tLN" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -33457,6 +33513,12 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"tNC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tNH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
@@ -33526,15 +33588,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"tQQ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33547,13 +33600,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"tRN" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"tRF" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "tRV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -33613,16 +33664,9 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
-"tUh" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "tUp" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
@@ -33631,9 +33675,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -33709,45 +33758,34 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"tXm" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+"tXu" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "tXC" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"tXF" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
-"tYx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"tYB" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "tYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town)
+"tYO" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "tYP" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
@@ -33794,12 +33832,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"uab" = (
 /obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "uaj" = (
 /obj/machinery/light/rogue/forge{
@@ -33807,15 +33841,17 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"uaI" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"uaQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "uaX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -33829,6 +33865,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"ubr" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ubv" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -33838,6 +33878,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"ubM" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "ubZ" = (
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -33871,6 +33917,25 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
+"udH" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"udL" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "udM" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -33895,10 +33960,14 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
-"uee" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"uem" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "ueD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -33956,13 +34025,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"ugr" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "ugK" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/torchholder/l,
@@ -33993,6 +34055,15 @@
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"uhv" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "uhw" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -34110,27 +34181,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"umt" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "umH" = (
 /obj/structure/bars/pipe{
 	dir = 5
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"umK" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "unm" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -34153,6 +34209,10 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
+"unY" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uod" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/dirt/road{
@@ -34199,6 +34259,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"upw" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "upx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -34227,14 +34291,6 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"uqa" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uqe" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
@@ -34262,11 +34318,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34290,10 +34344,6 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"urY" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "urZ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -34425,9 +34475,12 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "uvu" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34442,20 +34495,21 @@
 "uvF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
-"uvQ" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
-"uvR" = (
+"uvM" = (
 /obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uwa" = (
-/obj/structure/stairs{
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
 	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34504,19 +34558,23 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/rtfield)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -34571,19 +34629,13 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
-"uzW" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34643,6 +34695,12 @@
 "uAZ" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/shelter)
+"uBn" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "uBo" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/twig,
@@ -34688,11 +34746,6 @@
 "uCQ" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves)
-"uCR" = (
-/obj/structure/table/vtable,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "uCV" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/wood,
@@ -34707,12 +34760,11 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "uDv" = (
 /obj/structure/bookcase/random,
@@ -34748,19 +34800,16 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -34781,18 +34830,13 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "uGo" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -34802,6 +34846,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"uGq" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uGt" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -34852,38 +34900,40 @@
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"uHM" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uHW" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"uIi" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
-"uIj" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "uIk" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
+"uIo" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "uJk" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -34895,12 +34945,6 @@
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
-"uKn" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -35006,6 +35050,14 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"uNc" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uNf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -35027,12 +35079,6 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"uOt" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -35065,21 +35111,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
-"uPd" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -35139,10 +35173,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uQG" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "uRd" = (
 /obj/structure/bed/rogue/shit/bier,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/corpses,
@@ -35157,6 +35187,16 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"uRv" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"uRy" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -35177,13 +35217,6 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/rogue/indoors/town/church/chapel)
-"uSz" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "uSS" = (
 /obj/structure/bars,
@@ -35246,6 +35279,16 @@
 /obj/structure/fluff/statue,
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/shelter/mountains)
+"uUo" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "uUv" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35256,6 +35299,12 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uVk" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -35297,19 +35346,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"uWe" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
-"uWv" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "uWE" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
@@ -35417,8 +35453,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -35471,6 +35510,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"vbp" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vbC" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -35488,21 +35531,18 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"vbQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"vbR" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "vce" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
+"vcg" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vcj" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -35521,10 +35561,19 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
+"vcZ" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vdg" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -35552,10 +35601,6 @@
 "veg" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
-"veh" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "vey" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/oat,
@@ -35603,12 +35648,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "priest"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35657,10 +35698,24 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vgI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "vgZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vha" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vhg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -35722,8 +35777,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -35750,12 +35805,6 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vkl" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "vkI" = (
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35783,6 +35832,15 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"vlU" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "vlX" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -35876,23 +35934,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"vpo" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vpu" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35960,6 +36007,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"vrF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "vrG" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -35986,11 +36041,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/obj/structure/bed/rogue/inn/double,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -36135,10 +36188,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"vwi" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "vwl" = (
 /obj/structure/stairs{
 	dir = 8
@@ -36186,6 +36235,16 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"vyN" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -36243,6 +36302,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"vzO" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vzR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36301,15 +36370,8 @@
 /obj/item/clothing/neck/roguetown/psicross/silver,
 /obj/item/clothing/neck/roguetown/psicross,
 /obj/item/clothing/neck/roguetown/psicross,
+/obj/item/listenstone,
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
-"vBk" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
@@ -36348,6 +36410,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vCC" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vCD" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -36364,15 +36430,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"vCX" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "vDa" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/woodturned,
@@ -36418,12 +36475,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"vDP" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "vDS" = (
 /obj/structure/bars/pipe,
 /obj/item/roguegem/random,
@@ -36437,13 +36488,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"vEe" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "vEn" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -36491,11 +36535,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -36514,17 +36555,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church/chapel)
 "vGQ" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vGT" = (
 /obj/structure/spacevine,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -36535,14 +36571,21 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
+"vHy" = (
+/turf/closed/mineral/rogue,
 /area/rogue/indoors/town)
 "vIa" = (
 /turf/closed/mineral/rogue,
@@ -36571,12 +36614,6 @@
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"vJg" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vJt" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36584,10 +36621,12 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
-"vJN" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+"vJv" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vJU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -36615,8 +36654,14 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "vLD" = (
 /obj/structure/rack/rogue,
@@ -36680,13 +36725,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"vNu" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "vNv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -36723,6 +36761,10 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"vPe" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vPf" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/dirt,
@@ -36732,11 +36774,8 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "vPJ" = (
 /obj/structure/rack/rogue,
@@ -36779,16 +36818,8 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36889,8 +36920,29 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"vUD" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -36914,6 +36966,13 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"vVI" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vVM" = (
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
@@ -36966,11 +37025,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -37002,24 +37059,6 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
-"vYb" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"vYh" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "vYw" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -37041,13 +37080,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"vYZ" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -37132,6 +37164,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"wbF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -37236,7 +37278,12 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37251,12 +37298,11 @@
 	},
 /area/rogue/outdoors/tribalfort)
 "wgG" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wgO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/silver,
@@ -37299,6 +37345,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"wjw" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "wjB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -37316,18 +37366,18 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wki" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"wlk" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wlq" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
@@ -37361,6 +37411,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"wmn" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "wmK" = (
 /obj/structure/stairs{
 	dir = 1
@@ -37389,10 +37445,13 @@
 "wnd" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"wnq" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"wni" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wnv" = (
 /obj/structure/roguewindow,
 /obj/structure/bars,
@@ -37413,21 +37472,17 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "wou" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37455,13 +37510,18 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -37479,16 +37539,16 @@
 /area/rogue/outdoors/rtfield)
 "wqq" = (
 /obj/effect/decal/cobbleedge{
-	dir = 10
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/area/rogue/outdoors/mountains)
 "wqE" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "boat1";
@@ -37502,6 +37562,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"wqM" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "wqN" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -37511,10 +37575,8 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -37522,19 +37584,16 @@
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"wsR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+"wss" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"wsV" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
+"wsR" = (
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37545,13 +37604,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "wte" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "wtl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -37584,14 +37644,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wuX" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wve" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
@@ -37637,6 +37689,12 @@
 /obj/item/candle/skull/lit,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"wvV" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "wvW" = (
 /obj/item/clothing/ring/diamond{
 	desc = "A brilliant Ring to signify the beloved champion of Eora.";
@@ -37672,14 +37730,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wya" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "wyr" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/soil,
@@ -37688,12 +37738,8 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
@@ -37707,12 +37753,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"wzc" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -37776,12 +37816,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"wBt" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wBw" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -37813,13 +37847,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wBY" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wCg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -37838,16 +37865,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"wCF" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "wCP" = (
 /obj/effect/landmark/start/prisonerc,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors)
+"wDb" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "wDj" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -37880,23 +37907,23 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37921,6 +37948,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"wEY" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wFc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -37938,17 +37971,13 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"wFq" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -37985,11 +38014,24 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"wGu" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "wGD" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"wGP" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "wHa" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/cobble,
@@ -38000,23 +38042,9 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"wHm" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
-"wHS" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -38206,13 +38234,6 @@
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
-"wOO" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -38352,8 +38373,17 @@
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wSg" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "wSl" = (
-/turf/open/floor/rogue/herringbone,
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
@@ -38370,30 +38400,14 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"wTe" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
+"wTs" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
 /turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+	icon_state = "chess"
 	},
-/area/rogue/indoors/town/church/chapel)
-"wTs" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -38416,12 +38430,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38448,10 +38461,6 @@
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
-"wVA" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "wVI" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -38502,13 +38511,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wXW" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "wYk" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -38523,11 +38525,10 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38562,16 +38563,32 @@
 /obj/item/rogueweapon/sword,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"wZQ" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "xaf" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38612,11 +38629,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38665,8 +38681,21 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"xdJ" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38694,12 +38723,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"xeT" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "xff" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -38717,6 +38740,10 @@
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
+/area/rogue/indoors/town/church/chapel)
+"xfj" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "xfG" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -38771,17 +38798,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"xhv" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "xhw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -38864,16 +38880,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"xiY" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "xjl" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
@@ -38922,8 +38928,18 @@
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -38958,28 +38974,6 @@
 "xlm" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"xlp" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "xlx" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39001,6 +38995,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"xmQ" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xna" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -39052,14 +39052,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"xnP" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "xnQ" = (
 /obj/structure/chair/bench/church/mid{
 	dir = 1
@@ -39124,13 +39116,6 @@
 /obj/item/clothing/suit/roguetown/armor/leather/hide,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"xoZ" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "xpj" = (
 /obj/structure/statue/saints/cephine,
 /turf/open/floor/rogue/blocks,
@@ -39151,9 +39136,15 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
+"xpW" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -39186,6 +39177,12 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"xqZ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xrd" = (
 /obj/structure/bars/pipe,
 /turf/open/transparent/openspace,
@@ -39216,6 +39213,18 @@
 "xrI" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/shop)
+"xrY" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "xse" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -39232,10 +39241,21 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"xsD" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xsG" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"xsV" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "xtc" = (
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
@@ -39285,10 +39305,6 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"xue" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
 "xuh" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -39321,16 +39337,6 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
-"xvn" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "xvs" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -39380,10 +39386,15 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/area/rogue/under/cave)
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39492,13 +39503,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"xzK" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xzN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road{
@@ -39521,13 +39525,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -39552,9 +39551,30 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
+"xBh" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
+"xBk" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xBl" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"xBv" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xBB" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/tile{
@@ -39668,15 +39688,12 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/beach)
-"xDg" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+"xDa" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xDi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
@@ -39684,6 +39701,10 @@
 "xDn" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
+"xDp" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xDJ" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -39721,16 +39742,9 @@
 	},
 /area/rogue/outdoors/town)
 "xET" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"xFf" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39741,6 +39755,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"xFp" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xFt" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder{
@@ -39806,18 +39825,24 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"xGV" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xGW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xHe" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39862,15 +39887,6 @@
 /obj/item/rope,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"xIo" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "xID" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -39883,17 +39899,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "xJe" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39916,11 +39930,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"xKj" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "xKx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -39934,16 +39943,17 @@
 "xKz" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
-"xKA" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "xKF" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/church/chapel)
+"xKH" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "xKK" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/shoes/roguetown/boots/leather,
@@ -40150,6 +40160,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"xRn" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "xRr" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -40178,19 +40192,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"xSj" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "xSG" = (
 /obj/effect/landmark/start/shepherd,
 /turf/open/floor/rogue/tile,
@@ -40282,6 +40283,11 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"xUK" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "xUQ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -40322,12 +40328,27 @@
 /obj/structure/roguewindow/stained/silver,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"xVN" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "xWm" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"xWA" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "xWN" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
@@ -40410,16 +40431,6 @@
 "xYz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"xYI" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "xYM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -40542,10 +40553,8 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -40571,15 +40580,10 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
-"yej" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
+"yel" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "yer" = (
 /obj/structure/bars/passage/shutter,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -40684,6 +40688,14 @@
 /obj/item/natural/bundle/cloth,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"yhr" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "yhs" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -40727,21 +40739,20 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"yif" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "yiw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -40768,12 +40779,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -183615,18 +183622,18 @@ bpD
 bpD
 bpD
 bpD
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
 bpD
 bpD
 bpD
@@ -184017,7 +184024,7 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
 sYw
 sYw
@@ -184027,8 +184034,8 @@ sYw
 sYw
 sYw
 sYw
-xwi
-xwi
+auL
+auL
 bpD
 bpD
 bpD
@@ -184419,21 +184426,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-aev
-aev
-aev
-aev
-aev
-aev
+xAh
+xAh
+xAh
+xAh
+xAh
+xAh
+xAh
 sYw
-xwi
-xwi
-xwi
-xwi
-xwi
+auL
+auL
+auL
+auL
+auL
 bpD
 bpD
 bpD
@@ -184821,21 +184828,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-ijU
-vUf
-vUf
-cBG
-ijU
-aev
-sYw
-sYw
+xAh
+sAj
+fVM
+fVM
+wgG
+sAj
+xAh
 sYw
 sYw
 sYw
-xwi
+sYw
+sYw
+auL
 bpD
 bpD
 bpD
@@ -185223,21 +185230,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-vUf
-vUf
-cBG
-vUf
-xpM
-aev
-aev
-aev
-aev
-aev
+xAh
+fVM
+fVM
+wgG
+fVM
+mjP
+xAh
+xAh
+xAh
+xAh
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -185625,21 +185632,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-heJ
-dME
-vUf
-vUf
-vUf
-vUf
-vUf
-ijU
-aev
-aev
+xAh
+jti
+wni
+fVM
+fVM
+fVM
+fVM
+fVM
+sAj
+xAh
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -186027,21 +186034,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-xwi
-xwi
-evB
-hhU
-qmh
-vUf
-cBG
-ijU
-aev
-aev
+xAh
+auL
+auL
+jNF
+pnq
+poU
+fVM
+wgG
+sAj
+xAh
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -186429,21 +186436,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-che
-xwi
-xwi
-wte
-eEA
-vUf
-eib
-vUf
-dUC
-aev
+xAh
+xGV
+auL
+auL
+ccy
+fnP
+fVM
+jiW
+fVM
+sRY
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -186831,21 +186838,21 @@ bpD
 bpD
 bpD
 bpD
-xwi
+auL
 sYw
-aev
-gvi
-xwi
-xwi
-prX
-eEA
-aok
-vUf
-vUf
-dUC
-aev
+xAh
+nIh
+auL
+auL
+nAu
+fnP
+qBB
+fVM
+fVM
+sRY
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -187233,21 +187240,21 @@ sSS
 sSS
 sSS
 sSS
-xwi
+auL
 sYw
-aev
-xwi
-xwi
-eqo
-vUf
-qmh
-vUf
-cBG
-ijU
-aev
-aev
+xAh
+auL
+auL
+hRg
+fVM
+poU
+fVM
+wgG
+sAj
+xAh
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -187635,21 +187642,21 @@ sSS
 sSS
 sSS
 sSS
-xwi
+auL
 sYw
-aev
-xKA
-kEv
-vUf
-vUf
-vUf
-vUf
-vUf
-ijU
-aev
-aev
+xAh
+aTr
+nre
+fVM
+fVM
+fVM
+fVM
+fVM
+sAj
+xAh
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -188037,21 +188044,21 @@ sSS
 sSS
 sSS
 sSS
-xwi
+auL
 sYw
-aev
-vUf
-vUf
-vUf
-vUf
-xpM
-aev
-aev
-aev
-aev
-aev
+xAh
+fVM
+fVM
+fVM
+fVM
+mjP
+xAh
+xAh
+xAh
+xAh
+xAh
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -188439,21 +188446,21 @@ sSS
 sSS
 sSS
 sSS
-xwi
+auL
 sYw
-aev
-ijU
-nIN
-cBG
-cBG
-ijU
-aev
-sYw
-sYw
+xAh
+sAj
+rBd
+wgG
+wgG
+sAj
+xAh
 sYw
 sYw
 sYw
-xwi
+sYw
+sYw
+auL
 bpD
 bpD
 bpD
@@ -188841,21 +188848,21 @@ sSS
 sSS
 sSS
 sSS
-xwi
+auL
 sYw
-aev
-aev
-aev
-aev
-aev
-aev
-aev
+xAh
+xAh
+xAh
+xAh
+xAh
+xAh
+xAh
 sYw
-xwi
-xwi
-xwi
-xwi
-xwi
+auL
+auL
+auL
+auL
+auL
 bpD
 bpD
 bpD
@@ -189243,7 +189250,7 @@ sSS
 sSS
 sSS
 sSS
-xwi
+auL
 sYw
 sYw
 sYw
@@ -189253,7 +189260,7 @@ sYw
 sYw
 sYw
 sYw
-xwi
+auL
 bpD
 bpD
 bpD
@@ -189645,17 +189652,17 @@ sSS
 sSS
 sSS
 sSS
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
-xwi
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
+auL
 bpD
 bpD
 bpD
@@ -202881,15 +202888,15 @@ vRu
 vRu
 vRu
 fjw
-oSm
-oSm
-oSm
-oSm
-oSm
-oSm
-oSm
-oSm
-oSm
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 vup
 iTw
 iTw
@@ -203283,7 +203290,7 @@ vRu
 vRu
 fjw
 fjw
-oSm
+ebe
 txa
 txa
 txa
@@ -206900,8 +206907,8 @@ sYw
 sYw
 sYw
 sYw
-oSm
-oSm
+ebe
+ebe
 txa
 cFQ
 cBf
@@ -227808,7 +227815,7 @@ acD
 acD
 fhw
 acD
-ruC
+sLx
 acD
 acD
 acD
@@ -228211,8 +228218,8 @@ acD
 acD
 acD
 vuH
-cld
-woq
+cMs
+sbF
 acD
 azH
 azH
@@ -228610,7 +228617,7 @@ vRu
 vRu
 acD
 qgC
-woq
+sbF
 qgC
 vuH
 qgC
@@ -229011,12 +229018,12 @@ vRu
 vRu
 vRu
 acD
-woq
+sbF
 qgC
-cld
+cMs
 vuH
-cld
-woq
+cMs
+sbF
 acD
 qgC
 qgC
@@ -229414,11 +229421,11 @@ vRu
 vRu
 acD
 qgC
-woq
+sbF
 qgC
 vuH
-cld
-woq
+cMs
+sbF
 acD
 qgC
 qgC
@@ -229815,12 +229822,12 @@ vRu
 vRu
 vRu
 acD
-woq
+sbF
 qgC
 qgC
 vuH
-cld
-woq
+cMs
+sbF
 acD
 qgC
 qgC
@@ -230219,9 +230226,9 @@ vRu
 acD
 qgC
 qgC
-kad
+jec
 vuH
-cld
+cMs
 qgC
 acD
 vRu
@@ -230622,7 +230629,7 @@ acD
 acD
 acD
 acD
-tiH
+flR
 acD
 acD
 acD
@@ -231423,12 +231430,12 @@ vRu
 vRu
 acD
 qgC
-woq
-kwN
+sbF
+qKU
 vuH
 ffw
 qgC
-woq
+sbF
 acD
 vRu
 vRu
@@ -231826,7 +231833,7 @@ vRu
 acD
 qgC
 qgC
-kwN
+qKU
 qgC
 vuH
 vuH
@@ -232227,9 +232234,9 @@ vRu
 vRu
 acD
 qgC
-woq
+sbF
 qgC
-kwN
+qKU
 vuH
 vuH
 qgC
@@ -233031,9 +233038,9 @@ vRu
 vRu
 acD
 qgC
-foH
+onQ
 qgC
-foH
+onQ
 ffw
 vuH
 qgC
@@ -233434,11 +233441,11 @@ vRu
 acD
 qgC
 vRu
-kwN
+qKU
 vuH
 vuH
 vuH
-woq
+sbF
 acD
 vRu
 vRu
@@ -233838,8 +233845,8 @@ acD
 acD
 acD
 acD
-bux
-mSn
+hbR
+vgI
 acD
 acD
 vRu
@@ -280907,12 +280914,12 @@ hcW
 hcW
 hcW
 cWT
-iME
-iME
-iME
-iME
-iME
-iME
+sIE
+sIE
+sIE
+sIE
+sIE
+sIE
 uSw
 uSw
 uSw
@@ -280932,35 +280939,35 @@ uSw
 uSw
 uSw
 uSw
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281308,12 +281315,12 @@ uaL
 uaL
 uaL
 uaL
-nhR
-nuH
-wCF
-cRP
-cRP
-pzt
+veW
+tXu
+uHk
+vQV
+vQV
+omp
 nrw
 nrw
 nrw
@@ -281343,26 +281350,26 @@ ykt
 ykt
 ykt
 ykt
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
+veW
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281710,61 +281717,61 @@ wSn
 wSn
 uaL
 uaL
-nhR
-nuH
-iIR
-cRP
-cRP
-cRP
+veW
+tXu
+rcr
+vQV
+vQV
+vQV
 nrw
 nrw
-mzL
-eef
-aPR
-ilD
-ilD
-sxM
+nNF
+xqZ
+qzy
+qji
+qji
+fDB
 nrw
-vPA
-xdw
-xdw
-kfX
+iiG
+vFz
+vFz
+uBn
 kzQ
-caK
-bob
-bob
-fVY
-xhv
+qgP
+wYv
+wYv
+aXr
+ica
 nrw
-cRP
-cRP
-vdg
+vQV
+vQV
+uEX
 uaL
 uaL
 paf
 qvR
 qvR
-qGh
+mHp
 uaL
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
 kVc
-nhR
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -282112,62 +282119,62 @@ wSn
 wSn
 tzK
 uaL
-nhR
-nuH
-pxZ
-cRP
-aym
-txe
+veW
+tXu
+jdO
+vQV
+kss
+kmo
 nrw
 nrw
-cGA
-aPR
-aPR
-sCQ
-sCQ
-sCQ
+rhY
+qzy
+qzy
+nku
+nku
+nku
 nrw
 jlO
-xdw
-tli
-xdw
+vFz
+qjg
+vFz
 jlO
-caK
-bob
-bob
-arG
-jVq
+qgP
+wYv
+wYv
+lBD
+pCo
 nrw
-cRP
-cRP
-vdg
-leR
+vQV
+vQV
+uEX
+ogC
 uaL
 paf
 qvR
 qvR
-qGh
+mHp
 uaL
 uaL
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 cWT
 cWT
@@ -282514,65 +282521,65 @@ wSn
 uaL
 uaL
 uaL
-nhR
-nuH
-yiI
-cRP
-cRP
-txe
+veW
+tXu
+fJG
+vQV
+vQV
+kmo
 nrw
 nrw
-qCT
-aPR
-aPR
-eef
-aPR
-aPR
-jzh
+uDi
+qzy
+qzy
+xqZ
+qzy
+qzy
+dAf
 jlO
-xdw
-rrL
-xdw
+vFz
+cwd
+vFz
 jlO
 evo
-uIi
-bob
-rIj
-bob
+wTs
+wYv
+raQ
+wYv
 nrw
-cRP
-cRP
-vdg
-nfI
+vQV
+vQV
+uEX
+tYO
 uaL
 paf
 qvR
 qvR
-qGh
+mHp
 fxx
 aJj
 wSn
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -282916,66 +282923,66 @@ wSn
 uaL
 uaL
 uaL
-nhR
-nuH
-nuH
-xkF
-xkF
-bgY
-nuH
+veW
+tXu
+tXu
+wsR
+wsR
+tqu
+tXu
 nrw
-dnh
-qRp
-aPR
-aPR
-aPR
-aPR
-jzh
+xDa
+bPv
+qzy
+qzy
+qzy
+qzy
+dAf
 jlO
-xdw
-nMD
-xdw
+vFz
+aSD
+vFz
 jlO
 nrw
-qir
-bob
-bob
-bob
-vNu
-cRP
-cRP
-vdg
+rXa
+wYv
+wYv
+wYv
+mbO
+vQV
+vQV
+uEX
 uaL
 uaL
-oFQ
+qwd
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 wSn
 wSn
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 hcW
@@ -283318,68 +283325,68 @@ wSn
 wSn
 uaL
 uaL
-nhR
-nuH
-yiI
-xkF
-xkF
-bgY
-nuH
+veW
+tXu
+fJG
+wsR
+wsR
+tqu
+tXu
 nrw
-oUF
-eef
-aPR
-sXe
-sXe
-sXe
+jpM
+xqZ
+qzy
+vWY
+vWY
+vWY
 nrw
-oJO
-xdw
-kSq
-xdw
-oJO
+kFh
+vFz
+xrY
+vFz
+kFh
 nrw
-oRp
-bob
-cRP
-cRP
-vNu
-cRP
-cRP
-vdg
+nzV
+wYv
+vQV
+vQV
+mbO
+vQV
+vQV
+uEX
 ykt
 ykt
 ykt
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 wSn
 aJj
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 uaL
@@ -283681,7 +283688,7 @@ cWT
 hcW
 hcW
 hcW
-nZy
+qzH
 wSn
 wSn
 wSn
@@ -283720,69 +283727,69 @@ uaL
 uaL
 uaL
 uaL
-nhR
-nuH
-wCF
-xkF
-htf
-xkF
-hAD
-aPR
-aPR
-aPR
-wnq
-sCQ
-sCQ
-nRG
+veW
+tXu
+uHk
+wsR
+jFn
+wsR
+ixi
+qzy
+qzy
+qzy
+fRO
+nku
+nku
+kgK
 nrw
-iRN
-xdw
-xdw
-xdw
+lyJ
+vFz
+vFz
+vFz
 jlO
 nrw
-uIi
-bob
-cRP
-cRP
-vNu
-nTR
-cRP
-vdg
+wTs
+wYv
+vQV
+vQV
+mbO
+nBf
+vQV
+uEX
 uaL
 uaL
-oFQ
+qwd
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 wSn
 uaL
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 uaL
 uaL
 wSn
@@ -284122,15 +284129,15 @@ hcW
 hcW
 uaL
 uaL
-nhR
-nuH
-iIR
-xkF
-xkF
-xkF
-nuH
+veW
+tXu
+rcr
+wsR
+wsR
+wsR
+tXu
 nrw
-jzh
+dAf
 nrw
 nrw
 nrw
@@ -284139,51 +284146,51 @@ nrw
 nrw
 nrw
 jlO
-aCd
-oJO
+sCh
+kFh
 jlO
 nrw
-sWs
-bob
-cRP
-vEe
+hSy
+wYv
+vQV
+fic
 nrw
-eSt
-cRP
-vdg
-vFz
+hbc
+vQV
+uEX
+kya
 uaL
 paf
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
 wSn
 uaL
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 wSn
@@ -284524,67 +284531,67 @@ hcW
 hcW
 uaL
 uaL
-nhR
-nuH
-pxZ
-txq
-xkF
-xkF
-qrV
-cRP
-cRP
-phJ
-cRP
-qCM
-qCM
-cRP
+veW
+tXu
+jdO
+lpB
+wsR
+wsR
+lSX
+vQV
+vQV
+mzo
+vQV
+tgc
+tgc
+vQV
 mwq
 nrw
-qQb
+uUo
 nrw
 jlO
 jlO
 nrw
-qXw
-adK
-cRP
-wXW
+vUD
+qYw
+vQV
+fQq
 nrw
-nTR
-cRP
-vdg
-rgO
+nBf
+vQV
+uEX
+goz
 uaL
 paf
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
 uaL
 wSn
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 qvR
@@ -284926,65 +284933,65 @@ hcW
 hcW
 hcW
 uaL
-nhR
-nuH
-nuH
-nuH
-nuH
+veW
+tXu
+tXu
+tXu
+tXu
 nrw
 nrw
 mwq
-cRP
-aym
-cRP
-aym
-cRP
-cRP
-cRP
-cRP
-cRP
+vQV
+kss
+vQV
+kss
+vQV
+vQV
+vQV
+vQV
+vQV
 nrw
-wgG
-nrw
-nrw
+tsE
 nrw
 nrw
-vYZ
 nrw
 nrw
-cRP
-cRP
-vdg
+gpK
+nrw
+nrw
+vQV
+vQV
+uEX
 lsD
 lsD
-kQl
+hqw
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
 fxx
 wSn
-nhR
+veW
 kVc
-nhR
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -285328,65 +285335,65 @@ hcW
 hcW
 uaL
 uaL
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
 evo
 nrw
 nrw
-fua
-fua
-uxZ
-hjD
-fDB
-fDB
-fDB
-hjD
-cRP
+cfK
+cfK
+nYg
+suN
+xVN
+xVN
+xVN
+suN
+vQV
 nrw
-aPR
-wBt
-mjP
+qzy
+fMS
+mUg
 nrw
-tUR
-nTR
-eSt
-nTR
-cRP
-cRP
-vdg
+vPe
+nBf
+hbc
+nBf
+vQV
+vQV
+uEX
 rhD
 rhD
 rhD
 rhD
 rhD
-qGh
+mHp
 rZt
 fxx
 fxx
 fxx
 uaL
-nhR
+veW
 kVc
-nhR
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 uaL
@@ -285734,31 +285741,31 @@ uaL
 uaL
 qvR
 qvR
-nhR
+veW
 evo
-czM
-eSt
+agR
+hbc
 cbG
 cbG
-dnV
-hjD
-bhu
-mzc
-ivi
-txG
-cRP
+qjk
+suN
+jAI
+hej
+dfG
+avf
+vQV
 nrw
-aPR
-ark
-aPR
-yjP
-cRP
-cRP
-nTR
-cRP
-cRP
-cRP
-pdm
+qzy
+kKj
+qzy
+bRt
+vQV
+vQV
+nBf
+vQV
+vQV
+vQV
+bCb
 fxx
 fxx
 fxx
@@ -285771,24 +285778,24 @@ fxx
 fxx
 aJj
 wSn
-nhR
-nhR
+veW
+veW
 kVc
 kVc
-nhR
+veW
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 uaL
@@ -286136,34 +286143,34 @@ uaL
 uaL
 qvR
 qvR
-vjs
+dwO
 evo
-tUp
-eSt
+lZz
+hbc
 cbG
 cbG
-ifg
-hjD
-xAh
-rHJ
-lsb
-hjD
-cRP
-vpo
-aPR
-bif
-aPR
-wgG
-cRP
-cRP
-cRP
-cRP
-cRP
-cRP
-pdm
+dkV
+suN
+goh
+aFj
+twy
+suN
+vQV
+haw
+qzy
+cdn
+qzy
+tsE
+vQV
+vQV
+vQV
+vQV
+vQV
+vQV
+bCb
 fxx
 fxx
-hdk
+uxV
 fxx
 fxx
 fxx
@@ -286173,24 +286180,24 @@ fxx
 fxx
 uaL
 wSn
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 wSn
@@ -286538,31 +286545,31 @@ uaL
 uaL
 qvR
 qvR
-vjs
+dwO
 evo
-kkN
-eSt
+fLX
+hbc
 cbG
 cbG
-uxZ
-hjD
-dzf
-nuC
-hQd
-hjD
-cRP
+nYg
+suN
+wFp
+oBH
+eLp
+suN
+vQV
 nrw
-nSg
-nSg
-bif
-wgG
-cRP
-cRP
-cRP
-cRP
-cRP
-cRP
-pdm
+rTw
+rTw
+cdn
+tsE
+vQV
+vQV
+vQV
+vQV
+vQV
+vQV
+bCb
 fxx
 fxx
 fxx
@@ -286576,23 +286583,23 @@ fxx
 uaL
 uaL
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -286904,7 +286911,7 @@ uaL
 uaL
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -286940,37 +286947,37 @@ uaL
 uaL
 qvR
 qvR
-vjs
+dwO
 evo
 nrw
 nrw
-alx
-alx
-uxZ
-txG
-bVY
-bVY
-bVY
-hjD
-cRP
+nrv
+nrv
+nYg
+avf
+cCS
+cCS
+cCS
+suN
+vQV
 nrw
-uwa
-ibe
-aPR
-yjP
-cRP
-cRP
-nTR
-cRP
-cRP
-cRP
-vdg
+fBY
+htp
+qzy
+bRt
+vQV
+vQV
+nBf
+vQV
+vQV
+vQV
+uEX
 rhD
 rhD
 rhD
 rhD
 rhD
-qGh
+mHp
 rZt
 fxx
 fxx
@@ -286978,23 +286985,23 @@ fxx
 fxx
 aJj
 kVc
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -287342,37 +287349,37 @@ uaL
 uaL
 qvR
 qvR
-nhR
+veW
 evo
 nrw
 mwq
-cRP
-cRP
-cRP
-cRP
-cRP
-cRP
-cRP
-aym
-cRP
+vQV
+vQV
+vQV
+vQV
+vQV
+vQV
+vQV
+kss
+vQV
 nrw
 nrw
 nrw
-vYb
+xJe
 nrw
-tUR
-nTR
-eSt
-nTR
-cRP
-cRP
-vdg
-ugr
+vPe
+nBf
+hbc
+nBf
+vQV
+vQV
+uEX
+bPz
 qvR
 qvR
 qvR
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -287380,23 +287387,23 @@ fxx
 fxx
 uaL
 aJj
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
-nhR
+veW
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
-nhR
+veW
 kVc
 qvR
 qvR
@@ -287744,37 +287751,37 @@ uaL
 uaL
 uaL
 qvR
-nhR
+veW
 evo
 nrw
-fLK
-qYi
-oRV
-cRP
-qYi
-qYi
-cRP
+hci
+xET
+scS
+vQV
+xET
+xET
+vQV
 mwq
 nrw
 nrw
 nrw
 nrw
-bmL
-aPR
+vPA
+qzy
 nrw
 nrw
-aRR
+qWL
 nrw
 nrw
-nTR
-cRP
-vdg
+nBf
+vQV
+uEX
 uaL
 uaL
 uaL
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -287782,23 +287789,23 @@ fxx
 fxx
 wSn
 aJj
-nhR
-nhR
-nhR
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 wSn
@@ -288115,7 +288122,7 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -288144,9 +288151,9 @@ uaL
 uaL
 uaL
 hcW
-nhR
-nhR
-nhR
+veW
+veW
+veW
 evo
 nrw
 nrw
@@ -288158,25 +288165,25 @@ nrw
 nrw
 nrw
 nrw
-wHS
-wHS
+pKQ
+pKQ
 nrw
-bmL
-aPR
-bmL
-bIR
-obq
-ilD
+vPA
+qzy
+vPA
+jYZ
+fFH
+qji
 nrw
-eSt
-cRP
-vdg
+hbc
+vQV
+uEX
 uaL
 uaL
 uaL
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -288185,20 +288192,20 @@ fxx
 wSn
 aJj
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-qcZ
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+qqd
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -288548,37 +288555,37 @@ hcW
 hcW
 hcW
 cWT
-iME
-iME
-iME
-iME
-bmL
-bmL
-bmL
-wHS
-wHS
-bmL
-bmL
-bmL
-aPR
-iug
+sIE
+sIE
+sIE
+sIE
+vPA
+vPA
+vPA
+pKQ
+pKQ
+vPA
+vPA
+vPA
+qzy
+jlY
 nrw
-uOt
-aPR
-bif
-aPR
-ark
-aPR
-xzK
-nTR
-cRP
-vdg
+seC
+qzy
+cdn
+qzy
+kKj
+qzy
+gWf
+nBf
+vQV
+uEX
 qvR
 qvR
 qvR
 qvR
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -288587,20 +288594,20 @@ fxx
 wSn
 wSn
 kVc
-nhR
+veW
 kVc
-nhR
+veW
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -288947,40 +288954,40 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 cWT
-iME
+sIE
 iJR
-xue
-clV
-aPR
-vbQ
-iug
-jrP
-vbQ
-vbQ
-iug
-vbQ
-vsg
-aPR
-tUp
-obq
-aPR
-aPR
-aPR
-bif
-aPR
-yjP
-cRP
-cRP
-vdg
+wjw
+jVt
+qzy
+qqB
+jlY
+oMa
+qqB
+qqB
+jlY
+qqB
+bPs
+qzy
+lZz
+fFH
+qzy
+qzy
+qzy
+cdn
+qzy
+bRt
+vQV
+vQV
+uEX
 uaL
 uaL
 uaL
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -288995,15 +289002,15 @@ kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 lyL
@@ -289313,25 +289320,22 @@ uaL
 uaL
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
-aSD
-hcW
-hcW
-hcW
-hcW
-aSD
+rgO
 hcW
 hcW
 hcW
+hcW
+rgO
 hcW
 hcW
 hcW
@@ -289340,11 +289344,14 @@ hcW
 hcW
 hcW
 hcW
-aSD
 hcW
 hcW
 hcW
-aSD
+rgO
+hcW
+hcW
+hcW
+rgO
 hcW
 hcW
 hcW
@@ -289352,37 +289359,37 @@ hcW
 hcW
 hcW
 cWT
-iME
+sIE
 iJR
-kHd
-clV
-aPR
-vbQ
-iug
-tYx
-vbQ
-iug
-jrP
-iug
-iug
-aPR
+uFp
+jVt
+qzy
+qqB
+jlY
+iEv
+qqB
+jlY
+oMa
+jlY
+jlY
+qzy
 nrw
-aPR
-aPR
-sXe
-sXe
-aPR
-aPR
-yjP
-cRP
-cRP
-vdg
+qzy
+qzy
+vWY
+vWY
+qzy
+qzy
+bRt
+vQV
+vQV
+uEX
 uaL
 uaL
 uaL
 uaL
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -289390,22 +289397,22 @@ fxx
 fxx
 uaL
 wSn
-nhR
+veW
 kVc
 kVc
 kVc
-nhR
+veW
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -289749,42 +289756,42 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 cWT
-iME
-iME
-iME
-iME
-bmL
-bmL
-bmL
-uDi
-uDi
-bmL
-bmL
-bmL
-jrP
-aPR
-yej
-aPR
-aPR
-aRp
-mlp
-bjK
-bmL
+sIE
+sIE
+sIE
+sIE
+vPA
+vPA
+vPA
+oJO
+oJO
+vPA
+vPA
+vPA
+oMa
+qzy
+lyP
+qzy
+qzy
+aac
+uGq
+gqz
+vPA
 nrw
-cRP
-cRP
-vdg
-inE
+vQV
+vQV
+uEX
+dNL
 qvR
 qvR
 qvR
 qvR
-qGh
+mHp
 fxx
 fxx
 fxx
@@ -289792,22 +289799,22 @@ fxx
 fxx
 fxx
 wSn
-nhR
+veW
 kVc
-nhR
-kVc
-kVc
+veW
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -290144,7 +290151,7 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -290159,7 +290166,7 @@ cWT
 cWT
 cWT
 cWT
-iME
+sIE
 nrw
 nrw
 nrw
@@ -290196,20 +290203,20 @@ fxx
 uaL
 kVc
 kVc
-nhR
+veW
 kVc
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -290528,7 +290535,7 @@ qvR
 uaL
 uaL
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -290546,14 +290553,14 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -290562,10 +290569,10 @@ hcW
 hcW
 hcW
 cWT
-vjs
-vjs
-dXt
-dXt
+dwO
+dwO
+vHy
+vHy
 evo
 ykt
 ykt
@@ -290600,17 +290607,17 @@ aJj
 kVc
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 qvR
@@ -290931,7 +290938,7 @@ qvR
 qvR
 hcW
 hcW
-aSD
+rgO
 hcW
 kYc
 kYS
@@ -290940,7 +290947,7 @@ mzx
 kYc
 mzx
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -290964,8 +290971,8 @@ hcW
 hcW
 hcW
 hcW
-dXt
-vjs
+vHy
+dwO
 evo
 evo
 evo
@@ -291000,19 +291007,19 @@ fxx
 uaL
 uaL
 uaL
-nhR
+veW
 uaL
 kVc
 kVc
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -291345,16 +291352,16 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -291745,18 +291752,18 @@ msk
 ntQ
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -291809,13 +291816,13 @@ uaL
 uaL
 fxx
 fxx
-lZG
-vHd
-vHd
-vHd
-vHd
-vHd
-lZG
+raG
+wUw
+wUw
+wUw
+wUw
+wUw
+raG
 wSn
 uaL
 uaL
@@ -292136,7 +292143,7 @@ sJZ
 sJZ
 qvR
 hcW
-aSD
+rgO
 hcW
 hcW
 ldI
@@ -292211,13 +292218,13 @@ fxx
 fxx
 fxx
 fxx
-ghi
+rRF
 peN
 peN
 peN
 peN
 peN
-bEm
+qqn
 fxx
 fxx
 fxx
@@ -292526,7 +292533,7 @@ uaL
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 qvR
@@ -292558,13 +292565,13 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -292613,13 +292620,13 @@ fxx
 fxx
 fxx
 fxx
-vHd
+wUw
 peN
 peN
 peN
-rvY
+aVI
 peN
-vHd
+wUw
 fxx
 fxx
 fxx
@@ -292963,10 +292970,10 @@ hcW
 hcW
 hcW
 hcW
-aSD
-aSD
+rgO
+rgO
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -292987,14 +292994,14 @@ wSn
 wSn
 wSn
 xKz
-mma
-abZ
+nJL
+bqt
 lLa
 xKz
 xKz
-jKS
-jWA
-mSE
+fTS
+slQ
+geZ
 xKz
 jeb
 jeb
@@ -293360,8 +293367,8 @@ hcW
 hcW
 hcW
 hcW
-aSD
-aSD
+rgO
+rgO
 hcW
 hcW
 hcW
@@ -293389,18 +293396,18 @@ wSn
 wSn
 wSn
 xKz
-vLA
+fLK
 iYQ
 fVQ
-nrx
-qpt
+jJZ
+kIf
 sDa
 peN
 rUr
-pHA
-nrx
+vLA
+jJZ
 fVQ
-tXm
+hSO
 xKz
 qvR
 qvR
@@ -293417,13 +293424,13 @@ wSn
 uaL
 fTe
 wSn
-uPa
-iWj
-mzs
-mzs
-mzs
-iWj
-uPa
+eKd
+pCS
+izq
+izq
+izq
+pCS
+eKd
 uaL
 uaL
 uaL
@@ -293764,7 +293771,7 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -293791,18 +293798,18 @@ wSn
 wSn
 wSn
 xKz
-xFf
-abZ
+xFp
+bqt
 fVQ
 lLa
-qpt
+kIf
 sDa
 peN
 rUr
-pHA
+vLA
 lLa
 fVQ
-xeT
+uaQ
 xKz
 qvR
 qvR
@@ -293822,7 +293829,7 @@ uaL
 xKz
 bOK
 jeb
-dCZ
+xKH
 jeb
 bOK
 xKz
@@ -294159,14 +294166,14 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -294193,18 +294200,18 @@ wSn
 wSn
 wSn
 xKz
-vLA
+fLK
 iYQ
 fVQ
-oPr
-qpt
+qpX
+kIf
 sDa
 peN
 rUr
-pHA
+vLA
 hmU
 fVQ
-xeT
+uaQ
 xKz
 qvR
 qvR
@@ -294224,7 +294231,7 @@ uaL
 bOK
 tYP
 tYP
-tUh
+vJv
 tYP
 tYP
 xKz
@@ -294537,7 +294544,7 @@ uaL
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 qvR
 qvR
@@ -294559,7 +294566,7 @@ ndD
 kYc
 msk
 nxV
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -294595,8 +294602,8 @@ wSn
 wSn
 wSn
 xKz
-xFf
-abZ
+xFp
+bqt
 fVQ
 jeb
 jeb
@@ -294606,7 +294613,7 @@ rUr
 jeb
 jeb
 fVQ
-epL
+mZH
 xKz
 qvR
 qvR
@@ -294623,11 +294630,11 @@ uaL
 qvR
 qvR
 uaL
-eJO
+xpW
 tYP
-jAQ
+nfO
 tYP
-uHk
+ekl
 tYP
 xKz
 qvR
@@ -294997,18 +295004,18 @@ wSn
 wSn
 wSn
 xKz
-cMs
+qrZ
 iYQ
 fVQ
 fVQ
 jeb
-cGb
+txS
 peN
 rUr
 jeb
 fVQ
 tYP
-mck
+mYV
 xKz
 qvR
 qvR
@@ -295026,7 +295033,7 @@ qvR
 uaL
 wSn
 xKz
-hln
+vcZ
 tYP
 tYP
 tYP
@@ -295351,7 +295358,7 @@ uaL
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -295399,18 +295406,18 @@ wSn
 wSn
 wSn
 xKz
-wYv
+rdi
 lLa
 fVQ
 fVQ
-ofT
+mRR
 sDa
 peN
 rUr
-ofT
+mRR
 fVQ
 sCg
-eTZ
+iuK
 xKz
 qvR
 uaL
@@ -295429,10 +295436,10 @@ uaL
 wSn
 bOK
 tYP
-oMa
+vCC
 tYP
 sCg
-auL
+qCT
 xKz
 qvR
 qvR
@@ -295760,7 +295767,7 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -295801,18 +295808,18 @@ xKz
 xKz
 xKz
 xKz
-wYv
+rdi
 lLa
 kMi
-wDZ
+gKo
 jeb
-cGb
+txS
 peN
 rUr
 jeb
 fVQ
 sCg
-eTZ
+iuK
 xKz
 qvR
 uaL
@@ -295832,9 +295839,9 @@ wSn
 xKz
 xKz
 xKz
-qDn
+avA
 sCg
-eTZ
+iuK
 xKz
 qvR
 qvR
@@ -296206,7 +296213,7 @@ fVQ
 fVQ
 fVQ
 kMi
-cMs
+qrZ
 jeb
 sDa
 peN
@@ -296214,7 +296221,7 @@ rUr
 jeb
 fVQ
 tYP
-eTZ
+iuK
 xKz
 qvR
 qvR
@@ -296236,7 +296243,7 @@ xKz
 xKz
 tYP
 sCg
-eTZ
+iuK
 xKz
 qvR
 qvR
@@ -296546,7 +296553,7 @@ hcW
 wSn
 uaL
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -296606,17 +296613,17 @@ xKz
 mDY
 fVQ
 fVQ
-fIB
+lhd
 fVQ
 fVQ
-qpt
+kIf
 sDa
 peN
 rUr
-pHA
+vLA
 lLa
 fVQ
-jFn
+qza
 xKz
 qvR
 uaL
@@ -296636,9 +296643,9 @@ wSn
 xKz
 xKz
 xKz
-qDn
+avA
 sCg
-auL
+qCT
 xKz
 qvR
 uaL
@@ -296948,7 +296955,7 @@ wSn
 wSn
 uaL
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
@@ -296957,7 +296964,7 @@ hcW
 hcW
 hcW
 hcW
-aSD
+rgO
 wSn
 wSn
 qvR
@@ -297004,21 +297011,21 @@ xqL
 wSn
 wSn
 xKz
-wDZ
+gKo
 gqa
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-qpt
+kIf
 sDa
 peN
 rUr
-pHA
+vLA
 lLa
 fVQ
-mRU
+typ
 xKz
 qvR
 qvR
@@ -297038,7 +297045,7 @@ uaL
 xKz
 xKz
 xKz
-lav
+klx
 xKz
 xKz
 xKz
@@ -297347,19 +297354,19 @@ fyc
 cWT
 cWT
 wSn
-aSD
-aSD
-aSD
-aSD
+rgO
+rgO
+rgO
+rgO
 hcW
-aSD
+rgO
 hcW
 hcW
 hcW
-aSD
-aSD
-aSD
-aSD
+rgO
+rgO
+rgO
+rgO
 wSn
 wSn
 qvR
@@ -297406,21 +297413,21 @@ aJj
 uaL
 qvR
 xKz
-vLA
+fLK
 iYQ
 lLa
 fVQ
-fIB
+lhd
 fVQ
 fVQ
-qpt
+kIf
 sDa
 peN
 rUr
-pHA
-mHT
+vLA
+jWb
 fVQ
-lJL
+uvM
 xKz
 uaL
 uaL
@@ -297749,9 +297756,9 @@ fyc
 cWT
 cWT
 uaL
-aSD
-aSD
-aSD
+rgO
+rgO
+rgO
 hcW
 hcW
 hcW
@@ -297808,18 +297815,18 @@ evo
 evo
 evo
 xKz
-cMs
-abZ
+qrZ
+bqt
 kds
-wBY
+mQo
 xKz
-oPr
+qpX
 fVQ
 xKz
-aZv
-cVk
-kIf
 wgn
+kEU
+nPQ
+xBh
 xKz
 xKz
 xKz
@@ -298219,29 +298226,29 @@ xKz
 xKz
 xKz
 uWL
-vkl
-vkl
+khc
+khc
 xKz
 xKz
-uxV
-uxV
-nJy
-nJy
-nJy
-nJy
-nJy
-nJy
-uvQ
-uvQ
-nJy
-nJy
-uxV
-uxV
-uxV
-uxV
-nJy
-nJy
-nJy
+bmL
+bmL
+dTa
+dTa
+dTa
+dTa
+dTa
+dTa
+ocK
+ocK
+dTa
+dTa
+bmL
+bmL
+bmL
+bmL
+dTa
+dTa
+dTa
 axq
 dnx
 axl
@@ -305456,7 +305463,7 @@ xKz
 wVI
 wbg
 wbg
-rhx
+sxM
 wbg
 wbg
 wbg
@@ -305812,7 +305819,7 @@ mcK
 nBW
 mOY
 nBW
-jIP
+aJm
 nBW
 wtF
 wbg
@@ -307426,7 +307433,7 @@ wtF
 wbg
 wbg
 wbg
-rhx
+sxM
 wbg
 wbg
 wbg
@@ -309549,9 +309556,9 @@ bwS
 lVe
 bwS
 lVe
-biR
+tDO
 goK
-aHj
+fNu
 sux
 pYf
 pYf
@@ -310685,14 +310692,14 @@ wbg
 wbg
 wbg
 wVI
-iNc
-bpi
+wGP
+mdB
 nHz
 wVI
 wVI
 wVI
-xiY
-iNc
+iTh
+wGP
 wVI
 tUw
 wVI
@@ -310728,7 +310735,7 @@ fxx
 fxx
 fxx
 fxx
-hRF
+cBG
 fxx
 boU
 fxx
@@ -310746,13 +310753,13 @@ qvR
 wSn
 cyr
 hHF
-mbZ
+tXF
 wlD
 sIG
 wlD
 wlD
 wlD
-aHj
+fNu
 wlD
 sIG
 wlD
@@ -311053,7 +311060,7 @@ wbg
 xXq
 yhZ
 yhZ
-nxo
+wqM
 yhZ
 yhZ
 xXq
@@ -311466,13 +311473,13 @@ xez
 wbg
 wbg
 wbg
-rhx
+sxM
 wbg
 wbg
 wbg
 wbg
 wbg
-rhx
+sxM
 wbg
 wbg
 wbg
@@ -311520,7 +311527,7 @@ fxx
 fxx
 fxx
 fxx
-hRF
+cBG
 fxx
 fxx
 fxx
@@ -311888,7 +311895,7 @@ wbg
 wbg
 wbg
 wbg
-rhx
+sxM
 wbg
 wbg
 wbg
@@ -311896,7 +311903,7 @@ wbg
 wbg
 wbg
 wbg
-rhx
+sxM
 wbg
 wbg
 wbg
@@ -313105,7 +313112,7 @@ wbg
 xGM
 xGM
 rfO
-wsR
+adK
 ukb
 wvE
 rLt
@@ -313146,7 +313153,7 @@ trG
 ryI
 fZw
 fxx
-hRF
+cBG
 rhD
 qvR
 qvR
@@ -313504,10 +313511,10 @@ wew
 wxZ
 nRo
 bQf
-oGl
+qTE
 iPY
-xbW
-wsR
+aok
+adK
 ukb
 wvE
 wvE
@@ -313861,7 +313868,7 @@ aOn
 aOn
 lpa
 nCh
-rhx
+sxM
 wbg
 wbg
 hOh
@@ -313894,22 +313901,22 @@ pUl
 rJX
 tCr
 guP
-pmE
-ale
-gBI
+hSx
+aym
+tlq
 wbg
 qtV
 iPY
 iPY
 iPY
-jMf
+pcQ
 wVI
 weX
 wVI
-hGP
+gec
 hRv
-xbW
-wsR
+aok
+adK
 xMr
 yho
 wvE
@@ -314296,22 +314303,22 @@ rJX
 eai
 tCr
 guP
-jLr
-pKE
+oHc
+wGu
 iGf
 viq
 qtV
 iPY
 aOn
 aOn
-sbF
+syR
 wxZ
 wVI
 bQf
-bpt
+tqI
 nXd
-mAD
-wsR
+bLp
+adK
 dHZ
 xww
 wvE
@@ -314700,20 +314707,20 @@ fQm
 guP
 guP
 guP
-ale
+aym
 uTQ
 qtV
 nXd
-nBk
-nBk
-gbA
+cSc
+cSc
+loE
 wVI
 wVI
 wVI
 wVI
 wVI
 rmJ
-wsR
+adK
 pht
 vwQ
 vwQ
@@ -314770,7 +314777,7 @@ lVe
 uxL
 sZI
 xlx
-tHM
+eSt
 iTv
 cXU
 iTv
@@ -315048,7 +315055,7 @@ uOL
 jxy
 vbO
 oif
-pmC
+lvM
 oif
 uJk
 tOz
@@ -315105,16 +315112,16 @@ sxR
 sxR
 abh
 wbg
-qMC
-qMC
+ovj
+ovj
 aSH
-qMC
+ovj
 wVI
 wVI
 wVI
 wVI
 wVI
-ilT
+dBS
 oUn
 xMr
 vwQ
@@ -315496,7 +315503,7 @@ tYm
 oAn
 wbg
 wbg
-aUo
+pKn
 dTB
 tVP
 tVP
@@ -315505,7 +315512,7 @@ tCG
 tVP
 tVP
 tCG
-jUP
+kpy
 wbg
 wVI
 wVI
@@ -315907,9 +315914,9 @@ tVP
 tVP
 tVP
 tVP
-nfY
+vlU
 qtV
-jgg
+oON
 rZY
 wVI
 wxZ
@@ -316297,21 +316304,21 @@ pAS
 sZN
 sZN
 xdq
-ovj
+oGC
 wbg
 wbg
-aUo
+pKn
 rJC
 tVP
-nVG
-iPA
+dck
+cNt
 tVP
-jqk
+tZZ
 tVP
 tVP
-nfY
+vlU
 qtV
-jgg
+oON
 rZY
 wVI
 wxZ
@@ -316321,7 +316328,7 @@ wVI
 bQf
 wVI
 rZY
-qRW
+phB
 kjH
 kjH
 kjH
@@ -316351,7 +316358,7 @@ vLS
 uaL
 sjP
 wSn
-hRF
+cBG
 fxx
 lcg
 fQg
@@ -316699,23 +316706,23 @@ sZN
 sZN
 sZN
 xdq
-jMf
+pcQ
 wbg
 wbg
 wKT
 kFS
 tVP
-uab
-aWy
-xlp
-xKj
+jHv
+mZl
+iPk
+kLD
 tVP
 tCG
-nfY
+vlU
 wbg
 wbg
 wVI
-sSB
+tiH
 wVI
 wVI
 wVI
@@ -317051,7 +317058,7 @@ oif
 oif
 oif
 oif
-vJN
+upw
 eUJ
 eUJ
 jxy
@@ -317101,7 +317108,7 @@ sZN
 sZN
 lzC
 xdq
-ovj
+oGC
 wbg
 wbg
 wKT
@@ -317109,7 +317116,7 @@ eWj
 yfY
 ijS
 mmb
-tZZ
+lMr
 uaj
 yfY
 yfY
@@ -317119,8 +317126,8 @@ qEa
 vXm
 vXm
 vXm
-ebb
-tfp
+lkV
+trg
 wVI
 wVI
 wVI
@@ -317521,12 +317528,12 @@ wbg
 uqe
 ewM
 uqe
-pQO
-jMf
+dgh
+pcQ
 wVI
 wVI
 rZY
-cnX
+oDr
 rZY
 jXw
 xgi
@@ -317905,7 +317912,7 @@ pDy
 sZN
 sZN
 xdq
-ovj
+oGC
 wbg
 wbg
 cCQ
@@ -317917,18 +317924,18 @@ yfY
 yfY
 yfY
 yfY
-rXq
+wte
 wbg
-kJm
+rmE
 uqe
 uqe
 uqe
-kEc
+eCq
 wew
 weX
 wVI
 rZY
-bgT
+rTx
 rZY
 jXw
 xgi
@@ -317970,7 +317977,7 @@ gkv
 hLK
 njv
 fxx
-hRF
+cBG
 wxd
 wxd
 wSn
@@ -318276,7 +318283,7 @@ wrj
 jDm
 jDm
 mwE
-tJT
+eoz
 mwE
 wbg
 wbg
@@ -318307,25 +318314,25 @@ pAS
 sZN
 sZN
 xdq
-jMf
+pcQ
 wbg
 wbg
 cJz
 yfY
-cud
+amz
 ijS
-pnp
+wEY
 uaj
-tZZ
+lMr
 kfr
-xJe
+nPv
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-kEc
+eCq
 wew
 wVI
 wVI
@@ -318709,7 +318716,7 @@ ygF
 ygF
 uDv
 xdq
-ovj
+oGC
 wbg
 wbg
 wKT
@@ -318727,13 +318734,13 @@ qEa
 gGZ
 gGZ
 gGZ
-csB
-tFE
-wqq
-wqq
-wqq
-wqq
-wqq
+eQM
+xBk
+xdw
+xdw
+xdw
+xdw
+xdw
 kjH
 kjH
 kjH
@@ -319115,14 +319122,14 @@ qls
 wbg
 wbg
 wKT
-vDP
-uIj
-ksK
-qRm
-ksK
-qRm
-ksK
-qRm
+aOa
+pEb
+urF
+xbW
+urF
+xbW
+urF
+xbW
 wKT
 wbg
 wbg
@@ -319915,7 +319922,7 @@ pMj
 pPI
 xdq
 xdq
-ovj
+oGC
 wbg
 wbg
 wKT
@@ -319933,13 +319940,13 @@ wbg
 usR
 ncb
 ncb
-cAW
+uem
 wbg
 wVI
 wVI
 wVI
 wVI
-fdU
+nBX
 wVI
 wVI
 wbg
@@ -320317,18 +320324,18 @@ pOs
 pRW
 xdq
 qls
-gRJ
+mtG
 wbg
 wbg
 wKT
 wKT
 jCs
-ksK
-wFp
-ksK
-wFp
-ksK
-wFp
+urF
+rHj
+urF
+rHj
+urF
+rHj
 wKT
 wbg
 wbg
@@ -320718,7 +320725,7 @@ xdq
 xdq
 xdq
 xdq
-rGY
+wss
 wbg
 wbg
 wbg
@@ -320736,7 +320743,7 @@ wbg
 wbg
 vAB
 bnQ
-wpm
+ehZ
 nWM
 wbg
 kjH
@@ -321120,7 +321127,7 @@ xMr
 xMr
 xMr
 xMr
-jMf
+pcQ
 wbg
 wbg
 wbg
@@ -321522,7 +321529,7 @@ dCV
 csA
 dCV
 hXf
-ovj
+oGC
 wbg
 wbg
 wbg
@@ -321924,7 +321931,7 @@ dCV
 dCV
 dCV
 qee
-gRJ
+mtG
 wbg
 wbg
 wbg
@@ -322730,11 +322737,11 @@ xMr
 xMr
 gGZ
 qCy
-eTW
+qGh
 wVI
 weX
 wVI
-gRm
+rDp
 wbg
 ekQ
 qDx
@@ -323131,7 +323138,7 @@ bmi
 mgx
 xMr
 xAt
-hvh
+oDc
 wbg
 wVI
 wVI
@@ -323534,11 +323541,11 @@ oVp
 xMr
 qnO
 oZC
-hIG
+uwa
 wVI
 xbo
 wVI
-gRm
+rDp
 wbg
 hOh
 qDx
@@ -323936,11 +323943,11 @@ nTe
 qhC
 wbg
 wbg
-hIG
+uwa
 wVI
 wVI
 wVI
-gRm
+rDp
 wbg
 hOh
 qDx
@@ -324336,7 +324343,7 @@ oXn
 oXn
 oXn
 xMr
-xYI
+eCt
 wbg
 wbg
 wVI
@@ -324738,13 +324745,13 @@ paz
 bmi
 bmi
 xMr
-rGY
+wss
 wbg
-eTW
+qGh
 wVI
 weX
 wVI
-gRm
+rDp
 wbg
 lHf
 rfx
@@ -325140,7 +325147,7 @@ gVS
 gVS
 bmi
 xMr
-ovj
+oGC
 wbg
 wbg
 wbg
@@ -325542,7 +325549,7 @@ poR
 pPs
 bmi
 qhR
-rGY
+wss
 wbg
 wbg
 wbg
@@ -325968,7 +325975,7 @@ bJG
 wbg
 jpZ
 aOv
-sOE
+tJC
 aOv
 aOv
 aOv
@@ -326346,7 +326353,7 @@ orY
 orY
 bmi
 xMr
-ovj
+oGC
 wbg
 wbg
 wbg
@@ -326369,7 +326376,7 @@ ewt
 cEF
 wbg
 xll
-jbu
+tRF
 aOn
 jHc
 mwE
@@ -326748,7 +326755,7 @@ bmi
 mou
 bmi
 xMr
-ovj
+oGC
 wbg
 wbg
 wbg
@@ -327150,7 +327157,7 @@ xMr
 xMr
 xMr
 xMr
-jMf
+pcQ
 wbg
 wbg
 wbg
@@ -328436,7 +328443,7 @@ kVc
 kVc
 hcW
 cWT
-nhR
+veW
 hcW
 hcW
 hcW
@@ -328837,8 +328844,8 @@ kVc
 kVc
 kVc
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -329239,8 +329246,8 @@ wxd
 kVc
 kVc
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -329641,8 +329648,8 @@ wxd
 kVc
 kVc
 kVc
-nhR
-nhR
+veW
+veW
 hcW
 hcW
 hcW
@@ -329955,9 +329962,9 @@ xKF
 xKF
 xKF
 xKF
-xoZ
-hVW
-uzW
+cFo
+vbp
+iFj
 xKF
 xKF
 xKF
@@ -330043,8 +330050,8 @@ xqL
 kVc
 kVc
 kVc
-nhR
-nhR
+veW
+veW
 hcW
 hcW
 hcW
@@ -330351,21 +330358,21 @@ uaL
 xAt
 xAt
 xKF
-rPa
-cwd
-cwd
-hbc
+oiE
+oOv
+oOv
+xfj
 xKF
 xKF
 eBN
 eBN
 eBN
-mGn
-mGn
-lIF
+iug
+iug
+qnL
 trI
-cdn
-cdn
+aem
+aem
 hcp
 tkZ
 xKF
@@ -330445,8 +330452,8 @@ wxd
 kVc
 kVc
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -330753,22 +330760,22 @@ paf
 xAt
 xAt
 xKF
-bBh
-cwd
-cwd
-hbc
+lqv
+oOv
+oOv
+xfj
 xKF
 xKF
 ejY
 eBN
 eBN
-mGn
-mGn
+iug
+iug
 ejY
 trI
-cdn
+aem
 rTm
-cdn
+aem
 obL
 xKF
 vtw
@@ -330847,8 +330854,8 @@ sJZ
 wxd
 wxd
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -331155,10 +331162,10 @@ afX
 xAt
 xAt
 xKF
-cmf
-cwd
-cwd
-hbc
+pYB
+oOv
+oOv
+xfj
 xKF
 xKF
 xKF
@@ -331168,9 +331175,9 @@ xKF
 xKF
 xKF
 xKF
-cdn
-cdn
-cdn
+aem
+aem
+aem
 oiC
 xKF
 vtw
@@ -331249,8 +331256,8 @@ sJZ
 sJZ
 feP
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -331557,22 +331564,22 @@ paf
 xAt
 xAt
 xKF
-sJs
-cwd
-cwd
-nGT
+nIW
+oOv
+oOv
+ezG
 xKF
 ofq
 ofq
 xKF
-aac
+wou
 ofq
 eBN
-cdn
+aem
 uHj
-cdn
+aem
 bok
-cdn
+aem
 tkZ
 xKF
 vtw
@@ -331651,8 +331658,8 @@ sJZ
 sJZ
 wxd
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -331959,10 +331966,10 @@ paf
 xAt
 xAt
 xKF
-sQb
-cwd
-cwd
-seC
+aZp
+oOv
+oOv
+kHO
 xKF
 ofq
 ofq
@@ -331972,8 +331979,8 @@ ofq
 eBN
 bok
 uHj
-cdn
-dsW
+aem
+nrx
 idG
 obL
 xKF
@@ -332053,8 +332060,8 @@ qet
 sJZ
 wxd
 kVc
-nhR
-nhR
+veW
+veW
 kVc
 hcW
 hcW
@@ -332361,10 +332368,10 @@ paf
 xAt
 xAt
 xKF
-psB
-cwd
-dNL
-uKn
+qcq
+oOv
+iME
+nRE
 xKF
 ofq
 ofq
@@ -332372,9 +332379,9 @@ wVy
 ofq
 ofq
 eBN
-cdn
+aem
 uHj
-cdn
+aem
 iIl
 xKF
 xKF
@@ -332455,8 +332462,8 @@ qet
 qet
 wxd
 kVc
-nhR
-nhR
+veW
+veW
 hcW
 hcW
 hcW
@@ -332763,10 +332770,10 @@ paf
 xAt
 xAt
 xKF
-uFp
-uFp
+oPc
+oPc
 xKF
-jEB
+nWL
 xKF
 xKF
 xKF
@@ -332776,7 +332783,7 @@ ofq
 eBN
 bok
 uHj
-cdn
+aem
 tkZ
 xKF
 vtw
@@ -332857,8 +332864,8 @@ qet
 qet
 wxd
 kVc
-nhR
-nhR
+veW
+veW
 hcW
 hcW
 hcW
@@ -333164,21 +333171,21 @@ uaL
 afX
 xAt
 xAt
-asZ
+hbO
 fCM
 fCM
 cNo
 twX
 cNo
-kBg
+iBj
 eeO
 sKd
-dAf
+jMf
 eBN
 eBN
-cdn
+aem
 uHj
-cdn
+aem
 vCr
 xKF
 vtw
@@ -333566,21 +333573,21 @@ uaL
 paf
 xAt
 xAt
-asZ
+hbO
 fCM
 fCM
 fCM
 fCM
-oIv
-quP
-gbD
+oSN
+jBE
+dsW
 sKd
 xgL
-cdn
-cdn
-cdn
-cdn
-dsW
+aem
+aem
+aem
+aem
+nrx
 obL
 xKF
 vtw
@@ -333969,21 +333976,21 @@ uaL
 xAt
 xAt
 xKF
-oKh
+jMQ
 iuo
 iuo
 iuo
-oIv
+oSN
 wPC
-gbD
+dsW
 sKd
 xgL
-uaI
-cdn
-cdn
-cdn
-cdn
-cdn
+oIv
+aem
+aem
+aem
+aem
+aem
 xKF
 vtw
 vWe
@@ -334371,21 +334378,21 @@ paf
 xAt
 xAt
 xKF
-bLM
-bLM
-bLM
+tlQ
+tlQ
+tlQ
 iuo
 fCM
 sKd
 sKd
 vSM
-nep
-cdn
-cdn
+qHY
+aem
+aem
 wIl
 dXw
 uHg
-cdn
+aem
 xKF
 vtw
 vWe
@@ -334396,7 +334403,7 @@ vtw
 qZh
 ltk
 mwE
-tJT
+eoz
 mwE
 mwE
 aOv
@@ -334773,11 +334780,11 @@ paf
 xAt
 xAt
 xKF
-goz
-mVz
-qxn
+lsK
+bVa
+nEs
 iuo
-adJ
+ubM
 sKd
 sKd
 xKF
@@ -335183,7 +335190,7 @@ xKF
 xKF
 xKF
 xKF
-ibh
+njj
 eCn
 eCn
 xKF
@@ -338004,7 +338011,7 @@ iuo
 iuo
 fXv
 xKF
-wOR
+bSm
 wOR
 xKF
 alk
@@ -338808,7 +338815,7 @@ bEo
 iuo
 iuo
 xKF
-wOR
+bSm
 wOR
 rKn
 sKd
@@ -349434,8 +349441,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349836,8 +349843,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -350238,8 +350245,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -350640,8 +350647,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351042,8 +351049,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351444,8 +351451,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351846,8 +351853,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -352248,8 +352255,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -352650,8 +352657,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353052,8 +353059,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353454,8 +353461,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353856,8 +353863,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -354258,8 +354265,8 @@ uuE
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -354660,8 +354667,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355062,8 +355069,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355464,8 +355471,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355866,8 +355873,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -356268,8 +356275,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -356670,8 +356677,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357072,8 +357079,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357474,8 +357481,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357876,8 +357883,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -358278,8 +358285,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -358680,8 +358687,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359082,9 +359089,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359484,9 +359491,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359886,9 +359893,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -360288,9 +360295,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -360690,9 +360697,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361092,9 +361099,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361494,9 +361501,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361896,9 +361903,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -362298,9 +362305,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -362700,9 +362707,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -363102,9 +363109,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -363504,9 +363511,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -363906,9 +363913,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -364308,9 +364315,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -364710,9 +364717,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -365112,9 +365119,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -365514,9 +365521,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -365917,7 +365924,7 @@ uuE
 uuE
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -366319,7 +366326,7 @@ uuE
 uuE
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -366721,7 +366728,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367123,7 +367130,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367525,7 +367532,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367927,7 +367934,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -368329,7 +368336,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -368731,7 +368738,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -369133,7 +369140,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -369535,7 +369542,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -369937,7 +369944,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -370339,7 +370346,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -370741,7 +370748,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371143,7 +371150,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371541,11 +371548,11 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -371939,15 +371946,15 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -372340,12 +372347,12 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -372742,7 +372749,7 @@ uuE
 uuE
 uuE
 uuE
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373144,7 +373151,7 @@ uuE
 uuE
 uuE
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373546,7 +373553,7 @@ uuE
 uuE
 uuE
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373948,7 +373955,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374350,7 +374357,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374752,7 +374759,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375154,7 +375161,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375556,7 +375563,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375958,7 +375965,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376360,7 +376367,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376762,7 +376769,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377164,7 +377171,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377566,7 +377573,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377968,7 +377975,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378370,7 +378377,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378772,7 +378779,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379174,7 +379181,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379576,7 +379583,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379978,7 +379985,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -380380,7 +380387,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -380782,7 +380789,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381184,7 +381191,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381586,7 +381593,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381988,7 +381995,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -382390,7 +382397,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -382792,7 +382799,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383078,52 +383085,52 @@ tmH
 tmH
 tmH
 aUc
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
 uuE
 uuE
 uuE
@@ -383194,7 +383201,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383375,50 +383382,6 @@ fyc
 (88,1,4) = {"
 aUc
 aUc
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
 aUc
 aUc
 aUc
@@ -383480,6 +383443,50 @@ aUc
 aUc
 aUc
 aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -383519,14 +383526,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -383596,7 +383603,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383820,31 +383827,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-kvj
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
+fIB
+fIB
+fIB
+fIB
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -383858,8 +383865,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -383921,14 +383928,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -383998,7 +384005,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -384222,31 +384229,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-kvj
-loE
-efv
-nSL
-wSl
-vWY
-loE
-wSl
-wSl
-loE
-gwf
-kvj
-tJC
-kvj
-pMn
-tJC
-tJC
-qYw
-kvj
-kvj
-tJC
-lGI
+fIB
+fIB
+fIB
+fIB
+ebb
+hTo
+ijU
+quL
+tCz
+ebb
+quL
+quL
+ebb
+nDR
+fIB
+yel
+fIB
+tpg
+yel
+yel
+itC
+fIB
+fIB
+yel
+tfp
 erZ
 erZ
 erZ
@@ -384260,8 +384267,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -384323,14 +384330,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -384400,7 +384407,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -384624,31 +384631,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-kvj
-loE
-efv
-mnP
-wSl
-vWY
-loE
-wSl
-wSl
-loE
-lfb
-vGQ
-vGQ
-lfb
-loE
-nwk
-ieP
-loE
-fVM
-kvj
-djJ
-lGI
+fIB
+fIB
+fIB
+fIB
+ebb
+hTo
+wSg
+quL
+tCz
+ebb
+quL
+quL
+ebb
+reD
+tNC
+tNC
+reD
+ebb
+kwN
+gjq
+ebb
+sqX
+fIB
+aFE
+tfp
 erZ
 erZ
 erZ
@@ -384663,8 +384670,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -384725,14 +384732,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -384802,7 +384809,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385026,31 +385033,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-kvj
-loE
-loE
-loE
-bVT
-wSl
-loE
-wSl
-wSl
-loE
-nBf
-xET
-kvj
-uGf
-loE
-pcQ
-pcQ
-loE
-lYi
-bBL
-aoY
-lGI
+fIB
+fIB
+fIB
+fIB
+ebb
+ebb
+ebb
+wra
+quL
+ebb
+quL
+quL
+ebb
+eXr
+sHB
+fIB
+xkF
+ebb
+wlk
+wlk
+ebb
+htf
+cOw
+vsg
+tfp
 erZ
 erZ
 erZ
@@ -385065,8 +385072,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -385127,6 +385134,8 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -385134,8 +385143,6 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -385204,7 +385211,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385428,31 +385435,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-kvj
-loE
-loE
-loE
-bVT
-vWY
-loE
-wSl
-wSl
-loE
-mFB
-kvj
-kvj
-dYw
-loE
-dRd
-dRd
-loE
-loE
-loE
-loE
-loE
+fIB
+fIB
+fIB
+fIB
+ebb
+ebb
+ebb
+wra
+tCz
+ebb
+quL
+quL
+ebb
+cRP
+fIB
+fIB
+gip
+ebb
+kpU
+kpU
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -385467,8 +385474,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -385529,8 +385536,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -385606,7 +385613,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385830,31 +385837,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-kvj
-loE
-loE
-loE
-cuc
-wSl
-loE
-wSl
-wSl
-loE
-wFq
-kvj
-kvj
-dYw
-loE
-lhd
-kvj
-loE
-loE
-loE
-loE
-loE
+fIB
+fIB
+fIB
+fIB
+ebb
+ebb
+ebb
+luS
+quL
+ebb
+quL
+quL
+ebb
+cjJ
+fIB
+fIB
+gip
+ebb
+hjD
+fIB
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -385869,8 +385876,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -385889,8 +385896,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 aUc
 vIa
 erZ
@@ -385931,8 +385938,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -386008,7 +386015,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -386232,31 +386239,31 @@ erZ
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-loE
-loE
-loE
-loE
-loE
-kqv
-loE
-loE
-loE
-loE
-cAC
-xET
-kvj
-hhq
-loE
-vGQ
-vGQ
-qYw
-kvj
-djJ
-tJC
-lGI
+fIB
+fIB
+fIB
+ebb
+ebb
+ebb
+ebb
+ebb
+hQm
+ebb
+ebb
+ebb
+ebb
+wbF
+sHB
+fIB
+ppy
+ebb
+tNC
+tNC
+itC
+fIB
+aFE
+yel
+tfp
 erZ
 erZ
 erZ
@@ -386271,8 +386278,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -386291,9 +386298,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -386333,8 +386340,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -386410,7 +386417,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -386634,31 +386641,31 @@ vIa
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-loE
-dpQ
-wSl
-lkQ
-wSl
-wSl
-eoz
-loE
-uvR
-kvj
-kvj
-kvj
-vGQ
-lfb
-loE
-kvj
-kvj
-loE
-kvj
-kvj
-kvj
-lGI
+fIB
+fIB
+fIB
+ebb
+vVI
+quL
+xdJ
+quL
+quL
+aev
+ebb
+iUg
+fIB
+fIB
+fIB
+tNC
+reD
+ebb
+fIB
+fIB
+ebb
+fIB
+fIB
+fIB
+tfp
 erZ
 erZ
 erZ
@@ -386673,8 +386680,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -386692,10 +386699,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -386735,8 +386742,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -386812,7 +386819,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -387036,31 +387043,31 @@ vIa
 erZ
 erZ
 erZ
-kvj
-kvj
-kvj
-loE
-dmR
-wSl
-wSl
-wSl
-vWY
-rSZ
-loE
-uvR
-kvj
-bPz
-kvj
-bHc
-lfb
-loE
-lhd
-kvj
-loE
-bbY
-frx
-aoY
-lGI
+fIB
+fIB
+fIB
+ebb
+qoP
+quL
+quL
+quL
+tCz
+unY
+ebb
+iUg
+fIB
+jhu
+fIB
+hWj
+reD
+ebb
+hjD
+fIB
+ebb
+sah
+sqZ
+vsg
+tfp
 erZ
 erZ
 erZ
@@ -387075,8 +387082,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -387093,11 +387100,11 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -387137,8 +387144,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -387214,7 +387221,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -387438,31 +387445,31 @@ vIa
 vIa
 erZ
 erZ
-kvj
-kvj
-kvj
-loE
-uQG
-wSl
-wSl
-vWY
-wSl
-rSZ
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-hdO
-hdO
-loE
-loE
-loE
-loE
-loE
+fIB
+fIB
+fIB
+ebb
+igV
+quL
+quL
+tCz
+quL
+unY
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+afj
+afj
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -387478,7 +387485,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -387495,10 +387502,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -387539,8 +387546,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -387616,7 +387623,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -387843,24 +387850,24 @@ erZ
 erZ
 erZ
 erZ
-loE
-vox
-wSl
-wSl
-wSl
-wSl
-eoz
-loE
-uvu
-gJk
-dcO
-lkQ
-dcO
-gJk
-cVb
-wSl
-pns
-wVA
+ebb
+jnd
+quL
+quL
+quL
+quL
+aev
+ebb
+iqH
+clj
+bkT
+xdJ
+bkT
+clj
+rFS
+quL
+jhP
+xsD
 erZ
 erZ
 erZ
@@ -387880,7 +387887,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -387896,9 +387903,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -387941,14 +387948,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -388018,7 +388025,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -388245,24 +388252,24 @@ erZ
 erZ
 erZ
 erZ
-loE
-wUw
-vWY
-wSl
-iVf
-wSl
-tLN
-loE
-wSl
-cxa
-cxa
-wSl
-wOO
-wOO
-wSl
-vWY
-wSl
-wVA
+ebb
+haC
+tCz
+quL
+pKC
+quL
+iVX
+ebb
+quL
+jCH
+jCH
+quL
+oRp
+oRp
+quL
+tCz
+quL
+xsD
 erZ
 erZ
 erZ
@@ -388282,7 +388289,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -388298,9 +388305,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -388343,13 +388350,13 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -388420,7 +388427,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -388647,24 +388654,24 @@ erZ
 erZ
 erZ
 erZ
-loE
-iNC
-wSl
-uvu
-uCR
-wSl
-qzy
-pgX
-wSl
-vWY
-wSl
-vWY
-wSl
-wSl
-wSl
-wSl
-wSl
-wVA
+ebb
+xBv
+quL
+iqH
+jiL
+quL
+nuH
+iYE
+quL
+tCz
+quL
+tCz
+quL
+quL
+quL
+quL
+quL
+xsD
 erZ
 erZ
 erZ
@@ -388684,7 +388691,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -388700,9 +388707,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -388745,8 +388752,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -388822,7 +388829,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -389049,24 +389056,24 @@ erZ
 erZ
 erZ
 erZ
-loE
-pfz
-wSl
-uvu
-tiv
-wSl
-tLN
-loE
-wSl
-fHV
-fHV
-wSl
-wSl
-jlY
-jlY
-wSl
-vWY
-wVA
+ebb
+ubr
+quL
+iqH
+lzR
+quL
+iVX
+ebb
+quL
+pGU
+pGU
+quL
+quL
+lqG
+lqG
+quL
+tCz
+xsD
 erZ
 erZ
 erZ
@@ -389086,7 +389093,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -389102,9 +389109,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -389147,8 +389154,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -389224,7 +389231,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -389451,24 +389458,24 @@ erZ
 erZ
 erZ
 erZ
-loE
-bUi
-wSl
-wSl
-wSl
-wSl
-rcS
-loE
-uvu
-dcO
-dcO
-cVb
-pns
-wSl
-nSL
-wra
-wSl
-wVA
+ebb
+gWE
+quL
+quL
+quL
+quL
+rSz
+ebb
+iqH
+bkT
+bkT
+rFS
+jhP
+quL
+ijU
+abZ
+quL
+xsD
 erZ
 erZ
 erZ
@@ -389488,8 +389495,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -389503,10 +389510,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -389549,8 +389556,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -389626,7 +389633,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -389853,24 +389860,24 @@ erZ
 erZ
 erZ
 erZ
-loE
-flY
-wSl
-uvu
-uCR
-wSl
-rcS
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-oum
-oum
-loE
+ebb
+wyA
+quL
+iqH
+jiL
+quL
+rSz
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+gNh
+gNh
+ebb
 erZ
 erZ
 erZ
@@ -389890,8 +389897,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -389905,10 +389912,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -389951,7 +389958,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -390028,7 +390035,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -390255,28 +390262,28 @@ erZ
 erZ
 erZ
 erZ
-loE
-pfz
-wSl
-uvu
-tiv
-wSl
-maO
-loE
-txH
-hay
-shH
-fla
-shH
-hay
-fla
-wra
-wSl
-loE
-loE
-loE
-loE
-loE
+ebb
+ubr
+quL
+iqH
+lzR
+quL
+dPf
+ebb
+gvj
+xaD
+vrF
+bxG
+vrF
+xaD
+bxG
+abZ
+quL
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -390293,7 +390300,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -390307,10 +390314,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -390353,7 +390360,7 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -390430,7 +390437,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -390656,29 +390663,29 @@ erZ
 erZ
 aUc
 erZ
-loE
-loE
-bVT
-wSl
-wSl
-yif
-wSl
-pFL
-loE
-wSl
-wSl
-wSl
-wSl
-wSl
-wSl
-wSl
-jpw
-wSl
-qYw
-kvj
-kvj
-tJC
-lGI
+ebb
+ebb
+wra
+quL
+quL
+jNp
+quL
+dFp
+ebb
+quL
+quL
+quL
+quL
+quL
+quL
+quL
+xDp
+quL
+itC
+fIB
+fIB
+yel
+tfp
 erZ
 erZ
 erZ
@@ -390695,7 +390702,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -390709,10 +390716,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -390755,7 +390762,7 @@ erZ
 erZ
 erZ
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -390830,9 +390837,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
+aUc
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -391058,29 +391065,29 @@ vIa
 vIa
 aUc
 aUc
-loE
-loE
-bVT
-vWY
-wSl
-wSl
-wSl
-qzy
-loE
-maz
-wSl
-wSl
-bVP
-wSl
+ebb
+ebb
+wra
+tCz
+quL
+quL
+quL
+nuH
+ebb
+eml
+quL
+quL
 jpw
-wSl
-wSl
-wSl
-loE
-bCb
-kvj
-kvj
-lGI
+quL
+xDp
+quL
+quL
+quL
+ebb
+gJj
+fIB
+fIB
+tfp
 erZ
 erZ
 erZ
@@ -391097,7 +391104,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -391111,10 +391118,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -391231,8 +391238,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -391460,29 +391467,29 @@ vIa
 vIa
 aUc
 aUc
-itC
-itC
-bVT
-gip
-qzy
-wSl
-vWY
-wSl
-lqf
-wSl
-jpw
-wSl
-wSl
-wSl
-wSl
-wSl
-wSl
-wSl
-loE
-fVM
-kvj
-kvj
-lGI
+cLL
+cLL
+wra
+lnw
+nuH
+quL
+tCz
+quL
+aUN
+quL
+xDp
+quL
+quL
+quL
+quL
+quL
+quL
+quL
+ebb
+sqX
+fIB
+fIB
+tfp
 erZ
 erZ
 erZ
@@ -391499,7 +391506,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -391513,9 +391520,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -391633,7 +391640,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 gxt
@@ -391863,28 +391870,28 @@ vIa
 vIa
 vIa
 aUc
-itC
-itC
-itC
-qzy
-qzy
-wSl
-wSl
-bje
-sjf
-wSl
-wSl
-wSl
-wSl
-wSl
-wSl
-jpw
-wSl
-loE
-lhd
-kvj
-kvj
-lGI
+cLL
+cLL
+cLL
+nuH
+nuH
+quL
+quL
+bUq
+hes
+quL
+quL
+quL
+quL
+quL
+quL
+xDp
+quL
+ebb
+hjD
+fIB
+fIB
+tfp
 erZ
 erZ
 erZ
@@ -391901,7 +391908,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -391915,9 +391922,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -392034,8 +392041,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -392267,26 +392274,26 @@ vIa
 vIa
 aUc
 aUc
-itC
-itC
-rmO
-qzy
-qzy
-loE
-loE
-wou
-wou
-fQq
-wou
-wra
-wSl
-wSl
-wSl
-loE
-oiw
-aoY
-qjb
-lGI
+cLL
+cLL
+nbA
+nuH
+nuH
+ebb
+ebb
+jfJ
+jfJ
+iWj
+jfJ
+abZ
+quL
+quL
+quL
+ebb
+meQ
+vsg
+jgn
+tfp
 erZ
 erZ
 erZ
@@ -392303,7 +392310,7 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -392317,9 +392324,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -392435,8 +392442,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -392670,25 +392677,25 @@ vIa
 vIa
 aUc
 aUc
-itC
-itC
-itC
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-bjo
-bjo
-bjo
-bjo
-loE
-loE
-loE
-loE
-loE
+cLL
+cLL
+cLL
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+gLI
+gLI
+gLI
+gLI
+ebb
+ebb
+ebb
+ebb
+ebb
 erZ
 erZ
 erZ
@@ -392705,8 +392712,8 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -392719,9 +392726,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -392836,8 +392843,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -393076,7 +393083,7 @@ aUc
 aUc
 aUc
 aUc
-bqt
+mVz
 erZ
 erZ
 erZ
@@ -393107,9 +393114,9 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -393120,10 +393127,10 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -393238,7 +393245,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 uuE
@@ -393511,20 +393518,20 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -393639,8 +393646,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -393917,15 +393924,15 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -394040,8 +394047,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -394320,13 +394327,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-qKU
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+lGI
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -394441,8 +394448,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -394722,13 +394729,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-uWe
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+nOE
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -394840,10 +394847,10 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
-gxt
+aUc
+aUc
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -395100,12 +395107,12 @@ xKz
 xKz
 xKz
 xKz
-xaD
-aWb
-hoM
-txK
-rkK
-gMb
+iOL
+uNc
+iyt
+eAz
+yhr
+mMD
 xKz
 erZ
 erZ
@@ -395124,13 +395131,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-qKU
-jNF
-qKU
-lYb
-jNF
-cjJ
+nhR
+lGI
+qeY
+lGI
+wSl
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -395241,7 +395248,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -395497,10 +395504,10 @@ erZ
 fVQ
 fVQ
 xKz
-arA
-pYU
-pYU
-tpw
+dbK
+gjV
+gjV
+wpm
 xKz
 fVQ
 fVQ
@@ -395526,13 +395533,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-jNF
-jNF
-uWe
-qKU
-jNF
-cjJ
+nhR
+qeY
+qeY
+nOE
+lGI
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -395642,8 +395649,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -395907,14 +395914,14 @@ xKz
 fVQ
 fVQ
 jeb
-uqa
+xHe
 fVQ
-hcQ
+uzT
 xKz
 fVQ
 bvN
 tYP
-cCS
+esE
 jeb
 erZ
 erZ
@@ -395928,13 +395935,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-jNF
-jNF
-qKU
-lYb
-jNF
-cjJ
+nhR
+qeY
+qeY
+lGI
+wSl
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -396044,7 +396051,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -396305,18 +396312,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-pjB
+qzp
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-pjB
+qzp
 fVQ
 bvN
 tYP
-ptC
+bds
 jeb
 erZ
 erZ
@@ -396330,13 +396337,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-qKU
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+lGI
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -396445,7 +396452,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -396701,24 +396708,24 @@ erZ
 erZ
 erZ
 xKz
-gLG
-urF
+iOB
+jEB
 fVQ
 fVQ
 lLa
-jmo
+nru
 jeb
-lPz
-mQF
-tQQ
-rcr
+eza
+vha
+eaH
+faa
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-iuz
+eYO
 jeb
 erZ
 erZ
@@ -396732,13 +396739,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-uWe
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+nOE
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -396846,8 +396853,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -397103,12 +397110,12 @@ erZ
 erZ
 erZ
 xKz
-oGN
-urF
+pva
+jEB
 fVQ
 fVQ
 lLa
-jmo
+nru
 jeb
 xKz
 xKz
@@ -397120,7 +397127,7 @@ xKz
 fVQ
 tYP
 tYP
-jkU
+fYr
 jeb
 erZ
 erZ
@@ -397134,13 +397141,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-qKU
-jNF
-qKU
-lYb
-jNF
-cjJ
+nhR
+lGI
+qeY
+lGI
+wSl
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -397247,8 +397254,8 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -397505,24 +397512,24 @@ erZ
 erZ
 erZ
 xKz
-fEv
-urF
+hTc
+jEB
 fVQ
 fVQ
 fVQ
 fVQ
-pjB
+qzp
 fVQ
-wuX
-cel
-tET
+nnm
+vHd
+gMo
 fVQ
-mMp
+fap
 xKz
 fVQ
 bvN
 tYP
-cCS
+esE
 jeb
 erZ
 erZ
@@ -397536,13 +397543,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-jNF
-jNF
-uWe
-qKU
-jNF
-cjJ
+nhR
+qeY
+qeY
+nOE
+lGI
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -397648,8 +397655,8 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -397907,24 +397914,24 @@ erZ
 erZ
 erZ
 xKz
-eTQ
-urF
+rFg
+jEB
 fVQ
-khc
+ikM
 fVQ
 fVQ
 jeb
-hDv
+oRP
 fVQ
 fVQ
 fVQ
 fVQ
-wzc
+xmQ
 xKz
 fVQ
 bvN
 tYP
-ptC
+bds
 jeb
 erZ
 erZ
@@ -397938,13 +397945,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-qKU
-jNF
-qKU
-lYb
-jNF
-cjJ
+nhR
+lGI
+qeY
+lGI
+wSl
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -398050,7 +398057,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -398313,20 +398320,20 @@ xKz
 xKz
 xKz
 xKz
-lwa
+grg
 xKz
 xKz
-vJg
+rxu
 fVQ
 jeb
-uqa
+xHe
 fVQ
-mVd
+tub
 xKz
 fVQ
 tYP
 tYP
-iuz
+eYO
 jeb
 erZ
 erZ
@@ -398340,13 +398347,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-uWe
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+nOE
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -398451,7 +398458,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -398718,7 +398725,7 @@ fVQ
 fVQ
 fVQ
 xKz
-ggU
+rXP
 fVQ
 fVQ
 fVQ
@@ -398728,7 +398735,7 @@ xKz
 fVQ
 tYP
 tYP
-jkU
+fYr
 jeb
 erZ
 erZ
@@ -398742,13 +398749,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-qKU
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+lGI
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -398853,7 +398860,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -399120,17 +399127,17 @@ vZP
 lLa
 fVQ
 xKz
-mUt
-oxe
-msY
-hBU
+kRd
+vyN
+mbA
+hom
 fVQ
-qsC
+udL
 xKz
 fVQ
-fIB
+lhd
 tYP
-cCS
+esE
 jeb
 erZ
 erZ
@@ -399144,13 +399151,13 @@ erZ
 erZ
 erZ
 erZ
-mQA
-jNF
-jNF
-jNF
-jNF
-jNF
-cjJ
+nhR
+qeY
+qeY
+qeY
+qeY
+qeY
+nJy
 erZ
 erZ
 erZ
@@ -399254,7 +399261,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -399520,7 +399527,7 @@ fVQ
 lLa
 noC
 lLa
-hcQ
+uzT
 xKz
 xKz
 xKz
@@ -399530,7 +399537,7 @@ xKz
 xKz
 xKz
 fVQ
-fIB
+lhd
 fVQ
 fVQ
 jeb
@@ -399546,10 +399553,10 @@ erZ
 erZ
 erZ
 erZ
-mQA
-jNF
+nhR
+qeY
 xKz
-pcn
+vzO
 bOK
 jeb
 xKz
@@ -399655,8 +399662,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -399931,7 +399938,7 @@ fVQ
 fVQ
 xKz
 xKz
-lwa
+grg
 xKz
 xKz
 xKz
@@ -399948,8 +399955,8 @@ erZ
 erZ
 erZ
 erZ
-mQA
-jNF
+nhR
+qeY
 jeb
 fVQ
 ugK
@@ -400056,7 +400063,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -400457,7 +400464,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -400859,7 +400866,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -401260,7 +401267,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -401661,7 +401668,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -402463,8 +402470,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -402863,8 +402870,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -403264,8 +403271,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -403666,7 +403673,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -412509,7 +412516,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -412910,8 +412917,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -413312,7 +413319,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -413714,7 +413721,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -414113,9 +414120,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -414514,7 +414521,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -414915,7 +414922,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -415316,7 +415323,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -415717,7 +415724,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -416117,8 +416124,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -416517,9 +416524,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
+aUc
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -416918,8 +416925,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -417319,8 +417326,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -417719,8 +417726,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -418120,8 +418127,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -418522,7 +418529,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 uuE
@@ -418923,8 +418930,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 uuE
 uuE
@@ -419204,7 +419211,7 @@ ygF
 ygF
 ygF
 ygF
-lgr
+mGS
 jYR
 lHe
 lHe
@@ -419325,7 +419332,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 uuE
 uuE
@@ -432064,8 +432071,8 @@ wAm
 wAm
 wAm
 wAm
-rsS
-rsS
+tyI
+tyI
 wAm
 wAm
 wAm
@@ -432463,12 +432470,12 @@ teW
 kwf
 nRx
 rwH
-nlx
+fuG
 teW
 kqc
-qYf
+rff
 jjS
-iRc
+kWA
 vMQ
 vsf
 rwH
@@ -432476,8 +432483,8 @@ nKu
 jiv
 rwH
 teW
-qpX
-lZw
+dET
+mDR
 vMQ
 enq
 fZJ
@@ -432867,8 +432874,8 @@ jiv
 jiv
 uSx
 teW
-luX
-oQC
+nSr
+lRC
 jiv
 jiv
 jiv
@@ -432879,7 +432886,7 @@ jiv
 jjS
 teW
 hqI
-ikM
+bUi
 hqI
 enq
 fZJ
@@ -433270,7 +433277,7 @@ jiv
 teW
 teW
 vMQ
-oQC
+lRC
 jiv
 jiv
 jiv
@@ -433281,11 +433288,11 @@ jiv
 vIX
 teW
 hqI
-ikM
+bUi
 hqI
-dkx
-iVt
-lKw
+wvV
+rik
+grr
 fZJ
 fZJ
 fZJ
@@ -433676,18 +433683,18 @@ jiv
 jiv
 jiv
 qfh
-nSr
+npd
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-ikM
+bUi
 hqI
 jFM
 jFM
-bPv
+oAj
 fZJ
 fZJ
 fZJ
@@ -434077,19 +434084,19 @@ xSI
 jiv
 jiv
 jiv
-dQX
-veh
+iys
+oqr
 htU
 teW
 ael
 hqI
 hqI
 hqI
-ikM
+bUi
 hqI
 jFM
 jFM
-iSJ
+inx
 fZJ
 fZJ
 fZJ
@@ -434476,8 +434483,8 @@ xSI
 tML
 tML
 tML
-uPd
-uPd
+uhv
+uhv
 tML
 aGb
 tML
@@ -434487,11 +434494,11 @@ pDA
 hqI
 hqI
 hqI
-ikM
+bUi
 hqI
 jFM
 jFM
-iSJ
+inx
 fZJ
 fZJ
 fZJ
@@ -434880,20 +434887,20 @@ tML
 teW
 nyc
 ntK
-rSg
+gbA
 cAe
 cAe
-jkQ
+eEG
 teW
 ulu
 hqI
 fVE
-ikM
+bUi
 lLK
 hqI
-uWv
-uWv
-bos
+bjq
+bjq
+kvj
 fZJ
 fZJ
 fZJ
@@ -435282,7 +435289,7 @@ lPt
 swm
 nyc
 ntK
-tak
+lYl
 xrf
 xrf
 xrf
@@ -435290,8 +435297,8 @@ teW
 uNz
 hqI
 hqI
-ikM
-qUi
+bUi
+jju
 ojc
 enq
 fZJ
@@ -435684,10 +435691,10 @@ pLs
 swm
 nyc
 ntK
-lAg
-hCF
-hCF
-hCF
+iRN
+rSg
+rSg
+rSg
 teW
 ajj
 lLK
@@ -436086,16 +436093,16 @@ vrG
 wtl
 ntK
 ntK
-lYl
-wHm
-wHm
-wHm
+yiI
+sGW
+sGW
+sGW
 ohA
 bcN
 bcN
 bcN
 vWe
-cJt
+iZS
 ffv
 fZJ
 fZJ
@@ -436486,7 +436493,7 @@ oBU
 sUQ
 xXs
 ntK
-qvs
+qAh
 ntK
 uTT
 swm
@@ -436887,10 +436894,10 @@ uKB
 aur
 uZa
 cPw
-bWv
+jck
 ntK
 ntK
-jzB
+tak
 ybm
 ybm
 ybm
@@ -436899,7 +436906,7 @@ bcN
 bcN
 bcN
 vWe
-pnd
+mvI
 ffv
 fZJ
 fZJ
@@ -437292,14 +437299,14 @@ pLs
 swm
 nyc
 ntK
-rSg
-jkQ
-jkQ
-jkQ
+gbA
+eEG
+eEG
+eEG
 teW
 eYI
-uZC
-uZC
+vGN
+vGN
 wAm
 wAm
 ffv
@@ -437694,14 +437701,14 @@ oyP
 swm
 nyc
 ntK
-tak
+lYl
 xrf
 xrf
 xrf
 tML
-aVp
-aVp
-aVp
+uIo
+uIo
+uIo
 tML
 tML
 tML
@@ -438096,14 +438103,14 @@ tML
 aXE
 nyc
 ntK
-xSj
-xvn
-xvn
-ivM
+fAg
+xwi
+xwi
+eYu
 tML
-mua
-mua
-mua
+juM
+juM
+juM
 wAm
 wAm
 wAm
@@ -438120,7 +438127,7 @@ squ
 squ
 squ
 rTC
-egz
+rGY
 squ
 squ
 squ
@@ -438496,7 +438503,7 @@ tML
 teW
 tML
 tML
-nAQ
+rfk
 fnF
 tML
 aGb
@@ -438510,7 +438517,7 @@ wpe
 fQd
 eCn
 sNY
-ebJ
+cOK
 teW
 teW
 teW
@@ -438522,7 +438529,7 @@ squ
 squ
 squ
 rTC
-egz
+rGY
 rTC
 rTC
 rTC
@@ -438916,7 +438923,7 @@ eCn
 teW
 aor
 xfh
-rKB
+qDn
 teW
 squ
 squ
@@ -439312,8 +439319,8 @@ cfY
 cfY
 teW
 aTF
-sIE
-lJI
+jCr
+ppc
 eCn
 mYi
 gbX
@@ -439714,8 +439721,8 @@ uZy
 cfY
 alk
 eCn
-pgU
-ste
+qpt
+ooA
 eCn
 mYi
 gbX
@@ -440098,14 +440105,14 @@ erZ
 fZJ
 fZJ
 rxp
-rKK
+dzW
 uKB
 uBv
 tML
 tML
 tML
 xnv
-dpF
+dDU
 tML
 rMM
 cfY
@@ -440120,9 +440127,9 @@ eCn
 eCn
 eCn
 teW
-wTe
-xDg
-ahV
+kZl
+oOf
+smV
 teW
 squ
 squ
@@ -440904,8 +440911,8 @@ fZJ
 rxp
 uKB
 uKB
-nnZ
-vwi
+lLV
+xRn
 uKB
 nIr
 swm
@@ -441703,14 +441710,14 @@ vIa
 vIa
 aUc
 teW
-agJ
+aPR
 teW
 uKB
 uKB
-uEX
-jSc
-fDi
-uee
+qpp
+eeC
+uRy
+fNW
 tML
 swm
 swm
@@ -442105,10 +442112,10 @@ vIa
 vIa
 aUc
 teW
-eEQ
+ieI
 teW
-lcJ
-bFq
+dbH
+wDz
 tML
 tML
 ydR
@@ -442124,10 +442131,10 @@ idu
 sct
 sNp
 cfY
-jkx
-nhm
-gWR
-xHe
+obq
+qtZ
+jhv
+uxZ
 eCn
 teW
 lMZ
@@ -442515,21 +442522,21 @@ cgD
 tML
 hqI
 tML
-mdB
+kVv
 swm
 swm
 tML
-mQr
+tjf
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-jkx
-kFh
-ibY
-uSz
+obq
+lXK
+kiE
+uvu
 eCn
 teW
 lMZ
@@ -442923,15 +442930,15 @@ swm
 tML
 rMM
 eVa
-tYB
+tUR
 tcW
 tcW
 tcW
 eVa
-vBk
-rHj
-wya
-pQS
+cPD
+dJl
+fMq
+gvi
 eCn
 teW
 lMZ
@@ -443311,7 +443318,7 @@ vIa
 vIa
 aUc
 teW
-etM
+tjL
 nMd
 uKB
 uKB
@@ -443320,7 +443327,7 @@ tML
 tML
 tML
 wAm
-dpF
+dDU
 wAm
 wAm
 teW
@@ -443715,14 +443722,14 @@ aUc
 teW
 teW
 teW
-vwi
+xRn
 uKB
 uKB
-cYN
+sFQ
 iYx
-wki
-bHX
-bHX
+vcg
+tUp
+tUp
 teW
 iYx
 iYx
@@ -444117,18 +444124,18 @@ aUc
 lMZ
 lMZ
 teW
-vwi
+xRn
 uKB
 uKB
-qlL
+udH
 iYx
 vaa
-bHX
-rDI
+tUp
+uVk
 teW
-qwp
-nIl
-urY
+iSS
+iXP
+aIo
 iYx
 lMZ
 lMZ
@@ -444519,18 +444526,18 @@ vIa
 lAs
 lMZ
 teW
-vwi
+xRn
 uKB
 uKB
-jCr
+jNc
 iYx
-svk
-bHX
-bHX
+vdg
+tUp
+tUp
 teW
-nGi
-bHX
-bHX
+woq
+tUp
+tUp
 iYx
 lMZ
 lAs
@@ -444921,18 +444928,18 @@ vIa
 lAs
 lMZ
 teW
-ioM
+bsy
 uKB
 uKB
-cvC
+qzY
 iYx
-aem
-bHX
-bHX
-vYh
-bHX
-bHX
-sZX
+xUK
+tUp
+tUp
+ifg
+tUp
+tUp
+uGf
 iYx
 lMZ
 lAs
@@ -445328,13 +445335,13 @@ teW
 teW
 teW
 iYx
-cpS
-bHX
-eNu
+fED
+tUp
+qRp
 iYx
-dwO
-nhT
-mQd
+gUA
+bxw
+mmw
 iYx
 lMZ
 lAs
@@ -445730,9 +445737,9 @@ iYx
 iYx
 iYx
 iYx
-wki
-bHX
-fGT
+vcg
+tUp
+phe
 iYx
 iYx
 iYx
@@ -446129,16 +446136,16 @@ lAs
 lAs
 lMZ
 iYx
-fGT
-tRN
+phe
+hWp
 iYx
 iYx
-bHX
-eNu
+tUp
+qRp
 iYx
-qwp
-nIl
-urY
+iSS
+iXP
+aIo
 iYx
 lMZ
 lAs
@@ -446531,16 +446538,16 @@ lAs
 lAs
 lMZ
 iYx
-nGi
-bHX
-nAQ
-bHX
-bHX
-bHX
+woq
+tUp
+rfk
+tUp
+tUp
+tUp
 iYx
-nGi
-bHX
-bHX
+woq
+tUp
+tUp
 iYx
 lMZ
 lAs
@@ -446933,16 +446940,16 @@ lAs
 lAs
 lMZ
 iYx
-bHX
-bHX
+tUp
+tUp
 iYx
-bHX
-bHX
-bHX
-vYh
-bHX
-bHX
-sZX
+tUp
+tUp
+tUp
+ifg
+tUp
+tUp
+uGf
 iYx
 lMZ
 lAs
@@ -447335,16 +447342,16 @@ lAs
 lAs
 lMZ
 iYx
-mWk
-mQd
+rMH
+mmw
 iYx
-bHX
-umt
-dwk
+tUp
+wDb
+rRA
 iYx
-dwO
-nhT
-mQd
+gUA
+bxw
+mmw
 iYx
 lMZ
 lAs
@@ -447736,18 +447743,18 @@ vIa
 vIa
 vIa
 aUc
-rGS
+sAb
 iYx
 iYx
 iYx
-mbd
+pBE
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-rGS
+sAb
 aUc
 vIa
 vIa
@@ -448141,7 +448148,7 @@ aUc
 aUc
 iYx
 iYx
-jZP
+aXt
 tWY
 tWY
 iyd
@@ -448542,8 +448549,8 @@ vIa
 vIa
 aUc
 iYx
-iqW
-bVa
+rwx
+vox
 tWY
 tWY
 iyd
@@ -448944,8 +448951,8 @@ vIa
 vIa
 aUc
 iYx
-vbR
-bVa
+dEe
+vox
 tWY
 tWY
 iyd
@@ -449346,11 +449353,11 @@ vIa
 vIa
 aUc
 iYx
-bPy
-dpx
-uZC
-uZC
-uZC
+hbg
+tbb
+vGN
+vGN
+vGN
 iYx
 iYx
 iYx
@@ -449750,9 +449757,9 @@ aUc
 iYx
 iYx
 iYx
-gvV
-gvV
-saN
+vGQ
+vGQ
+qDb
 iYx
 lMZ
 lMZ
@@ -451748,16 +451755,16 @@ iyK
 iyK
 iyK
 iyK
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
 iyK
 iyK
 iyK
@@ -451861,7 +451868,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452149,17 +452156,17 @@ iyK
 iyK
 iyK
 iyK
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
 iyK
 iyK
 iyK
@@ -452263,7 +452270,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452552,16 +452559,16 @@ iyK
 iyK
 iyK
 iyK
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
 iyK
 iyK
 iyK
@@ -452665,7 +452672,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452954,16 +452961,16 @@ iyK
 iyK
 iyK
 iyK
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
-nPQ
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
+vjs
 iyK
 iyK
 iyK
@@ -453067,7 +453074,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453469,7 +453476,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453871,7 +453878,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -454273,7 +454280,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -454675,7 +454682,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455077,7 +455084,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455479,7 +455486,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455881,7 +455888,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -456283,7 +456290,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -456685,7 +456692,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457087,7 +457094,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457489,7 +457496,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457891,7 +457898,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -458293,7 +458300,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -458695,7 +458702,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459097,7 +459104,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459499,7 +459506,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459901,7 +459908,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -460303,7 +460310,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -460705,7 +460712,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461107,7 +461114,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461509,7 +461516,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461911,7 +461918,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -462313,7 +462320,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -462715,7 +462722,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463117,7 +463124,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463519,7 +463526,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463921,7 +463928,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464323,7 +464330,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464725,7 +464732,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465127,7 +465134,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465529,7 +465536,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465931,7 +465938,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466333,7 +466340,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466735,7 +466742,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467137,7 +467144,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467539,7 +467546,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467941,7 +467948,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468343,7 +468350,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468745,7 +468752,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469147,7 +469154,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469549,7 +469556,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469951,7 +469958,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470353,7 +470360,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470755,7 +470762,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471157,7 +471164,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471559,7 +471566,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471961,7 +471968,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472363,7 +472370,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472765,7 +472772,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473167,7 +473174,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473569,7 +473576,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473971,7 +473978,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474373,7 +474380,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474775,7 +474782,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475177,7 +475184,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475579,7 +475586,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475981,7 +475988,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -476383,7 +476390,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -476785,7 +476792,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -477187,7 +477194,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -477589,7 +477596,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -477991,7 +477998,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -478393,7 +478400,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -478795,7 +478802,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -479197,7 +479204,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -479599,7 +479606,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -480001,7 +480008,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -480403,7 +480410,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -480805,7 +480812,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -481207,7 +481214,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -481609,7 +481616,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482011,7 +482018,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482413,7 +482420,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482815,7 +482822,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -483217,7 +483224,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -483619,7 +483626,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -484021,7 +484028,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -484423,7 +484430,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -484825,7 +484832,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -485227,7 +485234,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -485629,7 +485636,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -485983,27 +485990,27 @@ aUc
 aUc
 aUc
 aUc
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -486326,36 +486333,36 @@ vIa
 aUc
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-loE
-eMs
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+uPa
 erZ
 erZ
 erZ
@@ -486405,6 +486412,7 @@ vIa
 vIa
 vIa
 vIa
+aUc
 vIa
 vIa
 vIa
@@ -486415,24 +486423,23 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 aUc
 vIa
 vIa
@@ -486725,39 +486732,39 @@ vIa
 vIa
 vIa
 vIa
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-kvj
-gkL
-loE
-loE
-loE
-tJC
-kvj
-kvj
-kvj
-tJC
-qYw
-kvj
-loE
-dht
-wyA
-mpG
-quL
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fIB
+gnX
+ebb
+ebb
+ebb
+yel
+fIB
+fIB
+fIB
+yel
+itC
+fIB
+ebb
+clh
+guK
+eIW
+emT
+jIP
+emT
 bzl
-quL
-xIo
 erZ
 erZ
 erZ
@@ -486807,6 +486814,7 @@ erZ
 erZ
 erZ
 vIa
+aUc
 vIa
 vIa
 vIa
@@ -486814,11 +486822,10 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -487127,39 +487134,39 @@ vIa
 erZ
 erZ
 erZ
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-kvj
-ixN
-loE
-loE
-loE
-kvj
-kvj
-eyb
-pAX
-pAX
-loE
-kvj
-mJj
-bzl
-ycz
-bzl
-ycz
-bzl
-bzl
-uzT
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fIB
+wmn
+ebb
+ebb
+ebb
+fIB
+fIB
+keJ
+reg
+reg
+ebb
+fIB
+ijs
+jIP
+uRv
+jIP
+uRv
+jIP
+jIP
+rcn
 erZ
 erZ
 erZ
@@ -487209,15 +487216,15 @@ erZ
 erZ
 erZ
 erZ
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -487529,39 +487536,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-kvj
-kvj
-dYw
-loE
-nBf
-nZq
-oiE
-pKQ
-loE
-loE
-loE
-qYw
-loE
-eza
-bzl
-bzl
-bzl
-bzl
-bzl
-vCX
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fIB
+fIB
+gip
+ebb
+eXr
+oCD
+pjB
+qZg
+ebb
+ebb
+ebb
+itC
+ebb
+pik
+jIP
+jIP
+jIP
+jIP
+jIP
+lWV
 erZ
 erZ
 erZ
@@ -487612,12 +487619,12 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -487931,39 +487938,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-kvj
-kvj
-dYw
-loE
-ogC
-kvj
-kvj
-tCz
-loE
-lhd
-wTs
-kvj
-loE
-hiK
-cUb
-xnP
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fIB
+fIB
+gip
+ebb
+wDZ
+fIB
+fIB
+dBW
+ebb
+hjD
+qRm
+fIB
+ebb
+xWA
+gFF
+uHM
+jIP
+jIP
+jIP
 bzl
-bzl
-bzl
-xIo
 erZ
 erZ
 erZ
@@ -488333,39 +488340,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-qYw
-loE
-loE
-loE
-ogC
-kvj
-kvj
-tCz
-loE
-wTs
-kvj
-kvj
-eMs
-pRL
-jxM
-aXe
-opC
-bzl
-ycz
-uzT
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+itC
+ebb
+ebb
+ebb
+wDZ
+fIB
+fIB
+dBW
+ebb
+qRm
+fIB
+fIB
+uPa
+mJO
+xsV
+pMn
+vUf
+jIP
+uRv
+rcn
 erZ
 erZ
 erZ
@@ -488735,39 +488742,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-loE
-rRD
-rRD
-suN
-loE
-nBf
-xET
-kvj
-uGf
-loE
-kvj
-oiE
-wTs
-eMs
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+ebb
+ycz
+ycz
+gue
+ebb
+eXr
+sHB
+fIB
+xkF
+ebb
+fIB
+pjB
+qRm
+uPa
 wQI
-bRM
+oOY
 wQI
-fqF
-bzl
-bzl
-vCX
+fJp
+jIP
+jIP
+lWV
 erZ
 erZ
 erZ
@@ -489137,39 +489144,39 @@ erZ
 erZ
 erZ
 erZ
-bqt
+mVz
 fIL
 wQD
 aUc
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-nBf
-xET
-kvj
-pKQ
-loE
-ogC
-oiE
-oiE
-tCz
-loE
-kvj
-kvj
-kvj
-eMs
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+eXr
+sHB
+fIB
+qZg
+ebb
+wDZ
+pjB
+pjB
+dBW
+ebb
+fIB
+fIB
+fIB
+uPa
 wQI
 wQI
-ptS
-hPo
+iSf
+nKI
+jIP
+jIP
 bzl
-bzl
-xIo
 erZ
 erZ
 erZ
@@ -489544,34 +489551,34 @@ eNY
 hby
 aUc
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-ogC
-kvj
-kvj
-tCz
-loE
-ogC
-kvj
-kvj
-tCz
-loE
-kvj
-wTs
-kvj
-eMs
-sYk
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+wDZ
+fIB
+fIB
+dBW
+ebb
+wDZ
+fIB
+fIB
+dBW
+ebb
+fIB
+qRm
+fIB
+uPa
+npZ
 wQI
-sYk
-gwt
-bzl
-bzl
-uzT
+npZ
+wqq
+jIP
+jIP
+rcn
 erZ
 erZ
 erZ
@@ -489947,33 +489954,33 @@ twI
 aUc
 aUc
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-wFq
-kvj
-rRD
-dYw
-loE
-nBf
-xET
-kvj
-uGf
-loE
-lhd
-kvj
-oiE
-loE
-loE
-loE
-loE
-mLH
-mLH
-mLH
-ePh
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+cjJ
+fIB
+ycz
+gip
+ebb
+eXr
+sHB
+fIB
+xkF
+ebb
+hjD
+fIB
+pjB
+ebb
+ebb
+ebb
+ebb
+mQA
+mQA
+mQA
+nTR
 erZ
 erZ
 erZ
@@ -490348,30 +490355,30 @@ twI
 twI
 twI
 aUc
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-wsV
-xET
-kvj
-eyb
-loE
-wFq
-kvj
-kvj
-dYw
-loE
-kvj
-oiE
-kvj
-kvj
-kvj
-dbH
-pcO
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+svA
+sHB
+fIB
+keJ
+ebb
+cjJ
+fIB
+fIB
+gip
+ebb
+fIB
+pjB
+fIB
+fIB
+fIB
+aHq
+dbt
 erZ
 erZ
 erZ
@@ -490749,31 +490756,31 @@ aUc
 aUc
 xGC
 oWI
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-rWb
-xET
-kvj
-pKQ
-loE
-ogC
-kvj
-kvj
-tCz
-loE
-kvj
-kvj
-kvj
-kvj
-umK
-qzH
-pcO
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fEQ
+sHB
+fIB
+qZg
+ebb
+wDZ
+fIB
+fIB
+dBW
+ebb
+fIB
+fIB
+fIB
+fIB
+mWP
+jfl
+dbt
 erZ
 erZ
 erZ
@@ -491151,31 +491158,31 @@ vIa
 aUc
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-wFq
-rRD
-kvj
-tCz
-loE
-nBf
-xET
-kvj
-uGf
-loE
-kvj
-kvj
-oiE
-kvj
-dbH
-hiq
-lpD
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+cjJ
+ycz
+fIB
+dBW
+ebb
+eXr
+sHB
+fIB
+xkF
+ebb
+fIB
+fIB
+pjB
+fIB
+aHq
+qwp
+wZQ
 erZ
 erZ
 erZ
@@ -491550,34 +491557,34 @@ erZ
 erZ
 erZ
 bQB
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-ogC
-kvj
-kvj
-dYw
-loE
-dYw
-oiE
-oiE
-tCz
-loE
-lhd
-kvj
-kvj
-kvj
-dbH
-qzH
-pcO
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+wDZ
+fIB
+fIB
+gip
+ebb
+gip
+pjB
+pjB
+dBW
+ebb
+hjD
+fIB
+fIB
+fIB
+aHq
+jfl
+dbt
 erZ
 erZ
 erZ
@@ -491952,34 +491959,34 @@ erZ
 erZ
 erZ
 bQB
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-nBf
-xET
-kvj
-vGN
-vGN
-vGN
-kvj
-kvj
-vGN
-vGN
-oiE
-kvj
-kvj
-rhI
-vQV
-qzH
-pcO
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+eXr
+sHB
+fIB
+uZC
+uZC
+uZC
+fIB
+fIB
+uZC
+uZC
+pjB
+fIB
+fIB
+aZf
+ksK
+jfl
+dbt
 erZ
 erZ
 erZ
@@ -492354,34 +492361,34 @@ erZ
 erZ
 erZ
 bQB
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-ogC
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+wDZ
+ycz
+fIB
 rRD
-kvj
-aBP
-loE
-cAC
-xET
-kvj
-hhq
-loE
-lhd
-oiE
-kvj
-kvj
-kvj
-vQV
-pcO
+ebb
+wbF
+sHB
+fIB
+ppy
+ebb
+hjD
+pjB
+fIB
+fIB
+fIB
+ksK
+dbt
 erZ
 erZ
 erZ
@@ -492756,37 +492763,37 @@ erZ
 erZ
 erZ
 bQB
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-ogC
-kvj
-rRD
-kvj
-qYw
-kvj
-kvj
-kvj
-loE
-loE
-loE
-loE
-loE
-lMg
-kvj
-kvj
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+wDZ
+fIB
+ycz
+fIB
+itC
+fIB
+fIB
+fIB
+ebb
+ebb
+ebb
+ebb
+ebb
+oBL
+fIB
+fIB
 uLh
 uLh
-aHY
-cLL
+fbe
+mGn
 uLh
 erZ
 erZ
@@ -493158,39 +493165,39 @@ erZ
 erZ
 erZ
 bQB
-bqt
+mVz
 uXW
 oRe
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-beK
-xET
-kvj
-aIk
-loE
-loE
-loE
-loE
-loE
-loE
-bqt
-bqt
-loE
-kvj
-wTs
-wTs
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+cld
+sHB
+fIB
+feB
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+mVz
+mVz
+ebb
+fIB
+qRm
+qRm
 uLh
-gSO
-tlQ
-eXp
+pQL
+yjP
+bHX
 uLh
-ebe
+mQr
 erZ
 erZ
 erZ
@@ -493554,46 +493561,46 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
 hqA
 pCW
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-loE
-loE
-loE
-loE
-loE
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-kvj
-kvj
-kvj
-hSF
-tlQ
-tlQ
-qTw
-cLL
-tlQ
-tlQ
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+ebb
+ebb
+ebb
+ebb
+ebb
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fIB
+fIB
+fIB
+tqx
+yjP
+yjP
+goD
+mGn
+yjP
+yjP
 erZ
 erZ
 erZ
@@ -493951,13 +493958,13 @@ erZ
 erZ
 erZ
 erZ
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
 lgg
 lgg
 lgg
@@ -493969,33 +493976,33 @@ lgg
 lgg
 lgg
 lgg
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-loE
-loE
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-kvj
-kvj
-kvj
-hSF
-tlQ
-tlQ
-tlQ
-hSF
-tlQ
-tlQ
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+ebb
+ebb
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+fIB
+fIB
+fIB
+tqx
+yjP
+yjP
+yjP
+tqx
+yjP
+yjP
 erZ
 erZ
 erZ
@@ -494349,13 +494356,13 @@ vIa
 vIa
 vIa
 vIa
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
 lgg
 lgg
 lgg
@@ -494375,29 +494382,29 @@ lgg
 lgg
 vIa
 vIa
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-lhd
-wTs
-kvj
-hSF
-tlQ
-tlQ
-tlQ
-cLL
-tlQ
-tlQ
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+hjD
+qRm
+fIB
+tqx
+yjP
+yjP
+yjP
+mGn
+yjP
+yjP
 erZ
 erZ
 erZ
@@ -494754,7 +494761,7 @@ vIa
 erZ
 erZ
 erZ
-bqt
+mVz
 lgg
 lgg
 lgg
@@ -494780,25 +494787,25 @@ vIa
 vIa
 vIa
 vIa
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-bqt
-loE
-sCc
-ogB
-kvj
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+mVz
+ebb
+pBp
+sXc
+fIB
 uLh
-rRA
-tlQ
-tlQ
+nvC
+yjP
+yjP
 uLh
-ebe
+mQr
 erZ
 erZ
 erZ
@@ -495184,22 +495191,22 @@ vIa
 vIa
 vIa
 aUc
-bqt
-loE
-dTa
-dTa
-dTa
-dTa
-dTa
-dTa
-dTa
-wDz
-wDz
+mVz
+ebb
+pdm
+pdm
+pdm
+pdm
+pdm
+pdm
+pdm
+auZ
+auZ
 uLh
 uLh
-kTm
-kTm
-rqw
+tle
+tle
+arY
 erZ
 erZ
 erZ
@@ -495586,8 +495593,8 @@ vIa
 vIa
 vIa
 vIa
-bqt
-bqt
+mVz
+mVz
 erZ
 erZ
 erZ
@@ -497208,14 +497215,14 @@ erZ
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -497605,19 +497612,19 @@ erZ
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -498007,24 +498014,24 @@ erZ
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -498409,24 +498416,24 @@ erZ
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -498809,26 +498816,26 @@ sri
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -499211,26 +499218,26 @@ sri
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -499613,26 +499620,26 @@ sri
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -500015,26 +500022,26 @@ erZ
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -500417,26 +500424,26 @@ erZ
 erZ
 erZ
 erZ
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -500819,7 +500826,7 @@ erZ
 erZ
 erZ
 erZ
-dbt
+xpM
 iJC
 bOK
 nEd
@@ -500827,18 +500834,18 @@ nEd
 nEd
 bOK
 iJC
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -501221,7 +501228,7 @@ erZ
 erZ
 erZ
 erZ
-dbt
+xpM
 bOK
 fVQ
 fVQ
@@ -501229,18 +501236,18 @@ bmG
 fVQ
 fVQ
 bOK
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -501623,7 +501630,7 @@ erZ
 erZ
 erZ
 erZ
-dbt
+xpM
 nEd
 fVQ
 lgN
@@ -501631,18 +501638,18 @@ jJC
 lgN
 fVQ
 nEd
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -502025,7 +502032,7 @@ erZ
 erZ
 erZ
 erZ
-dbt
+xpM
 nEd
 fVQ
 qxZ
@@ -502039,12 +502046,12 @@ vxC
 vxC
 vxC
 ppx
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -502427,7 +502434,7 @@ erZ
 erZ
 erZ
 erZ
-dbt
+xpM
 nEd
 fVQ
 fVQ
@@ -502441,12 +502448,12 @@ fZJ
 fZJ
 fZJ
 kZS
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -543019,11 +543026,11 @@ qzV
 nLH
 pil
 aqS
-veW
+htH
 fCM
 fCM
 fCM
-uFp
+oPc
 fCM
 nQU
 cGD
@@ -543812,8 +543819,8 @@ vIa
 vIa
 vIa
 vIa
-qeY
-qeY
+iSJ
+iSJ
 lAs
 woj
 qPA
@@ -544214,8 +544221,8 @@ vIa
 vIa
 vIa
 vIa
-qeY
-qeY
+iSJ
+iSJ
 lAs
 woj
 qPA
@@ -544616,8 +544623,8 @@ vIa
 vIa
 vIa
 vIa
-qeY
-qeY
+iSJ
+iSJ
 lAs
 woj
 qPA
@@ -545018,8 +545025,8 @@ vIa
 vIa
 vIa
 vIa
-qeY
-qeY
+iSJ
+iSJ
 lAs
 eJN
 bHY
@@ -545420,8 +545427,8 @@ vIa
 vIa
 vIa
 vIa
-qeY
-qeY
+iSJ
+iSJ
 lAs
 lAs
 lAs
@@ -545822,7 +545829,7 @@ vIa
 vIa
 vIa
 vIa
-qeY
+iSJ
 vIa
 vIa
 vIa
@@ -546224,7 +546231,7 @@ vIa
 vIa
 vIa
 vIa
-qeY
+iSJ
 vIa
 vIa
 vIa
@@ -546626,7 +546633,7 @@ vIa
 vIa
 vIa
 vIa
-qeY
+iSJ
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,8 +7,11 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -495,9 +498,14 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -974,10 +982,19 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"adJ" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "adK" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "adL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -1135,16 +1152,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "aev" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1221,6 +1235,14 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"agJ" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "agL" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -1246,6 +1268,15 @@
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"ahV" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
@@ -1300,11 +1331,6 @@
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"akm" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/loom,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "akn" = (
 /obj/item/roguebin/crackers,
 /turf/open/floor/rogue/blocks,
@@ -1317,13 +1343,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"akZ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+"ale" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "alk" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -1332,14 +1355,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"alz" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"alx" = (
+/obj/structure/stairs{
+	dir = 8
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "alL" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -1394,10 +1415,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "aok" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1426,15 +1451,15 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"aoY" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "apc" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"apx" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "aqc" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks,
@@ -1465,6 +1490,32 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"ark" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"arA" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"arG" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1492,13 +1543,10 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"atl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/composter/full,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+"asZ" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "atx" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/church,
@@ -1549,11 +1597,9 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1572,25 +1618,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"avi" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
-"avq" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "avQ" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -1598,13 +1625,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"avX" = (
-/obj/structure/gate/bars{
-	gid = "viking1";
-	redstone_id = "viking1"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "avY" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
@@ -1652,14 +1672,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"awV" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2";
-	pixel_x = 16
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "axk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -1672,12 +1684,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/garrison)
-"axp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "axq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -1703,9 +1709,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1767,12 +1773,6 @@
 /obj/item/clothing/cloak/stabard/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"aAh" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "aAs" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
@@ -1794,6 +1794,23 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
+"aBP" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"aCd" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1818,10 +1835,6 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"aDb" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1930,6 +1943,10 @@
 /obj/effect/landmark/map_load_mark/sewers_bottom,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"aHj" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
 "aHo" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
@@ -1947,9 +1964,6 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"aHC" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "aHK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/tavern)
@@ -1960,6 +1974,11 @@
 /obj/item/clothing/neck/roguetown/psicross/pestra,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"aHY" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "aIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/kitchen/spoon/plastic,
@@ -1971,6 +1990,20 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"aIk" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "aIx" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/closet/crate/roguecloset,
@@ -2150,20 +2183,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"aNR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "aNW" = (
 /obj/structure/table/wood,
 /obj/item/chair/rogue,
@@ -2220,11 +2239,8 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2269,6 +2285,14 @@
 /obj/structure/roguemachine/steward,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"aRp" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aRA" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
@@ -2283,6 +2307,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"aRR" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "aRU" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2299,11 +2329,8 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2360,6 +2387,14 @@
 "aUc" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/mountains)
+"aUo" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "aUE" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -2390,6 +2425,17 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"aVp" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "aVv" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -2407,10 +2453,28 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"aWb" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"aWy" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "aWO" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -2422,6 +2486,15 @@
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"aXe" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "aXh" = (
 /turf/open/floor/grass/snow,
 /area/rogue/outdoors/bog)
@@ -2480,6 +2553,17 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
+"aZv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "aZG" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/blocks,
@@ -2527,6 +2611,11 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
+"bbY" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bcj" = (
 /obj/structure/timeddoor/sixtyminute,
 /obj/structure/timeddoor/sixtyminute,
@@ -2591,6 +2680,17 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"beK" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "beQ" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
@@ -2642,6 +2742,21 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"bgT" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bgW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -2649,6 +2764,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"bgY" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "bhg" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2658,9 +2777,13 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
-"bhw" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
+"bhu" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "bhy" = (
 /obj/structure/mineral_door/wood/window{
@@ -2680,6 +2803,10 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"bif" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2690,22 +2817,16 @@
 /obj/structure/fluff/walldeco/wantedposter/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"biC" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "biG" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"biR" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "bjd" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -2714,15 +2835,20 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"bjp" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
+"bje" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"bjo" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bjx" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/ruinedwood{
@@ -2740,6 +2866,10 @@
 /obj/item/rogueweapon/tongs,
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
+"bjK" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "bjO" = (
 /obj/structure/lever/wall{
@@ -2830,18 +2960,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"bmx" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "bmG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood{
@@ -2849,8 +2967,9 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2868,12 +2987,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"bnK" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bnO" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road{
@@ -2911,6 +3024,11 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"bob" = (
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "boh" = (
 /obj/effect/landmark/start/villager{
 	dir = 4
@@ -2925,10 +3043,18 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
-"bop" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"bos" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "bow" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -2965,14 +3091,27 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"bpi" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bpn" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"bpp" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+"bpt" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bpx" = (
 /obj/structure/table/vtable/v2,
 /obj/item/reagent_containers/glass/mortar,
@@ -3115,31 +3254,12 @@
 /obj/effect/landmark/start/mason,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"bsL" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "bsO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"bsV" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3156,15 +3276,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"bty" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "btA" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -3210,6 +3321,11 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"bux" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "buL" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -3254,10 +3370,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"bvy" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
 "bvH" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -3396,9 +3508,10 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3448,6 +3561,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"bBh" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3457,6 +3574,13 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"bBL" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bBQ" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -3464,16 +3588,10 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
@@ -3512,6 +3630,13 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"bEm" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "bEo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -3543,6 +3668,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"bFq" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "bFr" = (
 /obj/structure/stairs{
 	dir = 4
@@ -3591,6 +3724,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bHc" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bHt" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -3614,12 +3751,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3631,13 +3764,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"bIe" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bIh" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
@@ -3657,18 +3783,16 @@
 "bIu" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"bIE" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "bIJ" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"bIR" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bIZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -3736,14 +3860,11 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"bLL" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
+"bLM" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "bMh" = (
 /obj/structure/flora/tree/jungle/small,
@@ -3826,24 +3947,26 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"bPk" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "bPv" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
+"bPy" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "bPz" = (
-/obj/structure/closet/crate/drawer,
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3872,14 +3995,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"bQz" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "bQA" = (
 /mob/living/simple_animal/pet/cat/black{
 	name = "Morticia"
@@ -3921,10 +4036,12 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
-"bRV" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
+"bRM" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "bSm" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -3996,16 +4113,13 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bVa" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4022,13 +4136,24 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bWg" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+"bVP" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
 	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"bVT" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"bVY" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "bWj" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -4059,6 +4184,12 @@
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
+"bWv" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "bWK" = (
 /obj/structure/chair/wood/rogue,
@@ -4100,13 +4231,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"bYy" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "bYA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4156,21 +4280,14 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"bZW" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
+"caK" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
 	},
-/area/rogue/indoors/town/garrison)
-"car" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
@@ -4272,6 +4389,16 @@
 /obj/structure/table/vtable/v2,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
+"cel" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cev" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/ruinedwood{
@@ -4294,13 +4421,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"ceX" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "cfw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4321,14 +4441,6 @@
 "cfY" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
-"cgc" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "cgq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -4377,6 +4489,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"che" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "chg" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -4437,13 +4555,6 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
-"ciQ" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ciX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -4472,19 +4583,13 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cjB" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "cjJ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4536,9 +4641,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4554,6 +4662,16 @@
 /obj/item/roguekey/nightmaiden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"clV" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "clY" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/poo,
@@ -4567,6 +4685,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"cmf" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "cmB" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/shop)
@@ -4616,6 +4740,20 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
+/area/rogue/outdoors/town)
+"cnX" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "cod" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -4669,6 +4807,11 @@
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"cpS" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "cpY" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -4730,19 +4873,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"csg" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "csi" = (
 /obj/structure/bars,
 /obj/structure/spider/stickyweb,
@@ -4763,6 +4893,30 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"csB" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4795,6 +4949,15 @@
 "ctS" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
+"cuc" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"cud" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "cue" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
@@ -4833,6 +4996,23 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"cvC" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "cvN" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road{
@@ -4840,9 +5020,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4898,6 +5077,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"cxa" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "cxb" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors/town/manor)
@@ -5009,6 +5194,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"czM" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "czO" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
@@ -5046,10 +5235,28 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"cAC" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "cAE" = (
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"cAW" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cBb" = (
 /obj/effect/landmark/start/nightmaiden{
 	dir = 8
@@ -5091,16 +5298,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/tribalfort)
@@ -5117,13 +5319,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"cCG" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cCQ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5143,9 +5338,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5173,17 +5368,6 @@
 "cDM" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/bog)
-"cDZ" = (
-/obj/structure/mineral_door/wood{
-	dir = 4;
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "cEk" = (
 /obj/structure/bookcase/random{
 	pixel_y = 20
@@ -5241,6 +5425,13 @@
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cGb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "cGc" = (
 /obj/structure/chair/wood/rogue,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -5258,35 +5449,19 @@
 	},
 /area/rogue/indoors/town/vault)
 "cGA" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
-"cGC" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "cGD" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"cGR" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "cGX" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -5325,13 +5500,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"cHU" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cIa" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/shop)
@@ -5354,14 +5522,6 @@
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"cIz" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5";
-	pixel_x = 17
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "cIC" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/herringbone,
@@ -5383,16 +5543,16 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"cJt" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "cJz" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/dwarfin)
-"cJU" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "cKj" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -5446,11 +5606,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5468,12 +5626,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5540,15 +5698,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"cOS" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -5610,24 +5759,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"cQP" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "cQY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors)
-"cRc" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "cRl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -5637,15 +5774,6 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
-"cRE" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "cRM" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5655,11 +5783,8 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5698,10 +5823,6 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
-"cSB" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "cSF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/bed/rogue,
@@ -5727,11 +5848,6 @@
 "cTA" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
-"cTF" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "cTG" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress,
@@ -5746,6 +5862,15 @@
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"cUb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "cUh" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt/road{
@@ -5783,10 +5908,24 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"cVb" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "cVc" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"cVk" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "cVm" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -5899,6 +6038,13 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"cYN" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "cYR" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/twig,
@@ -5992,21 +6138,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
+"dbH" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"dbH" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -6020,22 +6160,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"dbZ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "dcf" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -6077,6 +6201,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"dcO" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "dcP" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -6206,13 +6334,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"dgU" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
 "dhg" = (
 /obj/structure/roguewindow/stained/yellow,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -6237,6 +6358,13 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"dht" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "dhH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -6312,6 +6440,10 @@
 /obj/item/candle/skull/lit,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
+"djJ" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "djX" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -6342,6 +6474,12 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
+"dkx" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "dkI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -6360,18 +6498,6 @@
 /obj/item/clothing/under/roguetown/chainlegs,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"dlw" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dlx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -6407,16 +6533,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"dmj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "dmw" = (
 /obj/structure/fluff/walldeco/painting/queen{
 	pixel_y = 32
@@ -6443,6 +6559,13 @@
 "dmK" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/manor)
+"dmR" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dmS" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/woodturned,
@@ -6450,6 +6573,12 @@
 "dnf" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
 /area/rogue/indoors/town/manor)
+"dnh" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dnx" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -6458,6 +6587,25 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"dnV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "dnZ" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -6493,13 +6641,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"dpd" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "dpi" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
@@ -6512,6 +6653,18 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"dpx" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"dpF" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "dpL" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -6524,6 +6677,13 @@
 "dpP" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/under/cavewet/bogcaves)
+"dpQ" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dpT" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/guardsman,
@@ -6607,11 +6767,8 @@
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
 "dsW" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "dth" = (
 /obj/structure/fluff/railing/border,
@@ -6627,10 +6784,6 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
-"duh" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "duu" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -6688,6 +6841,20 @@
 /obj/effect/decal/remains/bigrat,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"dwk" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dwl" = (
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
@@ -6704,15 +6871,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6765,6 +6927,14 @@
 "dzb" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
+"dzf" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "dzx" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith2,
 /turf/open/floor/rogue/grass,
@@ -6785,10 +6955,15 @@
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
 /obj/structure/roguewindow/openclose{
-	dir = 1
+	dir = 1;
+	icon_state = "woodwindowdir"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6796,12 +6971,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"dAq" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "dAy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -6830,10 +6999,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"dBX" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6853,6 +7018,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"dCZ" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "dDf" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -6880,12 +7053,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dEo" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "dEA" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet,
@@ -6899,14 +7066,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"dEF" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -7089,6 +7248,13 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
+"dME" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dMN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7116,8 +7282,10 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
@@ -7141,15 +7309,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"dOw" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "dOx" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -7173,10 +7332,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"dOL" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "dPb" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7184,10 +7339,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"dPe" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "dPp" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -7265,17 +7416,19 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"dQw" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "dQJ" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
+"dQX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dQY" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/concrete,
@@ -7297,6 +7450,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"dRd" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dRl" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -7322,11 +7481,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"dSK" = (
-/obj/structure/roguewindow/stained/silver,
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "dSL" = (
 /turf/open/water/river{
 	dir = 4;
@@ -7364,9 +7518,11 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7425,25 +7581,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dUF" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
+"dUC" = (
+/obj/structure/stairs/stone{
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/magician)
-"dVb" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "dVf" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -7496,30 +7645,9 @@
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"dXn" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+"dXt" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "dXw" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -7556,6 +7684,10 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
+"dYw" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dYP" = (
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
@@ -7568,10 +7700,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"dZK" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "dZZ" = (
 /obj/structure/statue/saints/knight_l,
 /turf/open/floor/rogue/blocks,
@@ -7615,16 +7743,23 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ebe" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7650,6 +7785,13 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"ebJ" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ebR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7771,6 +7913,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"eef" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eeu" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/fermenting_barrel,
@@ -7838,6 +7986,12 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town)
+"efv" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "efw" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
@@ -7879,12 +8033,9 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
-"egC" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+"egz" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "egU" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
@@ -7921,6 +8072,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"eib" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eit" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -7945,16 +8103,6 @@
 /obj/item/roguekey/merchant,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
-"eiT" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eiV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
@@ -7989,10 +8137,6 @@
 /obj/effect/landmark/start/gravedigger,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"ejO" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ejV" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble/mossy,
@@ -8001,14 +8145,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
-"ekv" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ekI" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/shop)
@@ -8159,22 +8295,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"eoB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "epp" = (
 /obj/structure/fluff/walldeco/innsign{
 	alpha = 200;
@@ -8186,10 +8312,13 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
-"epN" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+"epL" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "epQ" = (
 /obj/structure/mineral_door/wood{
 	desc = "I shouldn't go in here...";
@@ -8207,15 +8336,16 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"eqr" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1";
-	pixel_x = 9
+"eqo" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eqt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -8268,28 +8398,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
-"erB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"erD" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "erN" = (
 /obj/structure/table/church{
 	dir = 1
@@ -8318,12 +8426,6 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
-"esu" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "esv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -8343,14 +8445,6 @@
 "esR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"esX" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "ete" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/rogue/firebowl/stump,
@@ -8376,6 +8470,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"etM" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "etS" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -8473,6 +8571,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"evB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "evJ" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
@@ -8503,17 +8611,6 @@
 /obj/structure/pillory/town_square/reinforced,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"ewU" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "exG" = (
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
@@ -8537,6 +8634,16 @@
 /obj/item/rogue/instrument/drum,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"eyb" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "eyq" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = -32
@@ -8555,12 +8662,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"eyM" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "eyR" = (
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/concrete,
@@ -8570,11 +8671,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8589,16 +8690,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
-"eAi" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -8659,16 +8750,6 @@
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"eCw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "eCK" = (
 /obj/structure/flora/rogueshroom2,
 /turf/open/floor/rogue/grass,
@@ -8706,12 +8787,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
-"eDY" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "eEy" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -8720,8 +8795,16 @@
 /obj/structure/well,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
+"eEA" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eEC" = (
 /obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"eEQ" = (
+/obj/structure/bars,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "eEU" = (
@@ -8900,19 +8983,18 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/magician)
-"eJL" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "eJN" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
+"eJO" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "eJP" = (
 /obj/structure/statue/saints/lady_l,
 /turf/open/floor/rogue/blocks,
@@ -8940,18 +9022,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"eLb" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "eLe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8979,33 +9049,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"eMv" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+"eMs" = (
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "eMz" = (
 /obj/structure/flora/rock,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"eMF" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh1";
-	aportalid = "wh2";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "eMI" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
@@ -9025,6 +9076,10 @@
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"eNu" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "eNB" = (
 /obj/structure/table/church{
 	dir = 1
@@ -9061,6 +9116,18 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"ePh" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ePQ" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = 1
@@ -9141,11 +9208,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
@@ -9181,6 +9245,27 @@
 	dir = 1
 	},
 /area/rogue/indoors)
+"eTQ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"eTW" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"eTZ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "eUb" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/town)
@@ -9319,6 +9404,13 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
+"eXp" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "eXH" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
@@ -9385,19 +9477,6 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"fab" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "faE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -9488,14 +9567,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
-"fdx" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "fdF" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -9512,6 +9583,10 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"fdU" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fel" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9705,6 +9780,16 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"fla" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "flA" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -9739,6 +9824,10 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
+"flY" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "fmm" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -9747,16 +9836,6 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"fmx" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "fmR" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomi{
@@ -9825,13 +9904,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"foR" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+"foH" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "foS" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomiv{
@@ -9852,14 +9928,6 @@
 /obj/structure/statue/saints/cephine2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fpm" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "fpQ" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/tribalguard,
@@ -9888,6 +9956,21 @@
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
+"fqF" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fqW" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/wood,
@@ -9896,6 +9979,14 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
+"frx" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "frB" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/exposed)
@@ -9944,10 +10035,6 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
-"fth" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
 "ftw" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -9984,6 +10071,12 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fua" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "fuu" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -10013,26 +10106,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fvB" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"fvH" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "fwp" = (
 /obj/structure/bars,
 /turf/closed/mineral/rogue,
@@ -10075,24 +10148,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"fxb" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "fxf" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/cooking/pan,
@@ -10105,10 +10160,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"fxM" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
 "fyb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10191,10 +10242,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fAj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "fAs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -10303,6 +10350,10 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fDi" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fDw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -10319,7 +10370,11 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/turf/closed/mineral/rogue/bedrock,
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
@@ -10352,6 +10407,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"fEv" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "fEF" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/church,
@@ -10365,13 +10426,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"fFh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -10388,6 +10442,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"fGT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fHi" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -10429,6 +10489,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"fHV" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fId" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
@@ -10446,12 +10512,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"fIs" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "fIw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
@@ -10469,11 +10529,10 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "fID" = (
 /obj/structure/stairs{
@@ -10557,13 +10616,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10590,10 +10649,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"fNp" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "fNw" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
@@ -10603,16 +10658,6 @@
 	dir = 4
 	},
 /area/rogue/indoors)
-"fOI" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "fON" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/indoors/shelter/mountains)
@@ -10694,12 +10739,14 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10745,10 +10792,6 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"fRA" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "fRC" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/landmark/start/prince,
@@ -10788,17 +10831,6 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
-"fSZ" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"fTd" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "fTe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road{
@@ -10822,31 +10854,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"fTH" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
-"fTJ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fTL" = (
 /obj/structure/closet/crate/chest/reward,
 /turf/open/floor/rogue/dirt/road{
@@ -10906,15 +10913,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"fVv" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fVE" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -10926,28 +10924,23 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"fVY" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "fWh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -11013,13 +11006,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fYy" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "fYH" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/dirt/road{
@@ -11033,13 +11019,6 @@
 "fZe" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
-"fZo" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "fZw" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobblerock,
@@ -11047,10 +11026,6 @@
 "fZJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"fZP" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "gaq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -11093,14 +11068,21 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/chair/bench/church{
-	dir = 1
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/structure/fluff/walldeco/church/line{
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
+"gbD" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
 	dir = 1;
-	icon_state = "churchslate"
+	icon_state = "wooden_floor2"
 	},
-/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "gbN" = (
 /obj/structure/statue/saints/knight2,
@@ -11112,16 +11094,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"gbR" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gbX" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
@@ -11153,13 +11125,6 @@
 "gdv" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/under/cavewet/bogcaves)
-"gdw" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "gdC" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors)
@@ -11254,23 +11219,21 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"ghb" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
+"ggU" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"ghT" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
+"ghi" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/ruinedwood{
@@ -11292,21 +11255,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"gir" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
-"giI" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -11339,11 +11294,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"gjr" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "gjB" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -11374,6 +11324,12 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"gkL" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "gkO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/storage/pill_bottle/dice,
@@ -11453,19 +11409,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"gnD" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gnG" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"gnI" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "gnJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager,
@@ -11492,9 +11439,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "goK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -11563,13 +11513,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"grD" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "grQ" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood{
@@ -11583,9 +11526,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"gsa" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "gsT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -11667,15 +11607,12 @@
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
-"guU" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gvi" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11696,6 +11633,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"gvV" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "gwd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -11709,6 +11650,23 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
+"gwf" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"gwt" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11874,6 +11832,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"gBI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "gBZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -11913,16 +11878,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"gDF" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -11936,10 +11891,6 @@
 "gEq" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
-"gEw" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
@@ -12040,13 +11991,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"gHp" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "gHt" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -12105,6 +12049,11 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"gJk" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gJs" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -12116,13 +12065,6 @@
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"gKb" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gKi" = (
 /obj/structure/mineral_door/wood/donjon{
 	locked = 1;
@@ -12188,6 +12130,16 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"gLG" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "gLO" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
@@ -12198,6 +12150,14 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"gMb" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gMg" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -12332,17 +12292,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
-"gQV" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "gRd" = (
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/dirt/road{
@@ -12371,6 +12320,16 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"gRm" = (
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "gRz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -12390,6 +12349,12 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"gRJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "gRU" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -12428,12 +12393,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"gSz" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "gSG" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -12451,6 +12410,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"gSO" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "gSP" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12556,6 +12521,14 @@
 /obj/effect/landmark/start/shophand,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"gWR" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "gWX" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -12589,10 +12562,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"gYj" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gYC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -12636,16 +12605,6 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"hai" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "hal" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile{
@@ -12669,6 +12628,15 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"hay" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "haB" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/blocks,
@@ -12700,12 +12668,8 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "hby" = (
 /obj/structure/stairs{
@@ -12779,6 +12743,14 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"hcQ" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hcR" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -12805,6 +12777,12 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"hdk" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "hdm" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	lockid = "farm"
@@ -12843,6 +12821,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"hdO" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hdR" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -12881,6 +12869,13 @@
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"heJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -12989,6 +12984,19 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"hhq" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "hhw" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -13004,26 +13012,22 @@
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/beach)
-"hhK" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "hhR" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hhU" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"hiq" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "hiz" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -13041,6 +13045,14 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hiK" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "hiL" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
@@ -13068,9 +13080,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
@@ -13110,6 +13121,13 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"hln" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "hlo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -13258,16 +13276,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"hnX" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "hob" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -13297,6 +13305,16 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"hoM" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hoR" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood,
@@ -13334,18 +13352,6 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/indoors/town/dwarfin)
-"hpM" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "hpO" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
@@ -13412,20 +13418,6 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"hrj" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
-"hrD" = (
-/obj/machinery/light/rogue/lanternpost{
-	pixel_x = 15
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
@@ -13457,19 +13449,13 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"htv" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "htA" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
@@ -13517,6 +13503,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hvh" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "hvi" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -13617,16 +13613,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hzR" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13655,16 +13641,6 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"hAr" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
-"hAA" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hAC" = (
 /obj/structure/bars,
 /turf/open/water/river{
@@ -13672,6 +13648,16 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"hAD" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "hAN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -13694,12 +13680,34 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"hBU" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hCu" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"hCF" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "hCL" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -13724,22 +13732,20 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"hDv" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hDP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "velder"
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"hDQ" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hDT" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/clothing/shoes/roguetown/nobleboot,
@@ -13811,25 +13817,9 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"hFZ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hGf" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves)
-"hGm" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "hGn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
@@ -13843,19 +13833,15 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"hGF" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"hGH" = (
-/obj/structure/table/wood{
+"hGP" = (
+/obj/structure/fluff/railing/wood{
 	dir = 1;
-	icon_state = "longtable_mid"
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hGU" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -13871,22 +13857,6 @@
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
-"hHm" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"hHz" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hHF" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -13928,6 +13898,14 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"hIG" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "hIN" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/churchbrick,
@@ -13974,13 +13952,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"hJY" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "hKq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -13989,14 +13960,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"hKx" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -14026,12 +13989,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"hLC" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "hLK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/rtfield)
@@ -14144,6 +14101,19 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"hPo" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "hPx" = (
 /obj/structure/fluff/statue/answer{
 	color = null;
@@ -14155,6 +14125,13 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"hQd" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hQe" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14232,17 +14209,10 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"hRC" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
+"hRF" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "hRK" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -14251,10 +14221,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"hRM" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "hSf" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile,
@@ -14275,6 +14241,13 @@
 	dir = 1
 	},
 /area/rogue/outdoors/bog)
+"hSF" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "hSK" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -14330,18 +14303,14 @@
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"hVz" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "hVJ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"hVW" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hVZ" = (
 /turf/open/floor/rogue/tile/checkeralt{
 	max_integrity = 99999
@@ -14366,9 +14335,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"hXa" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "hXf" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
@@ -14425,12 +14391,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"hZa" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/garrison)
 "hZe" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/under/roguetown/trou/leather,
@@ -14505,6 +14465,21 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"ibe" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"ibh" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ibW" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -14513,6 +14488,11 @@
 /obj/item/natural/bundle/bone/full,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"ibY" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "icc" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -14617,6 +14597,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ieP" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ieR" = (
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
@@ -14635,9 +14621,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14652,9 +14642,6 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"ifB" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
 "ifM" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -14723,10 +14710,6 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"iiR" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "ijS" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -14736,16 +14719,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -14774,23 +14750,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"ila" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ilm" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -14818,6 +14783,10 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"ilD" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14835,6 +14804,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"ilT" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ime" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -14850,13 +14825,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"imB" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "imV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -14871,6 +14839,15 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"inE" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14886,6 +14863,11 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"ioM" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ioU" = (
 /obj/structure/fermenting_barrel/water,
 /obj/structure/fermenting_barrel/water,
@@ -14900,14 +14882,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
-"ipw" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "ipQ" = (
 /obj/structure/bars/pipe{
 	dir = 9;
@@ -14919,15 +14893,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"iqu" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -14961,6 +14926,10 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"iqW" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iqY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -15010,12 +14979,8 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -15023,8 +14988,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -15049,6 +15015,13 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"iuz" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "iuE" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -15080,15 +15053,29 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ivv" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+"ivi" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
 	},
 /area/rogue/outdoors/town)
+"ivM" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "ivO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -15120,13 +15107,6 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"iwj" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -15154,6 +15134,12 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"ixN" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "iyd" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/church/chapel)
@@ -15357,14 +15343,6 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"iDQ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -15510,16 +15488,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"iIy" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "iIG" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -15533,6 +15501,10 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
+"iIR" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "iJC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -15543,9 +15515,6 @@
 "iJR" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/rtfield)
-"iKn" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
 "iKA" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -15653,9 +15622,8 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -15675,19 +15643,18 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"iNc" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iNk" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/effect/landmark/start/vampthrall,
 /obj/effect/landmark/start/vampthralllate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"iNo" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "iNu" = (
 /obj/structure/bars/passage/shutter/open,
 /obj/structure/bars/pipe,
@@ -15709,6 +15676,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"iNC" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iNE" = (
 /obj/machinery/anomalous_crystal,
 /turf/open/floor/rogue/grass,
@@ -15774,6 +15746,11 @@
 /obj/item/rogueweapon/sword/iron,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"iPA" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "iPB" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -15813,16 +15790,22 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"iQs" = (
-/obj/structure/chair/bench{
+"iRc" = (
+/obj/structure/fluff/railing/wood{
 	dir = 1;
-	icon_state = "bench"
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "iRe" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
@@ -15834,13 +15817,14 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15874,11 +15858,14 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15911,6 +15898,10 @@
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"iVf" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iVi" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -15921,15 +15912,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"iVn" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iVr" = (
 /obj/item/roguemachine/mastermail,
 /obj/structure/closet/crate/drawer{
@@ -15949,6 +15931,13 @@
 /obj/item/kitchen/spoon/plastic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"iVt" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "iVM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -15963,8 +15952,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -16113,14 +16106,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"jaY" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "jbb" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -16148,6 +16133,11 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"jbu" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "jbv" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16295,6 +16285,13 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"jgg" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jgh" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
@@ -16312,25 +16309,9 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"jgy" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
-"jhx" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16388,12 +16369,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"jkm" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "jkv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -16405,6 +16380,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"jkx" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "jkz" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -16421,6 +16404,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jkQ" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"jkU" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jlf" = (
 /obj/structure/stairs{
 	dir = 1
@@ -16450,10 +16447,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
@@ -16461,6 +16455,18 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
+"jmo" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jmv" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -16524,16 +16530,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/church/chapel)
-"jph" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "jpj" = (
 /obj/structure/rack/rogue,
 /obj/item/reagent_containers/glass/cup/silver,
@@ -16555,13 +16551,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16584,6 +16576,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"jqk" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "jqA" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
@@ -16608,6 +16604,11 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"jrP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jrZ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -16655,13 +16656,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"jtq" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "jtN" = (
 /obj/item/clothing/gloves/roguetown/plate/blk,
 /obj/item/rogueweapon/sword/rapier,
@@ -16751,6 +16745,13 @@
 "jxy" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/manor)
+"jxM" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "jxP" = (
 /obj/structure/table/wood,
 /obj/item/restraints/legcuffs/beartrap,
@@ -16760,15 +16761,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"jxX" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "jyb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/metal/barograte,
@@ -16792,12 +16784,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"jyw" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "jyD" = (
 /obj/machinery/light/rogue/oven/south,
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison{
@@ -16812,14 +16798,6 @@
 "jyI" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement)
-"jyO" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "jyT" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -16832,11 +16810,31 @@
 /obj/structure/closet/crate/chest/reward,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"jzh" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "jzy" = (
 /obj/structure/fluff/statue/tdummy,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"jzB" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "jzK" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -16866,6 +16864,13 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"jAQ" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jAV" = (
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
@@ -16873,11 +16878,6 @@
 "jAY" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"jBk" = (
-/obj/structure/fluff/wallclock/l,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "jBv" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -16885,13 +16885,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jCc" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -16900,8 +16893,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "jCs" = (
 /obj/structure/fluff/railing/border{
@@ -16993,8 +16989,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "jEB" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "jEL" = (
 /obj/structure/mineral_door/wood{
@@ -17016,6 +17014,12 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"jFn" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jFF" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/blocks,
@@ -17074,10 +17078,6 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/shop)
-"jHJ" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "jHP" = (
 /obj/effect/landmark/start/vagabondlate,
 /turf/open/floor/rogue/cobblerock,
@@ -17104,8 +17104,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -17128,6 +17129,17 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"jKS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jKW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -17137,6 +17149,18 @@
 "jKY" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/town)
+"jLr" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "jLs" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -17154,10 +17178,6 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"jLL" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jLX" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -17175,10 +17195,11 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -17228,29 +17249,12 @@
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"jNB" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jNC" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17323,12 +17327,6 @@
 	},
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
-"jPD" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/mountains)
 "jPM" = (
 /obj/structure/fluff/railing/border{
@@ -17416,6 +17414,10 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"jSc" = (
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jSp" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/church/chapel)
@@ -17446,12 +17448,6 @@
 "jTP" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
-"jUh" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "jUk" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -17470,6 +17466,15 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
+"jUP" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -17478,6 +17483,16 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
+"jVq" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17487,19 +17502,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"jWz" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+"jWA" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jWH" = (
 /obj/item/rogueweapon/tongs,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -17569,15 +17579,6 @@
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"jYO" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "jYR" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -17617,10 +17618,18 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"jZP" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kad" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "kan" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/mineral_door/bars{
@@ -17710,20 +17719,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"kdz" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH";
-	pixel_x = 19
-	},
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh2";
-	aportalid = "wh1";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = 18
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "kdM" = (
 /obj/structure/mineral_door/wood{
 	dir = 1;
@@ -17751,15 +17746,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"keM" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "keO" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -17818,9 +17804,11 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"kgb" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
+"kfX" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town)
 "kgj" = (
 /turf/open/floor/rogue/twig,
@@ -17852,13 +17840,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -17947,6 +17933,10 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"kkN" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "kld" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/concrete,
@@ -17959,15 +17949,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"klX" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "kms" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper,
@@ -18006,22 +17987,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"kol" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "kov" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"koJ" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "kpk" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -18051,6 +18020,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kqv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kqI" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree,
@@ -18061,18 +18040,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kqS" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "kqT" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -18169,12 +18136,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -18220,27 +18184,6 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"ktG" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"ktR" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "ktW" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/boss,
 /turf/open/floor/rogue/blocks,
@@ -18281,23 +18224,13 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"kuV" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -18338,16 +18271,16 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"kxw" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/under/cave)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18474,6 +18407,18 @@
 "kBd" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/tavern)
+"kBg" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kBk" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat/goatlet,
 /turf/open/floor/rogue/dirt,
@@ -18537,10 +18482,6 @@
 "kDc" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
-"kDh" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "kDm" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/red,
@@ -18571,16 +18512,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"kDX" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+"kEc" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "kEd" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -18598,6 +18536,13 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"kEv" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "kEB" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -18619,9 +18564,9 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18668,19 +18613,15 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"kGT" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kGY" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
+"kHd" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "kHs" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -18747,6 +18688,10 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
+"kJm" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "kJq" = (
 /obj/structure/fluff/statue/gargoyle/candles{
 	pixel_y = -7
@@ -18773,15 +18718,6 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"kKo" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "kKr" = (
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
@@ -18801,20 +18737,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"kKJ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "kKS" = (
 /obj/structure/mineral_door/bars{
 	lockid = "dungeon"
@@ -18872,12 +18794,6 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"kMA" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "kMG" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -19025,6 +18941,15 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
+"kQl" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "kQN" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
@@ -19071,6 +18996,18 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"kSq" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "kSz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -19108,6 +19045,12 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
+"kTm" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kTn" = (
 /obj/structure/roguemachine/atm{
 	pixel_x = 32;
@@ -19115,13 +19058,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"kTM" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -19156,18 +19092,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"kVq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "kVH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -19316,6 +19240,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"lav" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "lay" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /obj/structure/flora/newleaf,
@@ -19329,17 +19263,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"lbf" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"lbx" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lbB" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/scomstone,
@@ -19366,6 +19289,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lcJ" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "ldf" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -19401,11 +19332,12 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"leM" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
+"leR" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "leV" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -19419,10 +19351,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"lfn" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+"lfb" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -19473,6 +19405,10 @@
 "lgp" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/bog)
+"lgr" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "lgA" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road{
@@ -19503,29 +19439,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"lhi" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "Nelly";
-	health = "1000"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"lhj" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "lhq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
@@ -19569,10 +19490,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"liA" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "liE" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -19636,6 +19553,10 @@
 "lkM" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"lkQ" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lli" = (
 /obj/structure/rogue/trophy/deer,
 /obj/item/natural/rock,
@@ -19736,12 +19657,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -19782,6 +19699,20 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"lpD" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lpG" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/blocks,
@@ -19802,6 +19733,16 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"lqf" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -19823,21 +19764,19 @@
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"lsb" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lsc" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"lsi" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lsD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19846,13 +19785,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"lsW" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "lsX" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -19879,14 +19811,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"ltL" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "ltM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/rtfield)
@@ -19929,6 +19853,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"luX" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "lvr" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19941,6 +19872,17 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"lwa" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lwu" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/cobweb,
@@ -20053,6 +19995,16 @@
 "lAb" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/manor)
+"lAg" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "lAs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/church/chapel)
@@ -20117,14 +20069,6 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"lCN" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "lCO" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -20227,10 +20171,11 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "lGI" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
@@ -20281,10 +20226,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"lIu" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"lIF" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "lIH" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile{
@@ -20315,6 +20262,20 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"lJI" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"lJL" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "lJO" = (
 /obj/structure/table/wood{
@@ -20349,15 +20310,19 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lKl" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "lKn" = (
 /obj/item/clothing/head/peaceflower,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"lKw" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
@@ -20390,15 +20355,21 @@
 	},
 /area/rogue/under/town/basement)
 "lLK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/effect/landmark/start/druid,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"lMg" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lMD" = (
 /obj/item/natural/rock,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -20433,16 +20404,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
-"lOp" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lOz" = (
 /obj/structure/mineral_door/bars{
 	lockid = "graveyard"
@@ -20479,13 +20440,15 @@
 "lPu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"lPG" = (
-/obj/structure/stairs{
-	dir = 4
+"lPz" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "lPQ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20539,16 +20502,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"lSG" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
-"lSO" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "lTj" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp/deep,
@@ -20663,9 +20616,24 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
+"lYb" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
+"lYi" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lYl" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -20696,22 +20664,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"lYH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"lYS" = (
-/obj/item/paper{
-	name = "HIT THINE BELL";
-	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "lYU" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/herringbone,
@@ -20738,6 +20690,27 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"lZw" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"lZG" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "mab" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
@@ -20750,19 +20723,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"mah" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "maw" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/mountains)
+"maz" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "maA" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/carpet,
@@ -20774,22 +20744,23 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"maZ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
+"maO" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"mbd" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mbm" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"mbs" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -20799,6 +20770,22 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"mbZ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
+"mck" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "mcm" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter)
@@ -20838,14 +20825,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"mdt" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mdw" = (
 /obj/item/ingot/iron,
 /obj/item/ingot/iron,
@@ -20855,9 +20834,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20879,15 +20863,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"mdO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "mdX" = (
 /obj/structure/stairs{
 	dir = 8
@@ -20948,10 +20923,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
-"mfi" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "mfl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -20965,19 +20936,6 @@
 /obj/item/natural/rock/iron,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/tribalfort)
-"mfo" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "mfK" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician)
@@ -21020,14 +20978,6 @@
 /obj/item/chair/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"mhS" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mic" = (
 /obj/structure/mineral_door/wood/red{
 	lockid = "graveyard"
@@ -21043,14 +20993,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"mis" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "miD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -21083,11 +21025,11 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -21139,20 +21081,22 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"mlp" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mlJ" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"mlO" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
+"mma" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "mmb" = (
 /obj/machinery/anvil,
 /turf/open/floor/rogue/blocks,
@@ -21166,23 +21110,20 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"mmm" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "mmt" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"mnP" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21267,6 +21208,15 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"mpG" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mpP" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -21284,20 +21234,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"mqN" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "mrl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21346,10 +21282,6 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"msL" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "msM" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -21359,11 +21291,13 @@
 	},
 /area/rogue/indoors)
 "msY" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -21391,6 +21325,10 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"mua" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "mun" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -21434,16 +21372,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"mvx" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "mwd" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/grass,
@@ -21452,11 +21380,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"mwy" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "mwz" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -21493,11 +21416,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"mxs" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "mxx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt/road{
@@ -21539,6 +21457,13 @@
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mzc" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "mzk" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -21553,6 +21478,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"mzs" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mzx" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -21561,6 +21492,16 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"mzL" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mzM" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf/big,
@@ -21569,6 +21510,16 @@
 "mzZ" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"mAD" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mAM" = (
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -21670,14 +21621,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"mFp" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+"mFB" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "mFC" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -21687,23 +21636,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"mFE" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
-"mFF" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "mFJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -21768,25 +21700,33 @@
 	},
 /area/rogue/outdoors/rtfield)
 "mHT" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"mJj" = (
 /obj/structure/mineral_door/wood{
 	lockid = "mansionvampire";
 	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
-"mIn" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -21846,9 +21786,25 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"mLH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"mMp" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mMv" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
@@ -21934,14 +21890,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mPb" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "mPf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -21978,25 +21926,35 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"mQd" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mQq" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+/obj/structure/bookcase/random{
+	desc = s
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "mQA" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"mQF" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -22015,12 +21973,23 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"mRU" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mRW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"mSn" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "mSs" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks,
@@ -22032,14 +22001,19 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"mSy" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "mSD" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"mSE" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mSG" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/chair/bench{
@@ -22088,6 +22062,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"mUt" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mUB" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -22104,6 +22088,15 @@
 "mVa" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
+"mVd" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mVe" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/grass,
@@ -22114,12 +22107,16 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -22141,6 +22138,10 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
+"mWk" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mWx" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -22175,10 +22176,6 @@
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"mXh" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
 "mXi" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -22219,30 +22216,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"mYI" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "mYJ" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"mYM" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "mZo" = (
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
@@ -22327,16 +22304,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"nbK" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22422,6 +22389,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nep" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "ner" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/tile{
@@ -22445,18 +22423,25 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"nff" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"nfz" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nfI" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
+"nfY" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22470,6 +22455,13 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"nhm" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nht" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/cobblerock,
@@ -22481,7 +22473,11 @@
 /area/rogue/indoors/town/vault)
 "nhR" = (
 /turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/basement)
+/area/rogue/outdoors/rtfield)
+"nhT" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22532,21 +22528,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"njN" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"nke" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "The Erlking";
-	health = 1500
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22572,6 +22553,14 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"nlx" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "nlG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -22640,6 +22629,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"nnZ" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "noi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22736,9 +22729,12 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
 "nrx" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nrD" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/cobble,
@@ -22757,16 +22753,6 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"nsu" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "nsE" = (
 /obj/structure/roguetent,
 /obj/effect/decal/cleanable/dirt,
@@ -22806,6 +22792,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"nuC" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nuD" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
@@ -22825,9 +22818,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -22847,12 +22839,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"nvP" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "nvS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -22868,9 +22854,12 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"nwj" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
+"nwk" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "nwo" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -22926,6 +22915,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"nxo" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "nxr" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder/c,
@@ -22996,13 +22989,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"nyu" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "nyz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23054,6 +23040,14 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"nAQ" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "nAS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -23069,17 +23063,22 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"nBk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -23109,27 +23108,10 @@
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"nCd" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"nCo" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "nCN" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -23206,6 +23188,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nGi" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "nGw" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -23237,20 +23225,16 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"nGT" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nGV" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
-"nGY" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "nHb" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23278,6 +23262,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"nIl" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "nIo" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -23310,6 +23300,14 @@
 /obj/structure/bars/tough,
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
+"nIN" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nIQ" = (
 /obj/effect/landmark/start/mercenary{
 	dir = 4
@@ -23324,23 +23322,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"nJR" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
 "nJX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -23424,6 +23413,15 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"nMD" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "nMS" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -23473,10 +23471,6 @@
 /obj/structure/fluff/littlebanners/bluewhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"nOR" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "nOX" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23494,9 +23488,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23588,10 +23581,11 @@
 /obj/structure/statue/saints/magelady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"nRU" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"nRG" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nRW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -23604,11 +23598,17 @@
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"nSr" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
+"nSg" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"nSr" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
@@ -23618,14 +23618,12 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
-"nSF" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+"nSL" = (
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nSS" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -23656,13 +23654,9 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23723,6 +23717,12 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"nVG" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "nVU" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -23734,29 +23734,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
-"nWm" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
-"nWq" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"nWr" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "nWB" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -23852,10 +23829,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"nYl" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "nYp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -23899,12 +23872,31 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"nZq" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nZt" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/spear/billhook,
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nZy" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "nZQ" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -23929,10 +23921,8 @@
 /area/rogue/indoors)
 "obq" = (
 /obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23947,13 +23937,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town/roofs)
-"obJ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "obL" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -24085,6 +24068,17 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"ofT" = (
+/obj/structure/mineral_door/wood{
+	dir = 4;
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "ogh" = (
 /obj/structure/flora/newtree,
 /turf/closed/mineral/rogue/salt,
@@ -24106,15 +24100,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"ogB" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ogC" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -24180,6 +24177,10 @@
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"oiw" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oiC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
@@ -24189,15 +24190,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24205,15 +24200,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"oiW" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ojc" = (
 /obj/structure/fluff/railing/wood,
 /obj/machinery/light/rogue/torchholder/r,
@@ -24232,12 +24218,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"ojS" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -24270,13 +24250,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"oll" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "olD" = (
 /turf/open/floor/grass/snow{
 	icon_state = "ice"
@@ -24326,11 +24299,6 @@
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
-"omP" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "one" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -24346,13 +24314,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
-"onB" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "onM" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
@@ -24398,6 +24359,21 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"opC" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "opG" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/carpet/lord/right,
@@ -24536,6 +24512,16 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"oum" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ous" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -24549,13 +24535,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -24615,12 +24599,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"oxf" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
+"oxe" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oxk" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -24696,20 +24684,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"oza" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "oze" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/grass,
@@ -24777,11 +24751,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"oAH" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "oAZ" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -24814,14 +24783,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"oBD" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -24829,13 +24790,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"oBZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oCf" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/shelter)
@@ -24859,11 +24813,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"oCS" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oCW" = (
 /obj/structure/composter/full,
 /turf/open/floor/rogue/dirt/road,
@@ -24943,6 +24892,12 @@
 /obj/effect/decal/remains/bigrat,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"oFQ" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "oFR" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/hexstone,
@@ -24960,6 +24915,16 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oGl" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "oGv" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/effect/landmark/start/tribalcook,
@@ -24973,6 +24938,13 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
+"oGN" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oGU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/closed/mineral/rogue,
@@ -25027,17 +24999,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"oIC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
 "oIY" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -25065,16 +25029,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "oJO" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
 	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -25082,6 +25041,10 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"oKh" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "oKo" = (
 /obj/item/roguecoin/copper,
 /turf/open/water/swamp,
@@ -25096,11 +25059,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"oKT" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "oLb" = (
 /obj/structure/stairs{
 	dir = 1
@@ -25122,9 +25080,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -25214,10 +25172,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"oOS" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oOU" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25230,6 +25184,24 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"oPr" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oPv" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -25267,6 +25239,17 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
+"oQC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "oQZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/closed/mineral/rogue,
@@ -25294,10 +25277,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -25327,6 +25311,11 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"oRV" = (
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "oSb" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood,
@@ -25337,6 +25326,9 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"oSm" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "oSy" = (
 /obj/structure/rack/rogue,
 /obj/item/ingot/iron,
@@ -25371,10 +25363,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
-"oTK" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oUc" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -25398,13 +25386,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"oUR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+"oUF" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "oUS" = (
 /obj/structure/roguewindow/openclose{
@@ -25459,12 +25446,6 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"oVO" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "oVT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -25706,6 +25687,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"pcn" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "pct" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -25742,8 +25733,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"pcO" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pcQ" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "pcX" = (
@@ -25759,9 +25756,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -25832,6 +25831,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pfz" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "pfA" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/blocks/stonered,
@@ -25843,17 +25846,6 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"pfG" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "pfN" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
@@ -25876,6 +25868,24 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"pgU" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"pgX" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "phk" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguegem/green,
@@ -25884,6 +25894,11 @@
 "pht" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town)
+"phJ" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "phR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25948,9 +25963,14 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "pjB" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "pjC" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -25973,10 +25993,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"pka" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "pkj" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
@@ -26016,12 +26032,29 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"pmC" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
+"pmE" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "pmF" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/mince,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"pnd" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "pnl" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/bog,
@@ -26056,6 +26089,18 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pnp" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"pns" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pnD" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -26067,21 +26112,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"pnL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "pog" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
@@ -26212,6 +26242,14 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"prX" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "prZ" = (
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
@@ -26223,6 +26261,10 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"psB" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "psH" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26252,6 +26294,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"ptC" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ptK" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
@@ -26261,6 +26310,10 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors)
+"ptS" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "ptT" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -26292,13 +26345,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"puv" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -26349,11 +26395,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"pwH" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "pwQ" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/dirt,
@@ -26363,13 +26404,6 @@
 /obj/effect/landmark/start/tribalvillager,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"pwX" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "pxi" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/wood,
@@ -26408,6 +26442,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"pxZ" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "pyh" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -26422,14 +26461,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"pyz" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "pyB" = (
 /obj/item/shard,
 /turf/open/floor/rogue/cobble,
@@ -26466,6 +26497,16 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pzt" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "pzu" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -26497,14 +26538,6 @@
 "pAa" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
-"pAd" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "pAg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -26539,6 +26572,13 @@
 "pAV" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
+"pAX" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pBj" = (
 /mob/living/carbon/human/species/halforc/orc_raider/savage_orc/ambush,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26595,12 +26635,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
-"pDt" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bull,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "pDy" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -26658,14 +26692,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"pEp" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "pEC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -26673,6 +26699,10 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pFL" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26715,6 +26745,16 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"pHA" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "pHI" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile{
@@ -26754,13 +26794,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"pIO" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "pJa" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -26797,16 +26830,23 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"pKN" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
+"pKE" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
 	dir = 4
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "pKQ" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -26848,10 +26888,6 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
-"pLU" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "pMi" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
@@ -26865,10 +26901,14 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
@@ -26887,15 +26927,6 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"pML" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "pNd" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/rooftop{
@@ -26964,22 +26995,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"pOH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"pOL" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3";
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "pOO" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood,
@@ -26987,19 +27002,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"pOS" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"pPj" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "pPq" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "nobleguest"
@@ -27055,6 +27057,33 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"pQO" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
+"pQS" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pRj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -27065,6 +27094,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"pRL" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "pRO" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -27100,14 +27136,6 @@
 "pSB" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
-"pSO" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
 /area/rogue/indoors/town/garrison)
 "pSS" = (
 /obj/structure/fluff/statue/knight/interior/r,
@@ -27193,10 +27221,6 @@
 /obj/item/quiver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"pUH" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "pVg" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27216,12 +27240,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"pWl" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -27247,10 +27265,6 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
-"pWL" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "pWP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -27310,33 +27324,21 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
-"pYt" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "pYO" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"pYW" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"pYU" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "pZq" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -27456,6 +27458,10 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"qcZ" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "qda" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -27491,13 +27497,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"qdC" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "qdG" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -27525,16 +27524,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
+/turf/closed/mineral/rogue,
 /area/rogue/outdoors/town/roofs)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -27571,14 +27561,6 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"qfJ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "qfL" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/grass,
@@ -27596,12 +27578,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"qgY" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "qhg" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -27654,6 +27630,22 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"qir" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -27682,6 +27674,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"qjb" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qjd" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -27773,6 +27770,13 @@
 /obj/item/roguekey/garrison,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"qlL" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qlO" = (
 /obj/structure/stairs{
 	dir = 4
@@ -27783,23 +27787,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qmo" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"qmh" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "qmx" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
@@ -27876,10 +27867,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"qoJ" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27912,10 +27899,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qpS" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "qpT" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -27930,11 +27913,16 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
 /obj/structure/fluff/railing/wood{
-	pixel_y = -4
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -28006,12 +27994,6 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
-"qrm" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qrn" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1;
@@ -28035,6 +28017,12 @@
 "qrN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"qrV" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "qse" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/remains/human,
@@ -28046,6 +28034,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qsC" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qsI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -28083,11 +28083,6 @@
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
-"qtL" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "qtT" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -28125,9 +28120,18 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"quP" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -28158,6 +28162,10 @@
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"qvs" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "qvt" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -28184,22 +28192,20 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/obj/structure/fluff/wallclock/r,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"qwC" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qwD" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/rogue/naturalstone,
@@ -28224,6 +28230,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"qxn" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "qxH" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/structure/spider/stickyweb,
@@ -28239,29 +28252,6 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors/town/garrison)
-"qye" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"qyk" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"qyo" = (
-/obj/structure/table/vtable/v2,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "qyz" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road{
@@ -28291,24 +28281,15 @@
 	},
 /area/rogue/outdoors/bog)
 "qzy" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
-	},
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"qzN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -28335,9 +28316,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qAq" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "qBk" = (
 /obj/structure/stairs{
 	dir = 4
@@ -28371,6 +28349,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qCM" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qCN" = (
 /obj/structure/stairs{
 	dir = 1
@@ -28378,28 +28360,20 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
 	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
-"qCY" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -28422,23 +28396,10 @@
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
-"qEM" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "qEY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
-"qFo" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "qFu" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -28461,17 +28422,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"qGj" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -28508,15 +28461,6 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"qHy" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "qHC" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks,
@@ -28578,13 +28522,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/water/swamp,
 /area/rogue/indoors)
-"qKm" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "qKo" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood,
@@ -28599,17 +28536,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"qKY" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28637,13 +28566,9 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
 "qLF" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
+/obj/structure/roguewindow/stained/silver,
 /obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/chapel)
 "qLP" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -28663,6 +28588,12 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"qMC" = (
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
@@ -28708,11 +28639,6 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"qPE" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "qPH" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
@@ -28737,13 +28663,16 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"qPO" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+"qQb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qQd" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -28753,11 +28682,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"qQu" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -28777,10 +28701,15 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "qRp" = (
-/turf/open/floor/rogue/herringbone,
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
@@ -28791,6 +28720,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qRW" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qSc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/churchmarble,
@@ -28834,15 +28770,12 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"qTo" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
+"qTw" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "qTL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "archive"
@@ -28853,21 +28786,22 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"qUs" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
+"qUi" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
-"qUD" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "qUE" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -28925,6 +28859,15 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"qXw" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -28948,6 +28891,22 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/bog)
+"qYf" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
+"qYi" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qYl" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
@@ -28969,8 +28928,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -28994,13 +28957,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"qZr" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "qZw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -29019,10 +28975,6 @@
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
-"raJ" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "raL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -29085,10 +29037,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"rck" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -29096,18 +29044,24 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"rcS" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rcU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -29212,13 +29166,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/fluff/railing/stonehedge{
 	dir = 4
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -29248,12 +29201,11 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -29274,6 +29226,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"rhx" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "rhD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -29283,12 +29239,11 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"rhG" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
+"rhI" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "rhJ" = (
 /obj/structure/rogue/trophy/deer,
@@ -29326,10 +29281,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"riW" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "rjg" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -29376,6 +29327,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"rkK" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rkT" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -29438,6 +29397,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"rmO" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rnf" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "lord";
@@ -29525,22 +29488,6 @@
 "rqd" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"rqg" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "rqh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -29550,16 +29497,17 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"rqj" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "rqm" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"rqw" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "rqP" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29604,6 +29552,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rrL" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "rrP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -29620,14 +29576,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"rrX" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "rsb" = (
 /obj/structure/glowshroom,
 /turf/open/water/sewer,
@@ -29665,6 +29613,15 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"rsS" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "rta" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -29673,13 +29630,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"rtw" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "rtB" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -29707,6 +29657,16 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"ruC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "ruI" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -29717,11 +29677,10 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
-"rvA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"rvY" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29780,13 +29739,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
-"rwX" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rwY" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -29852,12 +29804,6 @@
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
-"rzh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "rzq" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -29888,10 +29834,6 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"rAj" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "rAz" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
@@ -29935,19 +29877,6 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"rCp" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "rCL" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -29976,6 +29905,12 @@
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"rDI" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -30062,25 +29997,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"rGv" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"rGG" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
 "rGQ" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -30089,32 +30005,34 @@
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"rGS" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "rGY" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"rHi" = (
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/tavern)
-"rHj" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"rHr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/area/rogue/outdoors/town)
+"rHi" = (
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/tavern)
+"rHj" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"rHJ" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -30125,6 +30043,15 @@
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"rIj" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "rIl" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 8
@@ -30197,6 +30124,24 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"rKB" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
+"rKK" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "rKQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -30251,9 +30196,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
-"rMO" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
 "rNg" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -30305,11 +30247,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"rOz" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "rOF" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/bog)
@@ -30319,14 +30256,14 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
-"rPu" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+"rPa" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rPE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -30393,12 +30330,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30412,9 +30346,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "rSc" = (
@@ -30424,6 +30356,10 @@
 "rSg" = (
 /obj/structure/chair/bench/church{
 	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -30439,17 +30375,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"rSH" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
 "rSK" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -30482,6 +30407,10 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"rSZ" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rTm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/fluff/statue/tdummy,
@@ -30580,6 +30509,13 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"rWb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "rWj" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -30609,12 +30545,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"rXe" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "rXl" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -30635,6 +30565,15 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"rXq" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "rXE" = (
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
@@ -30743,11 +30682,9 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"saz" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
+"saN" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "saS" = (
 /obj/structure/chair/wood/rogue{
@@ -30769,9 +30706,9 @@
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
 /obj/structure/fluff/railing/wood{
-	dir = 4
+	pixel_y = -4
 	},
-/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "scd" = (
@@ -30884,11 +30821,17 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -30912,21 +30855,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"sfZ" = (
-/obj/structure/table/vtable,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"sge" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "sgi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -30993,6 +30921,14 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"shH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "shV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -31037,6 +30973,14 @@
 /obj/structure/bars/tough,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
+"sjf" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sjo" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -31076,14 +31020,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"skh" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "skn" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -31104,34 +31040,12 @@
 	},
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
-"slh" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sls" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"slt" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"slz" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "slS" = (
 /obj/item/clothing/shoes/roguetown/boots/armoriron,
 /turf/open/floor/rogue/dirt/road{
@@ -31312,12 +31226,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"sqi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sqm" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/grass,
@@ -31371,12 +31279,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"ssk" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ssz" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
@@ -31399,6 +31301,13 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/outdoors/beach)
+"ste" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "stv" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31441,10 +31350,12 @@
 	},
 /area/rogue/outdoors/beach)
 "suN" = (
-/obj/structure/chair/wood/rogue{
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "suY" = (
 /obj/structure/fluff/railing/border{
@@ -31454,6 +31365,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"svk" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "svx" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -31485,12 +31402,6 @@
 "swm" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"swn" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "swu" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
@@ -31510,20 +31421,15 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"sxm" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "sxp" = (
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -31577,13 +31483,6 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"szF" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "szM" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
@@ -31595,12 +31494,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"szQ" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "szV" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks,
@@ -31610,15 +31503,6 @@
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"sAp" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "sAy" = (
 /obj/structure/bars/cemetery,
 /obj/structure/bars/cemetery,
@@ -31667,6 +31551,14 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
+"sCc" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sCg" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -31675,6 +31567,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"sCQ" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sCU" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -31707,13 +31603,6 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"sEX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "sFe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger/steel,
@@ -31841,9 +31730,16 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -31859,6 +31755,10 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"sJs" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "sJZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -31895,12 +31795,6 @@
 /obj/item/roguekey/walls,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"sKY" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sLb" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig,
@@ -31934,12 +31828,6 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"sNn" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
 "sNp" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -31971,6 +31859,11 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
+"sOE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "sPj" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt,
@@ -32009,15 +31902,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"sQo" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+"sQb" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -32040,6 +31928,10 @@
 /obj/item/reagent_containers/powder,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
+"sSB" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "sSC" = (
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -32168,6 +32060,12 @@
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sWs" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "sWL" = (
 /obj/effect/landmark/start/squire{
 	dir = 4
@@ -32189,6 +32087,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"sXe" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
@@ -32208,6 +32110,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"sYk" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "sYw" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
@@ -32250,6 +32156,14 @@
 "sZN" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"sZX" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "tag" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -32257,8 +32171,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -32266,10 +32180,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"tar" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
 "tat" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -32374,15 +32284,6 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"tdl" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "tdz" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -32447,9 +32348,15 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -32472,15 +32379,6 @@
 "tgZ" = (
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"tha" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "thM" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -32510,14 +32408,10 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "tiv" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tiB" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -32526,8 +32420,14 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -32562,16 +32462,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"tjt" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "tjU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/flail/sflail,
@@ -32639,6 +32529,13 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"tli" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -32646,10 +32543,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/mountains)
 "tlX" = (
 /obj/structure/table/wood{
@@ -32732,6 +32626,19 @@
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
+"tpw" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32777,14 +32684,6 @@
 /obj/structure/roguemachine/money/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"trg" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "trv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "royal";
@@ -32970,6 +32869,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"txe" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "txg" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /obj/structure/flora/roguegrass/water,
@@ -32977,6 +32880,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"txq" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "txC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -32990,6 +32901,29 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"txG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"txH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
+"txK" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "txR" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
@@ -33043,13 +32977,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tzn" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
 "tzy" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -33191,7 +33118,8 @@
 	},
 /area/rogue/outdoors/beach)
 "tCz" = (
-/turf/open/floor/rogue/churchrough,
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
@@ -33267,6 +33195,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tET" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tEU" = (
 /obj/structure/fluff/walldeco/stone{
 	pixel_y = 32
@@ -33283,12 +33219,16 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"tFq" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+"tFE" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tFH" = (
 /obj/item/dice,
 /obj/structure/table/wood{
@@ -33305,10 +33245,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"tFU" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "tGd" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -33342,6 +33278,10 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"tHM" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "tHN" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 1;
@@ -33407,13 +33347,18 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"tJT" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "tKu" = (
 /obj/structure/fluff/railing/border{
@@ -33427,12 +33372,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tKP" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/clothing/ring/dragon_ring,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tKW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -33446,6 +33385,10 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"tLN" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -33457,10 +33400,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"tMh" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "tMk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -33555,21 +33494,9 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"tOv" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
-"tOG" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "tOM" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -33599,6 +33526,15 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"tQQ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33611,6 +33547,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"tRN" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "tRV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -33619,12 +33562,6 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
-"tSr" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "tSx" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/dirt/road{
@@ -33644,12 +33581,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"tTl" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "tTF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -33682,32 +33613,27 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
+"tUh" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "tUp" = (
-/turf/closed/mineral/rogue,
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"tUB" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "tUO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -33783,18 +33709,41 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"tXm" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "tXC" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"tXF" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"tYx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"tYB" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "tYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -33845,15 +33794,23 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"uab" = (
 /obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "uaj" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"uaI" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -33872,12 +33829,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"ubc" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "ubv" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -33912,13 +33863,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"udB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "udC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -33951,6 +33895,10 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
+"uee" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ueD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -34004,15 +33952,17 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"ugc" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ugm" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"ugr" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "ugK" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/torchholder/l,
@@ -34146,14 +34096,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ulg" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"ulj" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ulu" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -34168,12 +34110,27 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"umt" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "umH" = (
 /obj/structure/bars/pipe{
 	dir = 5
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"umK" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "unm" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -34249,14 +34206,6 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"upK" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "upU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/asteroid/elite/broodmother,
 /turf/open/floor/rogue/blocks,
@@ -34278,6 +34227,14 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"uqa" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uqe" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
@@ -34305,9 +34262,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34331,6 +34290,10 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"urY" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "urZ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -34384,12 +34347,6 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
-"utA" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "utB" = (
 /obj/structure/table/wood,
@@ -34468,11 +34425,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "uvu" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34487,13 +34442,20 @@
 "uvF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
-"uwa" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
-"uwd" = (
-/obj/structure/closet/crate/roguecloset,
+"uvQ" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
+"uvR" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
+"uwa" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34530,11 +34492,6 @@
 "uxg" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"uxo" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "uxL" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -34547,19 +34504,19 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -34614,20 +34571,19 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/mountains)
+"uzW" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34732,6 +34688,11 @@
 "uCQ" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves)
+"uCR" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uCV" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/wood,
@@ -34746,8 +34707,13 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -34782,23 +34748,19 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4";
-	pixel_x = 13
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -34819,7 +34781,17 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "uGo" = (
 /obj/structure/mineral_door/wood{
@@ -34830,14 +34802,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"uGq" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uGt" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -34888,24 +34852,12 @@
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
 	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
-"uHm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -34915,6 +34867,20 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"uIi" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
+"uIj" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "uIk" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
@@ -34926,16 +34892,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"uJC" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
+"uKn" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -35004,13 +34969,6 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"uLQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "uLS" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
@@ -35069,6 +35027,12 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"uOt" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -35077,12 +35041,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/magician)
-"uOF" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "uOL" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
@@ -35107,8 +35065,20 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/ruinedwood,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
+"uPd" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
@@ -35121,13 +35091,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"uPA" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uPB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -35152,15 +35115,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"uPY" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "uQp" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -35185,6 +35139,10 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uQG" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uRd" = (
 /obj/structure/bed/rogue/shit/bier,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/corpses,
@@ -35199,10 +35157,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"uRv" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -35224,9 +35178,12 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"uSR" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
+"uSz" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "uSS" = (
 /obj/structure/bars,
@@ -35306,10 +35263,6 @@
 "uVq" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/church/chapel)
-"uVy" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "uVz" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble,
@@ -35344,6 +35297,19 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uWe" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
+"uWv" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "uWE" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
@@ -35412,12 +35378,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"uYr" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/sword/long,
-/obj/item/rogueweapon/mace/steel,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "uYx" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "garrison"
@@ -35528,6 +35488,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"vbQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"vbR" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "vce" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -35552,17 +35521,10 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"vde" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "vdg" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -35576,13 +35538,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town)
-"vdx" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "vdX" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -35597,6 +35552,10 @@
 "veg" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
+"veh" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vey" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/oat,
@@ -35637,12 +35596,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"veT" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "veV" = (
 /obj/structure/roguerock{
 	desc = "A rock protuding from the ground. This one bares the sign of Dendor."
@@ -35650,8 +35603,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35665,13 +35622,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"vfw" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "vfH" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -35704,7 +35654,7 @@
 	dir = 1;
 	icon_state = "border"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vgZ" = (
@@ -35771,13 +35721,8 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"vjb" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vjs" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/town)
 "vjx" = (
 /obj/structure/ladder,
@@ -35805,6 +35750,12 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vkl" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "vkI" = (
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35815,15 +35766,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"vkW" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "vkY" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -35934,15 +35876,23 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"vpo" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vpu" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36018,21 +35968,6 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"vrP" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
-"vsb" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vse" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/iron/messer,
@@ -36051,13 +35986,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -36172,36 +36105,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"vvk" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
-"vvB" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "vvJ" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/dirt,
@@ -36232,6 +36135,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"vwi" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "vwl" = (
 /obj/structure/stairs{
 	dir = 8
@@ -36255,11 +36162,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/indoors/town/church/chapel)
-"vxl" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "vxA" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood,
@@ -36401,18 +36303,13 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"vBo" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+"vBk" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/area/rogue/indoors/town)
-"vBG" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
+/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
@@ -36451,14 +36348,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"vCy" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "vCD" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -36475,12 +36364,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"vCY" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+"vCX" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vDa" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/woodturned,
@@ -36492,10 +36384,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"vDn" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "vDp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -36530,6 +36418,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vDP" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "vDS" = (
 /obj/structure/bars/pipe,
 /obj/item/roguegem/random,
@@ -36543,6 +36437,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"vEe" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vEn" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -36559,10 +36460,6 @@
 /obj/structure/statue/saints/magelady2_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"vEP" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "vEQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -36594,8 +36491,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -36614,15 +36514,17 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
-"vGQ" = (
-/obj/machinery/light/rogue/forge{
-	pixel_x = -1
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"vGQ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "vGT" = (
 /obj/structure/spacevine,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -36633,18 +36535,15 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"vHJ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "vIa" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
@@ -36672,6 +36571,12 @@
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"vJg" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vJt" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36679,6 +36584,10 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
+"vJN" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "vJU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -36706,9 +36615,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -36745,14 +36654,14 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "vMQ" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vMT" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -36771,6 +36680,13 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"vNu" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vNv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -36816,12 +36732,12 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -36863,10 +36779,16 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36878,10 +36800,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"vRB" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "vRF" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
@@ -36950,16 +36868,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
-"vTj" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vTm" = (
 /obj/structure/fluff/statue/knight/r{
 	desc = "The statue seems out of place and in mid-charge as if it were a true warrior and frozen in place.";
@@ -36981,11 +36889,8 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -37013,12 +36918,6 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"vVR" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "vWa" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -37045,13 +36944,6 @@
 /obj/structure/mineral_door/secret/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vWm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vWn" = (
 /obj/structure/plasticflaps,
 /turf/closed/mineral/rogue,
@@ -37074,9 +36966,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -37108,21 +37002,30 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
+"vYb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"vYh" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vYw" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors)
-"vYx" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "vYF" = (
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37138,6 +37041,13 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"vYZ" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -37184,10 +37094,6 @@
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"waG" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "waI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -37243,9 +37149,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"wcu" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "wcx" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -37323,10 +37226,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"wfK" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wfY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper/scroll,
@@ -37334,14 +37233,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "wgn" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37355,6 +37250,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"wgG" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wgO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/silver,
@@ -37414,6 +37316,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wki" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
@@ -37481,6 +37389,10 @@
 "wnd" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"wnq" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wnv" = (
 /obj/structure/roguewindow,
 /obj/structure/bars,
@@ -37501,25 +37413,21 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"wos" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "wou" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37547,9 +37455,13 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -37599,12 +37511,10 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -37618,6 +37528,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"wsV" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37628,14 +37545,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "wte" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wtl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -37668,6 +37584,14 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wuX" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wve" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
@@ -37723,25 +37647,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
-"wwz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -37767,6 +37672,14 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wya" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "wyr" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/soil,
@@ -37775,11 +37688,13 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -37792,6 +37707,12 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"wzc" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -37855,6 +37776,12 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"wBt" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wBw" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -37886,6 +37813,13 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wBY" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wCg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -37904,6 +37838,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"wCF" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wCP" = (
 /obj/effect/landmark/start/prisonerc,
 /turf/open/floor/rogue/dirt/road{
@@ -37942,7 +37880,10 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
@@ -37950,12 +37891,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37997,9 +37938,15 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
+"wFq" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "wFQ" = (
@@ -38053,17 +38000,23 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"wHm" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
-"wHL" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6";
-	pixel_x = 9
+"wHS" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -38121,16 +38074,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wKf" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wKh" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -38183,13 +38126,6 @@
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
-"wLB" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
 "wLL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -38242,11 +38178,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"wMv" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
 "wNb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bog)
@@ -38275,6 +38206,13 @@
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
+"wOO" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -38329,11 +38267,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"wPz" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "wPC" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -38420,11 +38353,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -38440,10 +38370,30 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"wTe" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "wTs" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -38466,11 +38416,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38479,14 +38430,6 @@
 /obj/structure/crabnest,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"wUA" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wUP" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/acolyte_alt,
@@ -38501,24 +38444,17 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
-"wVx" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "wVy" = (
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
+"wVA" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wVI" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wVL" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "wWC" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -38566,17 +38502,18 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wXW" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "wYk" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"wYp" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "wYt" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -38586,8 +38523,11 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38626,12 +38566,12 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38672,12 +38612,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "priest"
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38686,13 +38625,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"xcg" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "xck" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -38733,9 +38665,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38763,6 +38694,12 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xeT" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xff" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -38834,6 +38771,17 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"xhv" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "xhw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -38916,6 +38864,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"xiY" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "xjl" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
@@ -38964,15 +38922,8 @@
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -38984,12 +38935,6 @@
 "xkK" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"xkR" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xkS" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -39013,6 +38958,28 @@
 "xlm" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"xlp" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "xlx" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39020,13 +38987,6 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"xlI" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "xmn" = (
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/wood,
@@ -39092,6 +39052,14 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"xnP" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "xnQ" = (
 /obj/structure/chair/bench/church/mid{
 	dir = 1
@@ -39156,6 +39124,13 @@
 /obj/item/clothing/suit/roguetown/armor/leather/hide,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"xoZ" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "xpj" = (
 /obj/structure/statue/saints/cephine,
 /turf/open/floor/rogue/blocks,
@@ -39176,11 +39151,9 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -39218,8 +39191,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "xrf" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -39279,10 +39252,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"xto" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "xtq" = (
 /obj/structure/stairs{
 	dir = 8
@@ -39293,10 +39262,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
-"xtu" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "xtw" = (
 /obj/structure/stairs{
 	dir = 4
@@ -39320,6 +39285,10 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"xue" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "xuh" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -39352,6 +39321,16 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
+"xvn" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "xvs" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -39401,12 +39380,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/under/cave)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39511,16 +39488,17 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"xyM" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "xzi" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"xzK" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xzN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road{
@@ -39543,12 +39521,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -39689,6 +39668,15 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/beach)
+"xDg" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "xDi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
@@ -39696,11 +39684,6 @@
 "xDn" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
-"xDC" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "xDJ" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -39737,16 +39720,17 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xEP" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "xET" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"xFf" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39828,11 +39812,12 @@
 /area/rogue/outdoors/town)
 "xHe" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 5;
+	icon_state = "border"
 	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39877,6 +39862,15 @@
 /obj/item/rope,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"xIo" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "xID" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -39888,18 +39882,18 @@
 /obj/effect/landmark/start/guardsman,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"xIT" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "xJe" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39922,6 +39916,11 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"xKj" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "xKx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -39935,6 +39934,13 @@
 "xKz" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
+"xKA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xKF" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/church/chapel)
@@ -40172,6 +40178,19 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"xSj" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "xSG" = (
 /obj/effect/landmark/start/shepherd,
 /turf/open/floor/rogue/tile,
@@ -40263,10 +40282,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"xUO" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "xUQ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -40395,6 +40410,16 @@
 "xYz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"xYI" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xYM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -40517,15 +40542,11 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/outdoors/mountains)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -40550,6 +40571,15 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
+"yej" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "yer" = (
 /obj/structure/bars/passage/shutter,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -40697,20 +40727,21 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"yif" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "yiw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/rtfield)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -40737,23 +40768,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
@@ -40802,32 +40821,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"ykZ" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"ylg" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ylk" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -183622,18 +183615,18 @@ bpD
 bpD
 bpD
 bpD
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
 bpD
 bpD
 bpD
@@ -184024,7 +184017,7 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
 sYw
 sYw
@@ -184034,8 +184027,8 @@ sYw
 sYw
 sYw
 sYw
-lGI
-lGI
+xwi
+xwi
 bpD
 bpD
 bpD
@@ -184426,21 +184419,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
+aev
+aev
+aev
+aev
+aev
+aev
+aev
 sYw
-lGI
-lGI
-lGI
-lGI
-lGI
+xwi
+xwi
+xwi
+xwi
+xwi
 bpD
 bpD
 bpD
@@ -184828,21 +184821,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-adK
-bVa
-bVa
-aPR
-adK
-pKQ
-sYw
-sYw
+aev
+ijU
+vUf
+vUf
+cBG
+ijU
+aev
 sYw
 sYw
 sYw
-lGI
+sYw
+sYw
+xwi
 bpD
 bpD
 bpD
@@ -185230,21 +185223,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-bVa
-bVa
-aPR
-bVa
-ebe
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
+aev
+vUf
+vUf
+cBG
+vUf
+xpM
+aev
+aev
+aev
+aev
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -185632,21 +185625,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-uLQ
-xHe
-bVa
-bVa
-bVa
-bVa
-bVa
-adK
-pKQ
-pKQ
+aev
+heJ
+dME
+vUf
+vUf
+vUf
+vUf
+vUf
+ijU
+aev
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -186034,21 +186027,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-lGI
-lGI
-fvH
-aAh
-dBX
-bVa
-aPR
-adK
-pKQ
-pKQ
+aev
+xwi
+xwi
+evB
+hhU
+qmh
+vUf
+cBG
+ijU
+aev
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -186436,21 +186429,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-egC
-lGI
-lGI
-rrX
-hjD
-bVa
-lYS
-bVa
-wyA
-pKQ
+aev
+che
+xwi
+xwi
+wte
+eEA
+vUf
+eib
+vUf
+dUC
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -186838,21 +186831,21 @@ bpD
 bpD
 bpD
 bpD
-lGI
+xwi
 sYw
-pKQ
-lSO
-lGI
-lGI
-ekv
-hjD
-eMF
-bVa
-bVa
-wyA
-pKQ
+aev
+gvi
+xwi
+xwi
+prX
+eEA
+aok
+vUf
+vUf
+dUC
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -187240,21 +187233,21 @@ sSS
 sSS
 sSS
 sSS
-lGI
+xwi
 sYw
-pKQ
-lGI
-lGI
-gDF
-bVa
-dBX
-bVa
-aPR
-adK
-pKQ
-pKQ
+aev
+xwi
+xwi
+eqo
+vUf
+qmh
+vUf
+cBG
+ijU
+aev
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -187642,21 +187635,21 @@ sSS
 sSS
 sSS
 sSS
-lGI
+xwi
 sYw
-pKQ
-ksK
-rtw
-bVa
-bVa
-bVa
-bVa
-bVa
-adK
-pKQ
-pKQ
+aev
+xKA
+kEv
+vUf
+vUf
+vUf
+vUf
+vUf
+ijU
+aev
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -188044,21 +188037,21 @@ sSS
 sSS
 sSS
 sSS
-lGI
+xwi
 sYw
-pKQ
-bVa
-bVa
-bVa
-bVa
-ebe
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
+aev
+vUf
+vUf
+vUf
+vUf
+xpM
+aev
+aev
+aev
+aev
+aev
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -188446,21 +188439,21 @@ sSS
 sSS
 sSS
 sSS
-lGI
+xwi
 sYw
-pKQ
-adK
-bUi
-aPR
-aPR
-adK
-pKQ
-sYw
-sYw
+aev
+ijU
+nIN
+cBG
+cBG
+ijU
+aev
 sYw
 sYw
 sYw
-lGI
+sYw
+sYw
+xwi
 bpD
 bpD
 bpD
@@ -188848,21 +188841,21 @@ sSS
 sSS
 sSS
 sSS
-lGI
+xwi
 sYw
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
-pKQ
+aev
+aev
+aev
+aev
+aev
+aev
+aev
 sYw
-lGI
-lGI
-lGI
-lGI
-lGI
+xwi
+xwi
+xwi
+xwi
+xwi
 bpD
 bpD
 bpD
@@ -189250,7 +189243,7 @@ sSS
 sSS
 sSS
 sSS
-lGI
+xwi
 sYw
 sYw
 sYw
@@ -189260,7 +189253,7 @@ sYw
 sYw
 sYw
 sYw
-lGI
+xwi
 bpD
 bpD
 bpD
@@ -189652,17 +189645,17 @@ sSS
 sSS
 sSS
 sSS
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
-lGI
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
+xwi
 bpD
 bpD
 bpD
@@ -202888,15 +202881,15 @@ vRu
 vRu
 vRu
 fjw
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
-nhR
+oSm
+oSm
+oSm
+oSm
+oSm
+oSm
+oSm
+oSm
+oSm
 vup
 iTw
 iTw
@@ -203290,7 +203283,7 @@ vRu
 vRu
 fjw
 fjw
-nhR
+oSm
 txa
 txa
 txa
@@ -206907,8 +206900,8 @@ sYw
 sYw
 sYw
 sYw
-nhR
-nhR
+oSm
+oSm
 txa
 cFQ
 cBf
@@ -227815,7 +227808,7 @@ acD
 acD
 fhw
 acD
-dmj
+ruC
 acD
 acD
 acD
@@ -228218,8 +228211,8 @@ acD
 acD
 acD
 vuH
-xaD
-ikM
+cld
+woq
 acD
 azH
 azH
@@ -228617,7 +228610,7 @@ vRu
 vRu
 acD
 qgC
-ikM
+woq
 qgC
 vuH
 qgC
@@ -229018,12 +229011,12 @@ vRu
 vRu
 vRu
 acD
-ikM
+woq
 qgC
-xaD
+cld
 vuH
-xaD
-ikM
+cld
+woq
 acD
 qgC
 qgC
@@ -229421,11 +229414,11 @@ vRu
 vRu
 acD
 qgC
-ikM
+woq
 qgC
 vuH
-xaD
-ikM
+cld
+woq
 acD
 qgC
 qgC
@@ -229822,12 +229815,12 @@ vRu
 vRu
 vRu
 acD
-ikM
+woq
 qgC
 qgC
 vuH
-xaD
-ikM
+cld
+woq
 acD
 qgC
 qgC
@@ -230226,9 +230219,9 @@ vRu
 acD
 qgC
 qgC
-lfn
+kad
 vuH
-xaD
+cld
 qgC
 acD
 vRu
@@ -230629,7 +230622,7 @@ acD
 acD
 acD
 acD
-klX
+tiH
 acD
 acD
 acD
@@ -231430,12 +231423,12 @@ vRu
 vRu
 acD
 qgC
-ikM
-uHm
+woq
+kwN
 vuH
 ffw
 qgC
-ikM
+woq
 acD
 vRu
 vRu
@@ -231833,7 +231826,7 @@ vRu
 acD
 qgC
 qgC
-uHm
+kwN
 qgC
 vuH
 vuH
@@ -232234,9 +232227,9 @@ vRu
 vRu
 acD
 qgC
-ikM
+woq
 qgC
-uHm
+kwN
 vuH
 vuH
 qgC
@@ -233038,9 +233031,9 @@ vRu
 vRu
 acD
 qgC
-cQP
+foH
 qgC
-cQP
+foH
 ffw
 vuH
 qgC
@@ -233441,11 +233434,11 @@ vRu
 acD
 qgC
 vRu
-uHm
+kwN
 vuH
 vuH
 vuH
-ikM
+woq
 acD
 vRu
 vRu
@@ -233845,8 +233838,8 @@ acD
 acD
 acD
 acD
-vxl
-xdw
+bux
+mSn
 acD
 acD
 vRu
@@ -280914,12 +280907,12 @@ hcW
 hcW
 hcW
 cWT
-tJC
-tJC
-tJC
-tJC
-tJC
-tJC
+iME
+iME
+iME
+iME
+iME
+iME
 uSw
 uSw
 uSw
@@ -280939,35 +280932,35 @@ uSw
 uSw
 uSw
 uSw
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 cWT
 hcW
 hcW
@@ -281315,12 +281308,12 @@ uaL
 uaL
 uaL
 uaL
-uwa
-tiH
-bzl
-qRp
-qRp
-nsu
+nhR
+nuH
+wCF
+cRP
+cRP
+pzt
 nrw
 nrw
 nrw
@@ -281350,26 +281343,26 @@ ykt
 ykt
 ykt
 ykt
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
+nhR
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 cWT
 hcW
 hcW
@@ -281717,61 +281710,61 @@ wSn
 wSn
 uaL
 uaL
-uwa
-tiH
-tfp
-qRp
-qRp
-qRp
+nhR
+nuH
+iIR
+cRP
+cRP
+cRP
 nrw
 nrw
-nbK
-vsb
-veW
-oMa
-oMa
-cTF
+mzL
+eef
+aPR
+ilD
+ilD
+sxM
 nrw
-bHX
-wYv
-wYv
-szQ
+vPA
+xdw
+xdw
+kfX
 kzQ
-mdO
-dbH
-dbH
-vMQ
-cGR
+caK
+bob
+bob
+fVY
+xhv
 nrw
-qRp
-qRp
-abZ
+cRP
+cRP
+vdg
 uaL
 uaL
 paf
 qvR
 qvR
-dTa
+qGh
 uaL
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
-uwa
-kVc
-kVc
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 cWT
 hcW
 hcW
@@ -282119,62 +282112,62 @@ wSn
 wSn
 tzK
 uaL
-uwa
-tiH
-pwH
-qRp
-xto
-vLA
+nhR
+nuH
+pxZ
+cRP
+aym
+txe
 nrw
 nrw
-wUA
-veW
-veW
-wfK
-wfK
-wfK
+cGA
+aPR
+aPR
+sCQ
+sCQ
+sCQ
 nrw
 jlO
-wYv
-grD
-wYv
+xdw
+tli
+xdw
 jlO
-mdO
-dbH
-dbH
-jgy
-nGY
+caK
+bob
+bob
+arG
+jVq
 nrw
-qRp
-qRp
-abZ
-pDt
+cRP
+cRP
+vdg
+leR
 uaL
 paf
 qvR
 qvR
-dTa
+qGh
 uaL
 uaL
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 cWT
 cWT
 cWT
@@ -282521,65 +282514,65 @@ wSn
 uaL
 uaL
 uaL
-uwa
-tiH
-iiR
-qRp
-qRp
-vLA
+nhR
+nuH
+yiI
+cRP
+cRP
+txe
 nrw
 nrw
-cjB
-veW
-veW
-vsb
-veW
-veW
-iIy
+qCT
+aPR
+aPR
+eef
+aPR
+aPR
+jzh
 jlO
-wYv
-hGH
-wYv
+xdw
+rrL
+xdw
 jlO
 evo
-pAd
-dbH
-cGA
-dbH
+uIi
+bob
+rIj
+bob
 nrw
-qRp
-qRp
-abZ
-ojS
+cRP
+cRP
+vdg
+nfI
 uaL
 paf
 qvR
 qvR
-dTa
+qGh
 fxx
 aJj
 wSn
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 cWT
 hcW
 hcW
@@ -282923,66 +282916,66 @@ wSn
 uaL
 uaL
 uaL
-uwa
-tiH
-tiH
-gvi
-gvi
-apx
-tiH
+nhR
+nuH
+nuH
+xkF
+xkF
+bgY
+nuH
 nrw
-bnK
-esu
-veW
-veW
-veW
-veW
-iIy
+dnh
+qRp
+aPR
+aPR
+aPR
+aPR
+jzh
 jlO
-wYv
-erD
-wYv
+xdw
+nMD
+xdw
 jlO
 nrw
-rqg
-dbH
-dbH
-dbH
-onB
-qRp
-qRp
-abZ
+qir
+bob
+bob
+bob
+vNu
+cRP
+cRP
+vdg
 uaL
 uaL
-cLL
+oFQ
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 wSn
 wSn
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 hcW
 hcW
 hcW
@@ -283325,68 +283318,68 @@ wSn
 wSn
 uaL
 uaL
-uwa
-tiH
-iiR
-gvi
-gvi
-apx
-tiH
+nhR
+nuH
+yiI
+xkF
+xkF
+bgY
+nuH
 nrw
-lbx
-vsb
-veW
-pka
-pka
-pka
+oUF
+eef
+aPR
+sXe
+sXe
+sXe
 nrw
-eza
-wYv
-nBf
-wYv
-eza
+oJO
+xdw
+kSq
+xdw
+oJO
 nrw
-oVO
-dbH
-qRp
-qRp
-onB
-qRp
-qRp
-abZ
+oRp
+bob
+cRP
+cRP
+vNu
+cRP
+cRP
+vdg
 ykt
 ykt
 ykt
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 wSn
 aJj
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 hcW
 hcW
 uaL
@@ -283688,7 +283681,7 @@ cWT
 hcW
 hcW
 hcW
-kqS
+nZy
 wSn
 wSn
 wSn
@@ -283727,69 +283720,69 @@ uaL
 uaL
 uaL
 uaL
-uwa
-tiH
-bzl
-gvi
-wTs
-gvi
-hnX
-veW
-veW
-veW
-aDb
-wfK
-wfK
-omP
+nhR
+nuH
+wCF
+xkF
+htf
+xkF
+hAD
+aPR
+aPR
+aPR
+wnq
+sCQ
+sCQ
+nRG
 nrw
-eqr
-wYv
-wYv
-wYv
+iRN
+xdw
+xdw
+xdw
 jlO
 nrw
-pAd
-dbH
-qRp
-qRp
-onB
-wpm
-qRp
-abZ
+uIi
+bob
+cRP
+cRP
+vNu
+nTR
+cRP
+vdg
 uaL
 uaL
-cLL
+oFQ
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 wSn
 uaL
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 uaL
 uaL
 wSn
@@ -284129,15 +284122,15 @@ hcW
 hcW
 uaL
 uaL
-uwa
-tiH
-tfp
-gvi
-gvi
-gvi
-tiH
+nhR
+nuH
+iIR
+xkF
+xkF
+xkF
+nuH
 nrw
-iIy
+jzh
 nrw
 nrw
 nrw
@@ -284146,51 +284139,51 @@ nrw
 nrw
 nrw
 jlO
-sIE
-eza
+aCd
+oJO
 jlO
 nrw
-dEo
-dbH
-qRp
-obJ
+sWs
+bob
+cRP
+vEe
 nrw
-aev
-qRp
-abZ
-uOF
+eSt
+cRP
+vdg
+vFz
 uaL
 paf
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
 wSn
 uaL
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 wSn
@@ -284531,67 +284524,67 @@ hcW
 hcW
 uaL
 uaL
-uwa
-tiH
-pwH
-pOL
-gvi
-gvi
-jUh
-qRp
-qRp
-jBk
-qRp
-kgb
-kgb
-qRp
+nhR
+nuH
+pxZ
+txq
+xkF
+xkF
+qrV
+cRP
+cRP
+phJ
+cRP
+qCM
+qCM
+cRP
 mwq
 nrw
-yiI
+qQb
 nrw
 jlO
 jlO
 nrw
-vBo
-ceX
-qRp
-gHp
+qXw
+adK
+cRP
+wXW
 nrw
-wpm
-qRp
-abZ
-xIT
+nTR
+cRP
+vdg
+rgO
 uaL
 paf
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
 uaL
 wSn
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 qvR
@@ -284933,65 +284926,65 @@ hcW
 hcW
 hcW
 uaL
-uwa
-tiH
-tiH
-tiH
-tiH
+nhR
+nuH
+nuH
+nuH
+nuH
 nrw
 nrw
 mwq
-qRp
-xto
-qRp
-xto
-qRp
-qRp
-qRp
-qRp
-qRp
+cRP
+aym
+cRP
+aym
+cRP
+cRP
+cRP
+cRP
+cRP
 nrw
-eSt
-nrw
-nrw
+wgG
 nrw
 nrw
-dgU
 nrw
 nrw
-qRp
-qRp
-abZ
+vYZ
+nrw
+nrw
+cRP
+cRP
+vdg
 lsD
 lsD
-vrP
+kQl
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
 fxx
 wSn
-uwa
+nhR
 kVc
-uwa
-kVc
-kVc
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
@@ -285335,65 +285328,65 @@ hcW
 hcW
 uaL
 uaL
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
 evo
 nrw
 nrw
-vUf
-vUf
-fQq
-qAq
-aem
-aem
-aem
-qAq
-qRp
+fua
+fua
+uxZ
+hjD
+fDB
+fDB
+fDB
+hjD
+cRP
 nrw
-veW
-eDY
-uvu
+aPR
+wBt
+mjP
 nrw
-bhw
-wpm
-aev
-wpm
-qRp
-qRp
-abZ
+tUR
+nTR
+eSt
+nTR
+cRP
+cRP
+vdg
 rhD
 rhD
 rhD
 rhD
 rhD
-dTa
+qGh
 rZt
 fxx
 fxx
 fxx
 uaL
-uwa
+nhR
 kVc
-uwa
-kVc
-kVc
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 uaL
 uaL
@@ -285741,31 +285734,31 @@ uaL
 uaL
 qvR
 qvR
-uwa
+nhR
 evo
-vDn
-aev
+czM
+eSt
 cbG
 cbG
-yjP
-qAq
-tOv
-car
-esX
-nuH
-qRp
+dnV
+hjD
+bhu
+mzc
+ivi
+txG
+cRP
 nrw
-veW
-guU
-veW
-uPA
-qRp
-qRp
-wpm
-qRp
-qRp
-qRp
-jhx
+aPR
+ark
+aPR
+yjP
+cRP
+cRP
+nTR
+cRP
+cRP
+cRP
+pdm
 fxx
 fxx
 fxx
@@ -285778,24 +285771,24 @@ fxx
 fxx
 aJj
 wSn
-uwa
-uwa
+nhR
+nhR
 kVc
 kVc
-uwa
+nhR
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 uaL
 uaL
@@ -286143,34 +286136,34 @@ uaL
 uaL
 qvR
 qvR
-fDB
-evo
-vGN
-aev
-cbG
-cbG
-oUR
-qAq
-hKx
-qGh
-rRA
-qAq
-qRp
-sge
-veW
 vjs
-veW
+evo
+tUp
 eSt
-qRp
-qRp
-qRp
-qRp
-qRp
-qRp
-jhx
+cbG
+cbG
+ifg
+hjD
+xAh
+rHJ
+lsb
+hjD
+cRP
+vpo
+aPR
+bif
+aPR
+wgG
+cRP
+cRP
+cRP
+cRP
+cRP
+cRP
+pdm
 fxx
 fxx
-fTH
+hdk
 fxx
 fxx
 fxx
@@ -286180,24 +286173,24 @@ fxx
 fxx
 uaL
 wSn
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 uaL
 wSn
@@ -286545,31 +286538,31 @@ uaL
 uaL
 qvR
 qvR
-fDB
-evo
-fxM
-aev
-cbG
-cbG
-fQq
-qAq
-jaY
-hJY
-wDZ
-qAq
-qRp
-nrw
-rqj
-rqj
 vjs
+evo
+kkN
 eSt
-qRp
-qRp
-qRp
-qRp
-qRp
-qRp
-jhx
+cbG
+cbG
+uxZ
+hjD
+dzf
+nuC
+hQd
+hjD
+cRP
+nrw
+nSg
+nSg
+bif
+wgG
+cRP
+cRP
+cRP
+cRP
+cRP
+cRP
+pdm
 fxx
 fxx
 fxx
@@ -286583,23 +286576,23 @@ fxx
 uaL
 uaL
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 uaL
@@ -286911,7 +286904,7 @@ uaL
 uaL
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -286947,37 +286940,37 @@ uaL
 uaL
 qvR
 qvR
-fDB
+vjs
 evo
 nrw
 nrw
-iSJ
-iSJ
-fQq
-nuH
-cMs
-cMs
-cMs
-qAq
-qRp
+alx
+alx
+uxZ
+txG
+bVY
+bVY
+bVY
+hjD
+cRP
 nrw
-hLC
-gKb
-veW
-uPA
-qRp
-qRp
-wpm
-qRp
-qRp
-qRp
-abZ
+uwa
+ibe
+aPR
+yjP
+cRP
+cRP
+nTR
+cRP
+cRP
+cRP
+vdg
 rhD
 rhD
 rhD
 rhD
 rhD
-dTa
+qGh
 rZt
 fxx
 fxx
@@ -286985,23 +286978,23 @@ fxx
 fxx
 aJj
 kVc
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 uaL
@@ -287349,37 +287342,37 @@ uaL
 uaL
 qvR
 qvR
-uwa
+nhR
 evo
 nrw
 mwq
-qRp
-qRp
-qRp
-qRp
-qRp
-qRp
-qRp
-xto
-qRp
+cRP
+cRP
+cRP
+cRP
+cRP
+cRP
+cRP
+aym
+cRP
 nrw
 nrw
 nrw
-gbR
+vYb
 nrw
-bhw
-wpm
-aev
-wpm
-qRp
-qRp
-abZ
-fYy
+tUR
+nTR
+eSt
+nTR
+cRP
+cRP
+vdg
+ugr
 qvR
 qvR
 qvR
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -287387,23 +287380,23 @@ fxx
 fxx
 uaL
 aJj
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
-uwa
+nhR
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
-uwa
+nhR
 kVc
 qvR
 qvR
@@ -287751,37 +287744,37 @@ uaL
 uaL
 uaL
 qvR
-uwa
+nhR
 evo
 nrw
-awV
-qDn
-qwp
-qRp
-qDn
-qDn
-qRp
+fLK
+qYi
+oRV
+cRP
+qYi
+qYi
+cRP
 mwq
 nrw
 nrw
 nrw
 nrw
-lIu
-veW
+bmL
+aPR
 nrw
 nrw
-nWm
+aRR
 nrw
 nrw
-wpm
-qRp
-abZ
+nTR
+cRP
+vdg
 uaL
 uaL
 uaL
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -287789,23 +287782,23 @@ fxx
 fxx
 wSn
 aJj
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 uaL
 wSn
@@ -288122,7 +288115,7 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -288151,9 +288144,9 @@ uaL
 uaL
 uaL
 hcW
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
 evo
 nrw
 nrw
@@ -288165,25 +288158,25 @@ nrw
 nrw
 nrw
 nrw
-vvk
-vvk
+wHS
+wHS
 nrw
-lIu
-veW
-lIu
-rck
-jLL
-oMa
+bmL
+aPR
+bmL
+bIR
+obq
+ilD
 nrw
-aev
-qRp
-abZ
+eSt
+cRP
+vdg
 uaL
 uaL
 uaL
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -288192,20 +288185,20 @@ fxx
 wSn
 aJj
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-bvy
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+qcZ
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
@@ -288555,37 +288548,37 @@ hcW
 hcW
 hcW
 cWT
-tJC
-tJC
-tJC
-tJC
-lIu
-lIu
-lIu
-vvk
-vvk
-lIu
-lIu
-lIu
-veW
-qzN
+iME
+iME
+iME
+iME
+bmL
+bmL
+bmL
+wHS
+wHS
+bmL
+bmL
+bmL
+aPR
+iug
 nrw
-xkR
-veW
-vjs
-veW
-guU
-veW
-qyk
-wpm
-qRp
-abZ
+uOt
+aPR
+bif
+aPR
+ark
+aPR
+xzK
+nTR
+cRP
+vdg
 qvR
 qvR
 qvR
 qvR
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -288594,20 +288587,20 @@ fxx
 wSn
 wSn
 kVc
-uwa
+nhR
 kVc
-uwa
+nhR
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 kVc
@@ -288954,40 +288947,40 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 cWT
-tJC
+iME
 iJR
-qKY
-dwO
-veW
-rvA
-qzN
-lLK
-rvA
-rvA
-qzN
-rvA
-rzh
-veW
-vGN
-jLL
-veW
-veW
-veW
-vjs
-veW
-uPA
-qRp
-qRp
-abZ
+xue
+clV
+aPR
+vbQ
+iug
+jrP
+vbQ
+vbQ
+iug
+vbQ
+vsg
+aPR
+tUp
+obq
+aPR
+aPR
+aPR
+bif
+aPR
+yjP
+cRP
+cRP
+vdg
 uaL
 uaL
 uaL
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -289002,15 +288995,15 @@ kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 lyL
@@ -289320,25 +289313,22 @@ uaL
 uaL
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
-vFz
-hcW
-hcW
-hcW
-hcW
-vFz
+aSD
 hcW
 hcW
 hcW
+hcW
+aSD
 hcW
 hcW
 hcW
@@ -289347,11 +289337,14 @@ hcW
 hcW
 hcW
 hcW
-vFz
 hcW
 hcW
 hcW
-vFz
+aSD
+hcW
+hcW
+hcW
+aSD
 hcW
 hcW
 hcW
@@ -289359,37 +289352,37 @@ hcW
 hcW
 hcW
 cWT
-tJC
+iME
 iJR
-dOL
-dwO
-veW
-rvA
-qzN
-vWm
-rvA
-qzN
-lLK
-qzN
-qzN
-veW
+kHd
+clV
+aPR
+vbQ
+iug
+tYx
+vbQ
+iug
+jrP
+iug
+iug
+aPR
 nrw
-veW
-veW
-pka
-pka
-veW
-veW
-uPA
-qRp
-qRp
-abZ
+aPR
+aPR
+sXe
+sXe
+aPR
+aPR
+yjP
+cRP
+cRP
+vdg
 uaL
 uaL
 uaL
 uaL
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -289397,22 +289390,22 @@ fxx
 fxx
 uaL
 wSn
-uwa
+nhR
 kVc
 kVc
 kVc
-uwa
+nhR
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 qvR
@@ -289756,42 +289749,42 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 cWT
-tJC
-tJC
-tJC
-tJC
-lIu
-lIu
-lIu
-kol
-kol
-lIu
-lIu
-lIu
-lLK
-veW
-lsi
-veW
-veW
-jNB
-vjb
-bPz
-lIu
+iME
+iME
+iME
+iME
+bmL
+bmL
+bmL
+uDi
+uDi
+bmL
+bmL
+bmL
+jrP
+aPR
+yej
+aPR
+aPR
+aRp
+mlp
+bjK
+bmL
 nrw
-qRp
-qRp
-abZ
-cRE
+cRP
+cRP
+vdg
+inE
 qvR
 qvR
 qvR
 qvR
-dTa
+qGh
 fxx
 fxx
 fxx
@@ -289799,22 +289792,22 @@ fxx
 fxx
 fxx
 wSn
-uwa
+nhR
 kVc
-uwa
-kVc
-kVc
+nhR
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 qvR
@@ -290151,7 +290144,7 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -290166,7 +290159,7 @@ cWT
 cWT
 cWT
 cWT
-tJC
+iME
 nrw
 nrw
 nrw
@@ -290203,20 +290196,20 @@ fxx
 uaL
 kVc
 kVc
-uwa
+nhR
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 uaL
@@ -290535,7 +290528,7 @@ qvR
 uaL
 uaL
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -290553,14 +290546,14 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -290569,10 +290562,10 @@ hcW
 hcW
 hcW
 cWT
-fDB
-fDB
-tUp
-tUp
+vjs
+vjs
+dXt
+dXt
 evo
 ykt
 ykt
@@ -290607,17 +290600,17 @@ aJj
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 kVc
 qvR
@@ -290938,7 +290931,7 @@ qvR
 qvR
 hcW
 hcW
-vFz
+aSD
 hcW
 kYc
 kYS
@@ -290947,7 +290940,7 @@ mzx
 kYc
 mzx
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -290971,8 +290964,8 @@ hcW
 hcW
 hcW
 hcW
-tUp
-fDB
+dXt
+vjs
 evo
 evo
 evo
@@ -291007,19 +291000,19 @@ fxx
 uaL
 uaL
 uaL
-uwa
+nhR
 uaL
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 kVc
 qvR
 qvR
@@ -291352,16 +291345,16 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -291752,18 +291745,18 @@ msk
 ntQ
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -291816,13 +291809,13 @@ uaL
 uaL
 fxx
 fxx
-wVL
-tUR
-tUR
-tUR
-tUR
-tUR
-wVL
+lZG
+vHd
+vHd
+vHd
+vHd
+vHd
+lZG
 wSn
 uaL
 uaL
@@ -292143,7 +292136,7 @@ sJZ
 sJZ
 qvR
 hcW
-vFz
+aSD
 hcW
 hcW
 ldI
@@ -292218,13 +292211,13 @@ fxx
 fxx
 fxx
 fxx
-vdg
+ghi
 peN
 peN
 peN
 peN
 peN
-rwX
+bEm
 fxx
 fxx
 fxx
@@ -292533,7 +292526,7 @@ uaL
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 qvR
@@ -292565,13 +292558,13 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -292620,13 +292613,13 @@ fxx
 fxx
 fxx
 fxx
-tUR
+vHd
 peN
 peN
 peN
-nfz
+rvY
 peN
-tUR
+vHd
 fxx
 fxx
 fxx
@@ -292970,10 +292963,10 @@ hcW
 hcW
 hcW
 hcW
-vFz
-vFz
+aSD
+aSD
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -292994,14 +292987,14 @@ wSn
 wSn
 wSn
 xKz
-rPu
-fVv
+mma
+abZ
 lLa
 xKz
 xKz
-mmm
-hrj
-bjp
+jKS
+jWA
+mSE
 xKz
 jeb
 jeb
@@ -293367,8 +293360,8 @@ hcW
 hcW
 hcW
 hcW
-vFz
-vFz
+aSD
+aSD
 hcW
 hcW
 hcW
@@ -293396,18 +293389,18 @@ wSn
 wSn
 wSn
 xKz
-msL
+vLA
 iYQ
 fVQ
-cCG
+nrx
 qpt
 sDa
 peN
 rUr
-wgn
-cCG
+pHA
+nrx
 fVQ
-cBG
+tXm
 xKz
 qvR
 qvR
@@ -293424,13 +293417,13 @@ wSn
 uaL
 fTe
 wSn
-fIB
-ebb
-wSl
-wSl
-wSl
-ebb
-fIB
+uPa
+iWj
+mzs
+mzs
+mzs
+iWj
+uPa
 uaL
 uaL
 uaL
@@ -293771,7 +293764,7 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -293798,18 +293791,18 @@ wSn
 wSn
 wSn
 xKz
-mxs
-fVv
+xFf
+abZ
 fVQ
 lLa
 qpt
 sDa
 peN
 rUr
-wgn
+pHA
 lLa
 fVQ
-qEM
+xeT
 xKz
 qvR
 qvR
@@ -293829,7 +293822,7 @@ uaL
 xKz
 bOK
 jeb
-cRc
+dCZ
 jeb
 bOK
 xKz
@@ -294166,14 +294159,14 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -294200,18 +294193,18 @@ wSn
 wSn
 wSn
 xKz
-msL
+vLA
 iYQ
 fVQ
-fVM
+oPr
 qpt
 sDa
 peN
 rUr
-wgn
+pHA
 hmU
 fVQ
-qEM
+xeT
 xKz
 qvR
 qvR
@@ -294231,7 +294224,7 @@ uaL
 bOK
 tYP
 tYP
-utA
+tUh
 tYP
 tYP
 xKz
@@ -294544,7 +294537,7 @@ uaL
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 qvR
 qvR
@@ -294566,7 +294559,7 @@ ndD
 kYc
 msk
 nxV
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -294602,8 +294595,8 @@ wSn
 wSn
 wSn
 xKz
-mxs
-fVv
+xFf
+abZ
 fVQ
 jeb
 jeb
@@ -294613,7 +294606,7 @@ rUr
 jeb
 jeb
 fVQ
-iNo
+epL
 xKz
 qvR
 qvR
@@ -294630,11 +294623,11 @@ uaL
 qvR
 qvR
 uaL
-dVb
+eJO
 tYP
-jCc
+jAQ
 tYP
-fSZ
+uHk
 tYP
 xKz
 qvR
@@ -295004,18 +294997,18 @@ wSn
 wSn
 wSn
 xKz
-udB
+cMs
 iYQ
 fVQ
 fVQ
 jeb
-xcg
+cGb
 peN
 rUr
 jeb
 fVQ
 tYP
-jxX
+mck
 xKz
 qvR
 qvR
@@ -295033,7 +295026,7 @@ qvR
 uaL
 wSn
 xKz
-puv
+hln
 tYP
 tYP
 tYP
@@ -295358,7 +295351,7 @@ uaL
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -295406,18 +295399,18 @@ wSn
 wSn
 wSn
 xKz
-obq
+wYv
 lLa
 fVQ
 fVQ
-cDZ
+ofT
 sDa
 peN
 rUr
-cDZ
+ofT
 fVQ
 sCg
-ugc
+eTZ
 xKz
 qvR
 uaL
@@ -295436,10 +295429,10 @@ uaL
 wSn
 bOK
 tYP
-ulj
+oMa
 tYP
 sCg
-ejO
+auL
 xKz
 qvR
 qvR
@@ -295767,7 +295760,7 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -295808,18 +295801,18 @@ xKz
 xKz
 xKz
 xKz
-obq
+wYv
 lLa
 kMi
-qPO
+wDZ
 jeb
-xcg
+cGb
 peN
 rUr
 jeb
 fVQ
 sCg
-ugc
+eTZ
 xKz
 qvR
 uaL
@@ -295839,9 +295832,9 @@ wSn
 xKz
 xKz
 xKz
-aym
+qDn
 sCg
-ugc
+eTZ
 xKz
 qvR
 qvR
@@ -296213,7 +296206,7 @@ fVQ
 fVQ
 fVQ
 kMi
-udB
+cMs
 jeb
 sDa
 peN
@@ -296221,7 +296214,7 @@ rUr
 jeb
 fVQ
 tYP
-ugc
+eTZ
 xKz
 qvR
 qvR
@@ -296243,7 +296236,7 @@ xKz
 xKz
 tYP
 sCg
-ugc
+eTZ
 xKz
 qvR
 qvR
@@ -296553,7 +296546,7 @@ hcW
 wSn
 uaL
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -296613,17 +296606,17 @@ xKz
 mDY
 fVQ
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 qpt
 sDa
 peN
 rUr
-wgn
+pHA
 lLa
 fVQ
-qwC
+jFn
 xKz
 qvR
 uaL
@@ -296643,9 +296636,9 @@ wSn
 xKz
 xKz
 xKz
-aym
+qDn
 sCg
-ejO
+auL
 xKz
 qvR
 uaL
@@ -296955,7 +296948,7 @@ wSn
 wSn
 uaL
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
@@ -296964,7 +296957,7 @@ hcW
 hcW
 hcW
 hcW
-vFz
+aSD
 wSn
 wSn
 qvR
@@ -297011,7 +297004,7 @@ xqL
 wSn
 wSn
 xKz
-qPO
+wDZ
 gqa
 fVQ
 fVQ
@@ -297022,10 +297015,10 @@ qpt
 sDa
 peN
 rUr
-wgn
+pHA
 lLa
 fVQ
-cHU
+mRU
 xKz
 qvR
 qvR
@@ -297045,7 +297038,7 @@ uaL
 xKz
 xKz
 xKz
-mYM
+lav
 xKz
 xKz
 xKz
@@ -297354,19 +297347,19 @@ fyc
 cWT
 cWT
 wSn
-vFz
-vFz
-vFz
-vFz
+aSD
+aSD
+aSD
+aSD
 hcW
-vFz
+aSD
 hcW
 hcW
 hcW
-vFz
-vFz
-vFz
-vFz
+aSD
+aSD
+aSD
+aSD
 wSn
 wSn
 qvR
@@ -297413,21 +297406,21 @@ aJj
 uaL
 qvR
 xKz
-msL
+vLA
 iYQ
 lLa
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 qpt
 sDa
 peN
 rUr
-wgn
-fTJ
+pHA
+mHT
 fVQ
-kTM
+lJL
 xKz
 uaL
 uaL
@@ -297756,9 +297749,9 @@ fyc
 cWT
 cWT
 uaL
-vFz
-vFz
-vFz
+aSD
+aSD
+aSD
 hcW
 hcW
 hcW
@@ -297815,18 +297808,18 @@ evo
 evo
 evo
 xKz
-udB
-fVv
+cMs
+abZ
 kds
-szF
+wBY
 xKz
-fVM
+oPr
 fVQ
 xKz
-oJO
-upK
+aZv
+cVk
 kIf
-hZa
+wgn
 xKz
 xKz
 xKz
@@ -298226,29 +298219,29 @@ xKz
 xKz
 xKz
 uWL
-ubc
-ubc
+vkl
+vkl
 xKz
 xKz
-wcu
-wcu
-wou
-wou
-wou
-wou
-wou
-wou
-rMO
-rMO
-wou
-wou
-wcu
-wcu
-wcu
-wcu
-wou
-wou
-wou
+uxV
+uxV
+nJy
+nJy
+nJy
+nJy
+nJy
+nJy
+uvQ
+uvQ
+nJy
+nJy
+uxV
+uxV
+uxV
+uxV
+nJy
+nJy
+nJy
 axq
 dnx
 axl
@@ -305463,7 +305456,7 @@ xKz
 wVI
 wbg
 wbg
-bPv
+rhx
 wbg
 wbg
 wbg
@@ -305819,7 +305812,7 @@ mcK
 nBW
 mOY
 nBW
-vRB
+jIP
 nBW
 wtF
 wbg
@@ -307433,7 +307426,7 @@ wtF
 wbg
 wbg
 wbg
-bPv
+rhx
 wbg
 wbg
 wbg
@@ -307916,7 +307909,7 @@ qvR
 eOg
 uAZ
 xzN
-lgC
+xzN
 lOo
 rNg
 nuD
@@ -309556,9 +309549,9 @@ bwS
 lVe
 bwS
 lVe
-jyw
+biR
 goK
-wVx
+aHj
 sux
 pYf
 pYf
@@ -310692,14 +310685,14 @@ wbg
 wbg
 wbg
 wVI
-hrD
-uxZ
+iNc
+bpi
 nHz
 wVI
 wVI
 wVI
-mlO
-hrD
+xiY
+iNc
 wVI
 tUw
 wVI
@@ -310735,7 +310728,7 @@ fxx
 fxx
 fxx
 fxx
-bpp
+hRF
 fxx
 boU
 fxx
@@ -310753,13 +310746,13 @@ qvR
 wSn
 cyr
 hHF
-bWg
+mbZ
 wlD
 sIG
 wlD
 wlD
 wlD
-wVx
+aHj
 wlD
 sIG
 wlD
@@ -311060,7 +311053,7 @@ wbg
 xXq
 yhZ
 yhZ
-bRV
+nxo
 yhZ
 yhZ
 xXq
@@ -311473,13 +311466,13 @@ xez
 wbg
 wbg
 wbg
-bPv
+rhx
 wbg
 wbg
 wbg
 wbg
 wbg
-bPv
+rhx
 wbg
 wbg
 wbg
@@ -311527,7 +311520,7 @@ fxx
 fxx
 fxx
 fxx
-bpp
+hRF
 fxx
 fxx
 fxx
@@ -311895,7 +311888,7 @@ wbg
 wbg
 wbg
 wbg
-bPv
+rhx
 wbg
 wbg
 wbg
@@ -311903,7 +311896,7 @@ wbg
 wbg
 wbg
 wbg
-bPv
+rhx
 wbg
 wbg
 wbg
@@ -313102,16 +313095,16 @@ wbg
 wbg
 wbg
 wbg
-qzH
+rfO
 hUt
 vFj
-qzH
+rfO
 wbg
 wbg
 wbg
 xGM
 xGM
-qzH
+rfO
 wsR
 ukb
 wvE
@@ -313153,7 +313146,7 @@ trG
 ryI
 fZw
 fxx
-bpp
+hRF
 rhD
 qvR
 qvR
@@ -313511,9 +313504,9 @@ wew
 wxZ
 nRo
 bQf
-eCw
+oGl
 iPY
-nvP
+xbW
 wsR
 ukb
 wvE
@@ -313868,7 +313861,7 @@ aOn
 aOn
 lpa
 nCh
-bPv
+rhx
 wbg
 wbg
 hOh
@@ -313901,21 +313894,21 @@ pUl
 rJX
 tCr
 guP
-vYx
-quL
-fFh
+pmE
+ale
+gBI
 wbg
 qtV
 iPY
 iPY
 iPY
-cjJ
+jMf
 wVI
 weX
 wVI
-sQo
+hGP
 hRv
-nvP
+xbW
 wsR
 xMr
 yho
@@ -314303,21 +314296,21 @@ rJX
 eai
 tCr
 guP
-hpM
-xlI
+jLr
+pKE
 iGf
 viq
 qtV
 iPY
 aOn
 aOn
-oll
+sbF
 wxZ
 wVI
 bQf
-mfo
+bpt
 nXd
-tjt
+mAD
 wsR
 dHZ
 xww
@@ -314707,13 +314700,13 @@ fQm
 guP
 guP
 guP
-quL
+ale
 uTQ
 qtV
 nXd
-sbF
-sbF
-oiE
+nBk
+nBk
+gbA
 wVI
 wVI
 wVI
@@ -314777,7 +314770,7 @@ lVe
 uxL
 sZI
 xlx
-lSG
+tHM
 iTv
 cXU
 iTv
@@ -315055,7 +315048,7 @@ uOL
 jxy
 vbO
 oif
-mfi
+pmC
 oif
 uJk
 tOz
@@ -315112,16 +315105,16 @@ sxR
 sxR
 abh
 wbg
-cJU
-cJU
+qMC
+qMC
 aSH
-cJU
+qMC
 wVI
 wVI
 wVI
 wVI
 wVI
-slt
+ilT
 oUn
 xMr
 vwQ
@@ -315164,7 +315157,7 @@ hLK
 nht
 fxx
 fxx
-avX
+wxd
 wxd
 wSn
 wSn
@@ -315503,7 +315496,7 @@ tYm
 oAn
 wbg
 wbg
-bQz
+aUo
 dTB
 tVP
 tVP
@@ -315512,7 +315505,7 @@ tCG
 tVP
 tVP
 tCG
-uPY
+jUP
 wbg
 wVI
 wVI
@@ -315914,9 +315907,9 @@ tVP
 tVP
 tVP
 tVP
-tha
+nfY
 qtV
-foR
+jgg
 rZY
 wVI
 wxZ
@@ -316304,21 +316297,21 @@ pAS
 sZN
 sZN
 xdq
-qpX
+ovj
 wbg
 wbg
-bQz
+aUo
 rJC
 tVP
-hGm
-sxm
+nVG
+iPA
 tVP
-tZZ
+jqk
 tVP
 tVP
-tha
+nfY
 qtV
-foR
+jgg
 rZY
 wVI
 wxZ
@@ -316328,7 +316321,7 @@ wVI
 bQf
 wVI
 rZY
-nWq
+qRW
 kjH
 kjH
 kjH
@@ -316358,7 +316351,7 @@ vLS
 uaL
 sjP
 wSn
-bpp
+hRF
 fxx
 lcg
 fQg
@@ -316706,23 +316699,23 @@ sZN
 sZN
 sZN
 xdq
-cjJ
+jMf
 wbg
 wbg
 wKT
 kFS
 tVP
-raJ
-fOI
-vvB
-oKT
+uab
+aWy
+xlp
+xKj
 tVP
 tCG
-tha
+nfY
 wbg
 wbg
 wVI
-lKl
+sSB
 wVI
 wVI
 wVI
@@ -317058,7 +317051,7 @@ oif
 oif
 oif
 oif
-waG
+vJN
 eUJ
 eUJ
 jxy
@@ -317108,7 +317101,7 @@ sZN
 sZN
 lzC
 xdq
-qpX
+ovj
 wbg
 wbg
 wKT
@@ -317116,8 +317109,8 @@ eWj
 yfY
 ijS
 mmb
-uRv
-vGQ
+tZZ
+uaj
 yfY
 yfY
 wKT
@@ -317126,8 +317119,8 @@ qEa
 vXm
 vXm
 vXm
-aNR
-eAi
+ebb
+tfp
 wVI
 wVI
 wVI
@@ -317528,12 +317521,12 @@ wbg
 uqe
 ewM
 uqe
-wwz
-cjJ
+pQO
+jMf
 wVI
 wVI
 rZY
-mqN
+cnX
 rZY
 jXw
 xgi
@@ -317912,7 +317905,7 @@ pDy
 sZN
 sZN
 xdq
-qpX
+ovj
 wbg
 wbg
 cCQ
@@ -317924,18 +317917,18 @@ yfY
 yfY
 yfY
 yfY
-rGG
+rXq
 wbg
-koJ
+kJm
 uqe
 uqe
 uqe
-qFo
+kEc
 wew
 weX
 wVI
 rZY
-bsV
+bgT
 rZY
 jXw
 xgi
@@ -317977,7 +317970,7 @@ gkv
 hLK
 njv
 fxx
-bpp
+hRF
 wxd
 wxd
 wSn
@@ -318283,7 +318276,7 @@ wrj
 jDm
 jDm
 mwE
-dZK
+tJT
 mwE
 wbg
 wbg
@@ -318314,25 +318307,25 @@ pAS
 sZN
 sZN
 xdq
-cjJ
+jMf
 wbg
 wbg
 cJz
 yfY
-epN
+cud
 ijS
-eyM
-vGQ
-uRv
+pnp
+uaj
+tZZ
 kfr
-hHm
+xJe
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-qFo
+kEc
 wew
 wVI
 wVI
@@ -318716,7 +318709,7 @@ ygF
 ygF
 uDv
 xdq
-qpX
+ovj
 wbg
 wbg
 wKT
@@ -318734,8 +318727,8 @@ qEa
 gGZ
 gGZ
 gGZ
-dXn
-mIn
+csB
+tFE
 wqq
 wqq
 wqq
@@ -319122,14 +319115,14 @@ qls
 wbg
 wbg
 wKT
-tSr
-rXe
-urF
-vQV
-urF
-vQV
-urF
-vQV
+vDP
+uIj
+ksK
+qRm
+ksK
+qRm
+ksK
+qRm
 wKT
 wbg
 wbg
@@ -319922,7 +319915,7 @@ pMj
 pPI
 xdq
 xdq
-qpX
+ovj
 wbg
 wbg
 wKT
@@ -319940,13 +319933,13 @@ wbg
 usR
 ncb
 ncb
-vgA
+cAW
 wbg
 wVI
 wVI
 wVI
 wVI
-giI
+fdU
 wVI
 wVI
 wbg
@@ -320324,25 +320317,25 @@ pOs
 pRW
 xdq
 qls
-vox
+gRJ
 wbg
 wbg
 wKT
 wKT
 jCs
-urF
-xwi
-urF
-xwi
-urF
-xwi
+ksK
+wFp
+ksK
+wFp
+ksK
+wFp
 wKT
 wbg
 wbg
 usR
 xAt
 xAt
-pEp
+vgA
 wbg
 kjH
 xxF
@@ -320725,7 +320718,7 @@ xdq
 xdq
 xdq
 xdq
-xAh
+rGY
 wbg
 wbg
 wbg
@@ -320743,7 +320736,7 @@ wbg
 wbg
 vAB
 bnQ
-cgc
+wpm
 nWM
 wbg
 kjH
@@ -321127,7 +321120,7 @@ xMr
 xMr
 xMr
 xMr
-cjJ
+jMf
 wbg
 wbg
 wbg
@@ -321529,7 +321522,7 @@ dCV
 csA
 dCV
 hXf
-qpX
+ovj
 wbg
 wbg
 wbg
@@ -321931,7 +321924,7 @@ dCV
 dCV
 dCV
 qee
-vox
+gRJ
 wbg
 wbg
 wbg
@@ -322719,7 +322712,7 @@ wSn
 nZj
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -322737,11 +322730,11 @@ xMr
 xMr
 gGZ
 qCy
-iRN
+eTW
 wVI
 weX
 wVI
-iQs
+gRm
 wbg
 ekQ
 qDx
@@ -323121,7 +323114,7 @@ wSn
 nZj
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -323138,7 +323131,7 @@ bmi
 mgx
 xMr
 xAt
-nWr
+hvh
 wbg
 wVI
 wVI
@@ -323523,7 +323516,7 @@ uaL
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -323541,11 +323534,11 @@ oVp
 xMr
 qnO
 oZC
-fdx
+hIG
 wVI
 xbo
 wVI
-iQs
+gRm
 wbg
 hOh
 qDx
@@ -323925,7 +323918,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -323943,11 +323936,11 @@ nTe
 qhC
 wbg
 wbg
-fdx
+hIG
 wVI
 wVI
 wVI
-iQs
+gRm
 wbg
 hOh
 qDx
@@ -324327,7 +324320,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -324343,7 +324336,7 @@ oXn
 oXn
 oXn
 xMr
-ycz
+xYI
 wbg
 wbg
 wVI
@@ -324729,7 +324722,7 @@ uaL
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 xMr
@@ -324745,13 +324738,13 @@ paz
 bmi
 bmi
 xMr
-xAh
+rGY
 wbg
-iRN
+eTW
 wVI
 weX
 wVI
-iQs
+gRm
 wbg
 lHf
 rfx
@@ -325131,7 +325124,7 @@ lgA
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 hcm
@@ -325147,7 +325140,7 @@ gVS
 gVS
 bmi
 xMr
-qpX
+ovj
 wbg
 wbg
 wbg
@@ -325533,7 +325526,7 @@ nBq
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 jZn
@@ -325549,7 +325542,7 @@ poR
 pPs
 bmi
 qhR
-xAh
+rGY
 wbg
 wbg
 wbg
@@ -325935,7 +325928,7 @@ qvR
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 cwN
@@ -325975,7 +325968,7 @@ bJG
 wbg
 jpZ
 aOv
-wMv
+sOE
 aOv
 aOv
 aOv
@@ -326337,7 +326330,7 @@ uaL
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 cwN
@@ -326353,7 +326346,7 @@ orY
 orY
 bmi
 xMr
-qpX
+ovj
 wbg
 wbg
 wbg
@@ -326376,7 +326369,7 @@ ewt
 cEF
 wbg
 xll
-oAH
+jbu
 aOn
 jHc
 mwE
@@ -326739,7 +326732,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 hRy
@@ -326755,7 +326748,7 @@ bmi
 mou
 bmi
 xMr
-qpX
+ovj
 wbg
 wbg
 wbg
@@ -327141,8 +327134,8 @@ uaL
 paf
 xAt
 xAt
+rfx
 wbg
-wbg
 xMr
 xMr
 xMr
@@ -327157,7 +327150,7 @@ xMr
 xMr
 xMr
 xMr
-cjJ
+jMf
 wbg
 wbg
 wbg
@@ -328443,7 +328436,7 @@ kVc
 kVc
 hcW
 cWT
-uwa
+nhR
 hcW
 hcW
 hcW
@@ -328844,8 +328837,8 @@ kVc
 kVc
 kVc
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -329246,8 +329239,8 @@ wxd
 kVc
 kVc
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -329648,8 +329641,8 @@ wxd
 kVc
 kVc
 kVc
-uwa
-uwa
+nhR
+nhR
 hcW
 hcW
 hcW
@@ -329962,9 +329955,9 @@ xKF
 xKF
 xKF
 xKF
-pKN
-jCr
-fTd
+xoZ
+hVW
+uzW
 xKF
 xKF
 xKF
@@ -330050,8 +330043,8 @@ xqL
 kVc
 kVc
 kVc
-uwa
-uwa
+nhR
+nhR
 hcW
 hcW
 hcW
@@ -330358,10 +330351,10 @@ uaL
 xAt
 xAt
 xKF
-ltL
-gsa
-gsa
-vWY
+rPa
+cwd
+cwd
+hbc
 xKF
 xKF
 eBN
@@ -330369,7 +330362,7 @@ eBN
 eBN
 mGn
 mGn
-bIE
+lIF
 trI
 cdn
 cdn
@@ -330452,8 +330445,8 @@ wxd
 kVc
 kVc
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -330760,10 +330753,10 @@ paf
 xAt
 xAt
 xKF
-cCS
-gsa
-gsa
-vWY
+bBh
+cwd
+cwd
+hbc
 xKF
 xKF
 ejY
@@ -330854,8 +330847,8 @@ sJZ
 wxd
 wxd
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -331162,10 +331155,10 @@ afX
 xAt
 xAt
 xKF
-uYr
-gsa
-gsa
-vWY
+cmf
+cwd
+cwd
+hbc
 xKF
 xKF
 xKF
@@ -331256,8 +331249,8 @@ sJZ
 sJZ
 feP
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -331564,15 +331557,15 @@ paf
 xAt
 xAt
 xKF
-pWL
-gsa
-gsa
-vHJ
+sJs
+cwd
+cwd
+nGT
 xKF
 ofq
 ofq
 xKF
-xJe
+aac
 ofq
 eBN
 cdn
@@ -331658,8 +331651,8 @@ sJZ
 sJZ
 wxd
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -331966,10 +331959,10 @@ paf
 xAt
 xAt
 xKF
-vde
-gsa
-gsa
-bmx
+sQb
+cwd
+cwd
+seC
 xKF
 ofq
 ofq
@@ -331980,7 +331973,7 @@ eBN
 bok
 uHj
 cdn
-nrx
+dsW
 idG
 obL
 xKF
@@ -332060,8 +332053,8 @@ qet
 sJZ
 wxd
 kVc
-uwa
-uwa
+nhR
+nhR
 kVc
 hcW
 hcW
@@ -332368,10 +332361,10 @@ paf
 xAt
 xAt
 xKF
-fRA
-gsa
-mbs
-uxV
+psB
+cwd
+dNL
+uKn
 xKF
 ofq
 ofq
@@ -332462,8 +332455,8 @@ qet
 qet
 wxd
 kVc
-uwa
-uwa
+nhR
+nhR
 hcW
 hcW
 hcW
@@ -332770,10 +332763,10 @@ paf
 xAt
 xAt
 xKF
-rgO
-rgO
+uFp
+uFp
 xKF
-saz
+jEB
 xKF
 xKF
 xKF
@@ -332864,8 +332857,8 @@ qet
 qet
 wxd
 kVc
-uwa
-uwa
+nhR
+nhR
 hcW
 hcW
 hcW
@@ -333171,16 +333164,16 @@ uaL
 afX
 xAt
 xAt
-qzy
+asZ
 fCM
 fCM
 cNo
 twX
 cNo
-rHr
+kBg
 eeO
 sKd
-hRC
+dAf
 eBN
 eBN
 cdn
@@ -333573,21 +333566,21 @@ uaL
 paf
 xAt
 xAt
-qzy
+asZ
 fCM
 fCM
 fCM
 fCM
-dPe
-mah
-dsW
+oIv
+quP
+gbD
 sKd
 xgL
 cdn
 cdn
 cdn
 cdn
-nrx
+dsW
 obL
 xKF
 vtw
@@ -333976,16 +333969,16 @@ uaL
 xAt
 xAt
 xKF
-pLU
+oKh
 iuo
 iuo
 iuo
-dPe
+oIv
 wPC
-dsW
+gbD
 sKd
 xgL
-mXh
+uaI
 cdn
 cdn
 cdn
@@ -334378,15 +334371,15 @@ paf
 xAt
 xAt
 xKF
-qCT
-qCT
-qCT
+bLM
+bLM
+bLM
 iuo
 fCM
 sKd
 sKd
 vSM
-rSH
+nep
 cdn
 cdn
 wIl
@@ -334403,7 +334396,7 @@ vtw
 qZh
 ltk
 mwE
-dZK
+tJT
 mwE
 mwE
 aOv
@@ -334780,11 +334773,11 @@ paf
 xAt
 xAt
 xKF
-pIO
-gQV
-pwX
+goz
+mVz
+qxn
 iuo
-oIv
+adJ
 sKd
 sKd
 xKF
@@ -335190,7 +335183,7 @@ xKF
 xKF
 xKF
 xKF
-qKU
+ibh
 eCn
 eCn
 xKF
@@ -383827,31 +383820,31 @@ erZ
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-uGf
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+kvj
+kvj
+kvj
+kvj
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
 erZ
 erZ
 erZ
@@ -384229,31 +384222,31 @@ erZ
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-uGf
-aac
+kvj
+kvj
+kvj
+kvj
+loE
+efv
+nSL
+wSl
+vWY
+loE
+wSl
+wSl
+loE
+gwf
+kvj
+tJC
+kvj
 pMn
-pWl
-jIP
-tlQ
-aac
-jIP
-jIP
-aac
-qQu
-uGf
-gnD
-uGf
-jph
-gnD
-gnD
-rcr
-uGf
-uGf
-gnD
-dAf
+tJC
+tJC
+qYw
+kvj
+kvj
+tJC
+lGI
 erZ
 erZ
 erZ
@@ -384631,31 +384624,31 @@ erZ
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-uGf
-aac
-pMn
-nTR
-jIP
-tlQ
-aac
-jIP
-jIP
-aac
-gYj
-seC
-seC
-gYj
-aac
-mVz
-qrm
-aac
-oOS
-uGf
-hHz
-dAf
+kvj
+kvj
+kvj
+kvj
+loE
+efv
+mnP
+wSl
+vWY
+loE
+wSl
+wSl
+loE
+lfb
+vGQ
+vGQ
+lfb
+loE
+nwk
+ieP
+loE
+fVM
+kvj
+djJ
+lGI
 erZ
 erZ
 erZ
@@ -385033,31 +385026,31 @@ erZ
 erZ
 erZ
 erZ
+kvj
+kvj
+kvj
+kvj
+loE
+loE
+loE
+bVT
+wSl
+loE
+wSl
+wSl
+loE
+nBf
+xET
+kvj
 uGf
-uGf
-uGf
-uGf
-aac
-aac
-aac
-ulg
-jIP
-aac
-jIP
-jIP
-aac
-mvx
-mQA
-uGf
-jWz
-aac
-vVR
-vVR
-aac
-ciQ
-bIe
-oTK
-dAf
+loE
+pcQ
+pcQ
+loE
+lYi
+bBL
+aoY
+lGI
 erZ
 erZ
 erZ
@@ -385435,31 +385428,31 @@ erZ
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-uGf
-aac
-aac
-aac
-ulg
-tlQ
-aac
-jIP
-jIP
-aac
-tKP
-uGf
-uGf
-cSB
-aac
-uaj
-uaj
-aac
-aac
-aac
-aac
-aac
+kvj
+kvj
+kvj
+kvj
+loE
+loE
+loE
+bVT
+vWY
+loE
+wSl
+wSl
+loE
+mFB
+kvj
+kvj
+dYw
+loE
+dRd
+dRd
+loE
+loE
+loE
+loE
+loE
 erZ
 erZ
 erZ
@@ -385837,31 +385830,31 @@ erZ
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-uGf
-aac
-aac
-aac
-sxM
-jIP
-aac
-jIP
-jIP
-aac
-kwN
-uGf
-uGf
-cSB
-aac
-liA
-uGf
-aac
-aac
-aac
-aac
-aac
+kvj
+kvj
+kvj
+kvj
+loE
+loE
+loE
+cuc
+wSl
+loE
+wSl
+wSl
+loE
+wFq
+kvj
+kvj
+dYw
+loE
+lhd
+kvj
+loE
+loE
+loE
+loE
+loE
 erZ
 erZ
 erZ
@@ -386239,31 +386232,31 @@ erZ
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-aac
-aac
-aac
-aac
-aac
-mHT
-aac
-aac
-aac
-aac
-nJy
-mQA
-uGf
-csg
-aac
-seC
-seC
-rcr
-uGf
-hHz
-gnD
-dAf
+kvj
+kvj
+kvj
+loE
+loE
+loE
+loE
+loE
+kqv
+loE
+loE
+loE
+loE
+cAC
+xET
+kvj
+hhq
+loE
+vGQ
+vGQ
+qYw
+kvj
+djJ
+tJC
+lGI
 erZ
 erZ
 erZ
@@ -386641,31 +386634,31 @@ vIa
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-aac
-bYy
-jIP
-kFh
-jIP
-jIP
-mSy
-aac
-gip
-uGf
-uGf
-uGf
-seC
-gYj
-aac
-uGf
-uGf
-aac
-uGf
-uGf
-uGf
-dAf
+kvj
+kvj
+kvj
+loE
+dpQ
+wSl
+lkQ
+wSl
+wSl
+eoz
+loE
+uvR
+kvj
+kvj
+kvj
+vGQ
+lfb
+loE
+kvj
+kvj
+loE
+kvj
+kvj
+kvj
+lGI
 erZ
 erZ
 erZ
@@ -387043,31 +387036,31 @@ vIa
 erZ
 erZ
 erZ
-uGf
-uGf
-uGf
-aac
-gir
-jIP
-jIP
-jIP
-tlQ
-fZP
-aac
-gip
-uGf
-uFp
-uGf
-pUH
-gYj
-aac
-liA
-uGf
-aac
-uxo
-khc
-oTK
-dAf
+kvj
+kvj
+kvj
+loE
+dmR
+wSl
+wSl
+wSl
+vWY
+rSZ
+loE
+uvR
+kvj
+bPz
+kvj
+bHc
+lfb
+loE
+lhd
+kvj
+loE
+bbY
+frx
+aoY
+lGI
 erZ
 erZ
 erZ
@@ -387445,31 +387438,31 @@ vIa
 vIa
 erZ
 erZ
-uGf
-uGf
-uGf
-aac
-fNp
-jIP
-jIP
-tlQ
-jIP
-fZP
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-slh
-slh
-aac
-aac
-aac
-aac
-aac
+kvj
+kvj
+kvj
+loE
+uQG
+wSl
+wSl
+vWY
+wSl
+rSZ
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+hdO
+hdO
+loE
+loE
+loE
+loE
+loE
 erZ
 erZ
 erZ
@@ -387850,24 +387843,24 @@ erZ
 erZ
 erZ
 erZ
-aac
-nRU
-jIP
-jIP
-jIP
-jIP
-mSy
-aac
-pjB
-mwy
-nwj
-kFh
-nwj
-mwy
-suN
-jIP
-slz
-xUO
+loE
+vox
+wSl
+wSl
+wSl
+wSl
+eoz
+loE
+uvu
+gJk
+dcO
+lkQ
+dcO
+gJk
+cVb
+wSl
+pns
+wVA
 erZ
 erZ
 erZ
@@ -388252,24 +388245,24 @@ erZ
 erZ
 erZ
 erZ
-aac
-nyu
-tlQ
-jIP
-tFU
-jIP
-goz
-aac
-jIP
-xEP
-xEP
-jIP
-rhG
-rhG
-jIP
-tlQ
-jIP
-xUO
+loE
+wUw
+vWY
+wSl
+iVf
+wSl
+tLN
+loE
+wSl
+cxa
+cxa
+wSl
+wOO
+wOO
+wSl
+vWY
+wSl
+wVA
 erZ
 erZ
 erZ
@@ -388654,24 +388647,24 @@ erZ
 erZ
 erZ
 erZ
-aac
-xDC
-jIP
-pjB
-sfZ
-jIP
-aHC
-fvB
-jIP
-tlQ
-jIP
-tlQ
-jIP
-jIP
-jIP
-jIP
-jIP
-xUO
+loE
+iNC
+wSl
+uvu
+uCR
+wSl
+qzy
+pgX
+wSl
+vWY
+wSl
+vWY
+wSl
+wSl
+wSl
+wSl
+wSl
+wVA
 erZ
 erZ
 erZ
@@ -389056,24 +389049,24 @@ erZ
 erZ
 erZ
 erZ
-aac
-qpS
-jIP
-pjB
-qyo
-jIP
-goz
-aac
-jIP
-veT
-veT
-jIP
-jIP
-sqi
-sqi
-jIP
-tlQ
-xUO
+loE
+pfz
+wSl
+uvu
+tiv
+wSl
+tLN
+loE
+wSl
+fHV
+fHV
+wSl
+wSl
+jlY
+jlY
+wSl
+vWY
+wVA
 erZ
 erZ
 erZ
@@ -389458,24 +389451,24 @@ erZ
 erZ
 erZ
 erZ
-aac
-hGF
-jIP
-jIP
-jIP
-jIP
-mdB
-aac
-pjB
-nwj
-nwj
-suN
-slz
-jIP
-pWl
-sKY
-jIP
-xUO
+loE
+bUi
+wSl
+wSl
+wSl
+wSl
+rcS
+loE
+uvu
+dcO
+dcO
+cVb
+pns
+wSl
+nSL
+wra
+wSl
+wVA
 erZ
 erZ
 erZ
@@ -389860,24 +389853,24 @@ erZ
 erZ
 erZ
 erZ
-aac
-gEw
-jIP
-pjB
-sfZ
-jIP
-mdB
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-hFZ
-hFZ
-aac
+loE
+flY
+wSl
+uvu
+uCR
+wSl
+rcS
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+oum
+oum
+loE
 erZ
 erZ
 erZ
@@ -390262,28 +390255,28 @@ erZ
 erZ
 erZ
 erZ
-aac
-qpS
-jIP
-pjB
-qyo
-jIP
-qPE
-aac
-jlY
-jYO
-rfO
-eoB
-rfO
-jYO
-eoB
-sKY
-jIP
-aac
-aac
-aac
-aac
-aac
+loE
+pfz
+wSl
+uvu
+tiv
+wSl
+maO
+loE
+txH
+hay
+shH
+fla
+shH
+hay
+fla
+wra
+wSl
+loE
+loE
+loE
+loE
+loE
 erZ
 erZ
 erZ
@@ -390663,29 +390656,29 @@ erZ
 erZ
 aUc
 erZ
-aac
-aac
-ulg
-jIP
-jIP
-kuV
-jIP
-tOG
-aac
-jIP
-jIP
-jIP
-jIP
-jIP
-jIP
-jIP
-rGY
-jIP
-rcr
-uGf
-uGf
-gnD
-dAf
+loE
+loE
+bVT
+wSl
+wSl
+yif
+wSl
+pFL
+loE
+wSl
+wSl
+wSl
+wSl
+wSl
+wSl
+wSl
+jpw
+wSl
+qYw
+kvj
+kvj
+tJC
+lGI
 erZ
 erZ
 erZ
@@ -391065,29 +391058,29 @@ vIa
 vIa
 aUc
 aUc
-aac
-aac
-ulg
-tlQ
-jIP
-jIP
-jIP
-aHC
-aac
-duh
-jIP
-jIP
-lhi
-jIP
-rGY
-jIP
-jIP
-jIP
-aac
-xyM
-uGf
-uGf
-dAf
+loE
+loE
+bVT
+vWY
+wSl
+wSl
+wSl
+qzy
+loE
+maz
+wSl
+wSl
+bVP
+wSl
+jpw
+wSl
+wSl
+wSl
+loE
+bCb
+kvj
+kvj
+lGI
 erZ
 erZ
 erZ
@@ -391467,29 +391460,29 @@ vIa
 vIa
 aUc
 aUc
-ifB
-ifB
-ulg
-wHL
-aHC
-jIP
-tlQ
-jIP
-fmx
-jIP
-rGY
-jIP
-jIP
-jIP
-jIP
-jIP
-jIP
-jIP
-aac
-oOS
-uGf
-uGf
-dAf
+itC
+itC
+bVT
+gip
+qzy
+wSl
+vWY
+wSl
+lqf
+wSl
+jpw
+wSl
+wSl
+wSl
+wSl
+wSl
+wSl
+wSl
+loE
+fVM
+kvj
+kvj
+lGI
 erZ
 erZ
 erZ
@@ -391870,28 +391863,28 @@ vIa
 vIa
 vIa
 aUc
-ifB
-ifB
-ifB
-aHC
-aHC
-jIP
-jIP
-kDX
-cIz
-jIP
-jIP
-jIP
-jIP
-jIP
-jIP
-rGY
-jIP
-aac
-liA
-uGf
-uGf
-dAf
+itC
+itC
+itC
+qzy
+qzy
+wSl
+wSl
+bje
+sjf
+wSl
+wSl
+wSl
+wSl
+wSl
+wSl
+jpw
+wSl
+loE
+lhd
+kvj
+kvj
+lGI
 erZ
 erZ
 erZ
@@ -392274,26 +392267,26 @@ vIa
 vIa
 aUc
 aUc
-ifB
-ifB
-qoJ
-aHC
-aHC
-aac
-aac
-dOw
-dOw
-vkW
-dOw
-sKY
-jIP
-jIP
-jIP
-aac
-uwd
-oTK
-wPz
-dAf
+itC
+itC
+rmO
+qzy
+qzy
+loE
+loE
+wou
+wou
+fQq
+wou
+wra
+wSl
+wSl
+wSl
+loE
+oiw
+aoY
+qjb
+lGI
 erZ
 erZ
 erZ
@@ -392677,25 +392670,25 @@ vIa
 vIa
 aUc
 aUc
-ifB
-ifB
-ifB
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-nff
-nff
-nff
-nff
-aac
-aac
-aac
-aac
-aac
+itC
+itC
+itC
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+bjo
+bjo
+bjo
+bjo
+loE
+loE
+loE
+loE
+loE
 erZ
 erZ
 erZ
@@ -394327,13 +394320,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-nPQ
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+qKU
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -394729,13 +394722,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wLB
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+uWe
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -395107,12 +395100,12 @@ xKz
 xKz
 xKz
 xKz
-uJC
-oBD
-wKf
-eiT
-uGq
-iDQ
+xaD
+aWb
+hoM
+txK
+rkK
+gMb
 xKz
 erZ
 erZ
@@ -395131,13 +395124,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-nPQ
-wDz
-nPQ
-fth
-wDz
-vPA
+mQA
+qKU
+jNF
+qKU
+lYb
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -395504,10 +395497,10 @@ erZ
 fVQ
 fVQ
 xKz
-ylg
-ogC
-ogC
-nCd
+arA
+pYU
+pYU
+tpw
 xKz
 fVQ
 fVQ
@@ -395533,13 +395526,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wDz
-wDz
-wLB
-nPQ
-wDz
-vPA
+mQA
+jNF
+jNF
+uWe
+qKU
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -395914,14 +395907,14 @@ xKz
 fVQ
 fVQ
 jeb
-dEF
+uqa
 fVQ
-mFp
+hcQ
 xKz
 fVQ
 bvN
 tYP
-iME
+cCS
 jeb
 erZ
 erZ
@@ -395935,13 +395928,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wDz
-wDz
-nPQ
-fth
-wDz
-vPA
+mQA
+jNF
+jNF
+qKU
+lYb
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -396312,18 +396305,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-bZW
+pjB
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-bZW
+pjB
 fVQ
 bvN
 tYP
-pOS
+ptC
 jeb
 erZ
 erZ
@@ -396337,13 +396330,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-nPQ
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+qKU
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -396708,24 +396701,24 @@ erZ
 erZ
 erZ
 xKz
-ktR
-wUw
+gLG
+urF
 fVQ
 fVQ
 lLa
-dlw
+jmo
 jeb
-keM
-msY
-iqu
-iVn
+lPz
+mQF
+tQQ
+rcr
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-woq
+iuz
 jeb
 erZ
 erZ
@@ -396739,13 +396732,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wLB
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+uWe
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -397110,12 +397103,12 @@ erZ
 erZ
 erZ
 xKz
-rHj
-wUw
+oGN
+urF
 fVQ
 fVQ
 lLa
-dlw
+jmo
 jeb
 xKz
 xKz
@@ -397127,7 +397120,7 @@ xKz
 fVQ
 tYP
 tYP
-vsg
+jkU
 jeb
 erZ
 erZ
@@ -397141,13 +397134,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-nPQ
-wDz
-nPQ
-fth
-wDz
-vPA
+mQA
+qKU
+jNF
+qKU
+lYb
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -397512,24 +397505,24 @@ erZ
 erZ
 erZ
 xKz
-swn
-wUw
+fEv
+urF
 fVQ
 fVQ
 fVQ
 fVQ
-bZW
+pjB
 fVQ
-pSO
-vTj
-ovj
+wuX
+cel
+tET
 fVQ
-alz
+mMp
 xKz
 fVQ
 bvN
 tYP
-iME
+cCS
 jeb
 erZ
 erZ
@@ -397543,13 +397536,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wDz
-wDz
-wLB
-nPQ
-wDz
-vPA
+mQA
+jNF
+jNF
+uWe
+qKU
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -397914,24 +397907,24 @@ erZ
 erZ
 erZ
 xKz
-fpm
-wUw
+eTQ
+urF
 fVQ
-hAA
+khc
 fVQ
 fVQ
 jeb
-mhS
+hDv
 fVQ
 fVQ
 fVQ
 fVQ
-kvj
+wzc
 xKz
 fVQ
 bvN
 tYP
-pOS
+ptC
 jeb
 erZ
 erZ
@@ -397945,13 +397938,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-nPQ
-wDz
-nPQ
-fth
-wDz
-vPA
+mQA
+qKU
+jNF
+qKU
+lYb
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -398320,20 +398313,20 @@ xKz
 xKz
 xKz
 xKz
-ktG
+lwa
 xKz
 xKz
-pPj
+vJg
 fVQ
 jeb
-dEF
+uqa
 fVQ
-qCY
+mVd
 xKz
 fVQ
 tYP
 tYP
-woq
+iuz
 jeb
 erZ
 erZ
@@ -398347,13 +398340,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wLB
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+uWe
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -398725,7 +398718,7 @@ fVQ
 fVQ
 fVQ
 xKz
-kGT
+ggU
 fVQ
 fVQ
 fVQ
@@ -398735,7 +398728,7 @@ xKz
 fVQ
 tYP
 tYP
-vsg
+jkU
 jeb
 erZ
 erZ
@@ -398749,13 +398742,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-nPQ
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+qKU
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -399127,17 +399120,17 @@ vZP
 lLa
 fVQ
 xKz
-hDQ
-rGv
-biC
-ykZ
+mUt
+oxe
+msY
+hBU
 fVQ
-jNF
+qsC
 xKz
 fVQ
-lhd
+fIB
 tYP
-iME
+cCS
 jeb
 erZ
 erZ
@@ -399151,13 +399144,13 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wDz
-wDz
-wDz
-wDz
-wDz
-vPA
+mQA
+jNF
+jNF
+jNF
+jNF
+jNF
+cjJ
 erZ
 erZ
 erZ
@@ -399527,7 +399520,7 @@ fVQ
 lLa
 noC
 lLa
-mFp
+hcQ
 xKz
 xKz
 xKz
@@ -399537,7 +399530,7 @@ xKz
 xKz
 xKz
 fVQ
-lhd
+fIB
 fVQ
 fVQ
 jeb
@@ -399553,10 +399546,10 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wDz
+mQA
+jNF
 xKz
-xkF
+pcn
 bOK
 jeb
 xKz
@@ -399938,7 +399931,7 @@ fVQ
 fVQ
 xKz
 xKz
-ktG
+lwa
 xKz
 xKz
 xKz
@@ -399955,8 +399948,8 @@ erZ
 erZ
 erZ
 erZ
-pdm
-wDz
+mQA
+jNF
 jeb
 fVQ
 ugK
@@ -419211,7 +419204,7 @@ ygF
 ygF
 ygF
 ygF
-riW
+lgr
 jYR
 lHe
 lHe
@@ -432071,8 +432064,8 @@ wAm
 wAm
 wAm
 wAm
-qLF
-qLF
+rsS
+rsS
 wAm
 wAm
 wAm
@@ -432470,22 +432463,22 @@ teW
 kwf
 nRx
 rwH
-ipw
+nlx
 teW
 kqc
-kVq
+qYf
 jjS
-dbZ
-wte
+iRc
+vMQ
 vsf
 rwH
 nKu
 jiv
 rwH
 teW
-dbt
-eMv
-wte
+qpX
+lZw
+vMQ
 enq
 fZJ
 fZJ
@@ -432874,8 +432867,8 @@ jiv
 jiv
 uSx
 teW
-nSr
-ijU
+luX
+oQC
 jiv
 jiv
 jiv
@@ -432886,7 +432879,7 @@ jiv
 jjS
 teW
 hqI
-bmL
+ikM
 hqI
 enq
 fZJ
@@ -433276,8 +433269,8 @@ jiv
 jiv
 teW
 teW
-wte
-ijU
+vMQ
+oQC
 jiv
 jiv
 jiv
@@ -433288,11 +433281,11 @@ jiv
 vIX
 teW
 hqI
-bmL
+ikM
 hqI
-maZ
-atl
-jyO
+dkx
+iVt
+lKw
 fZJ
 fZJ
 fZJ
@@ -433683,18 +433676,18 @@ jiv
 jiv
 jiv
 qfh
-itC
+nSr
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-bmL
+ikM
 hqI
 jFM
 jFM
-akm
+bPv
 fZJ
 fZJ
 fZJ
@@ -434084,19 +434077,19 @@ xSI
 jiv
 jiv
 jiv
-mQr
-uVy
+dQX
+veh
 htU
 teW
 ael
 hqI
 hqI
 hqI
-bmL
+ikM
 hqI
 jFM
 jFM
-qTo
+iSJ
 fZJ
 fZJ
 fZJ
@@ -434483,8 +434476,8 @@ xSI
 tML
 tML
 tML
-tdl
-tdl
+uPd
+uPd
 tML
 aGb
 tML
@@ -434494,11 +434487,11 @@ pDA
 hqI
 hqI
 hqI
-bmL
+ikM
 hqI
 jFM
 jFM
-qTo
+iSJ
 fZJ
 fZJ
 fZJ
@@ -434887,20 +434880,20 @@ tML
 teW
 nyc
 ntK
-gbA
-cAe
-cAe
 rSg
+cAe
+cAe
+jkQ
 teW
 ulu
 hqI
 fVE
-bmL
-uPa
+ikM
+lLK
 hqI
-gSz
-gSz
-qeY
+uWv
+uWv
+bos
 fZJ
 fZJ
 fZJ
@@ -435289,16 +435282,16 @@ lPt
 swm
 nyc
 ntK
-tUB
-lYl
-lYl
-lYl
+tak
+xrf
+xrf
+xrf
 teW
 uNz
 hqI
 hqI
-bmL
-hhK
+ikM
+qUi
 ojc
 enq
 fZJ
@@ -435682,7 +435675,7 @@ erZ
 erZ
 fZJ
 fZJ
-dSK
+qLF
 gys
 tsB
 aur
@@ -435691,15 +435684,15 @@ pLs
 swm
 nyc
 ntK
-pYt
-cRP
-cRP
-cRP
+lAg
+hCF
+hCF
+hCF
 teW
 ajj
-uPa
-uPa
-uPa
+lLK
+lLK
+lLK
 tML
 tML
 fZJ
@@ -436093,16 +436086,16 @@ vrG
 wtl
 ntK
 ntK
-hai
-xrf
-xrf
-xrf
+lYl
+wHm
+wHm
+wHm
 ohA
 bcN
 bcN
 bcN
 vWe
-sNn
+cJt
 ffv
 fZJ
 fZJ
@@ -436493,7 +436486,7 @@ oBU
 sUQ
 xXs
 ntK
-dNL
+qvs
 ntK
 uTT
 swm
@@ -436894,10 +436887,10 @@ uKB
 aur
 uZa
 cPw
-jkm
+bWv
 ntK
 ntK
-tak
+jzB
 ybm
 ybm
 ybm
@@ -436906,7 +436899,7 @@ bcN
 bcN
 bcN
 vWe
-nJR
+pnd
 ffv
 fZJ
 fZJ
@@ -437290,7 +437283,7 @@ erZ
 erZ
 fZJ
 fZJ
-dSK
+qLF
 pfp
 sUb
 aur
@@ -437299,10 +437292,10 @@ pLs
 swm
 nyc
 ntK
-gbA
 rSg
-rSg
-rSg
+jkQ
+jkQ
+jkQ
 teW
 eYI
 uZC
@@ -437701,14 +437694,14 @@ oyP
 swm
 nyc
 ntK
-tUB
-lYl
-lYl
-lYl
+tak
+xrf
+xrf
+xrf
 tML
-pfG
-pfG
-pfG
+aVp
+aVp
+aVp
 tML
 tML
 tML
@@ -438103,14 +438096,14 @@ tML
 aXE
 nyc
 ntK
-rCp
-bPk
-bPk
-mFE
+xSj
+xvn
+xvn
+ivM
 tML
-rAj
-rAj
-rAj
+mua
+mua
+mua
 wAm
 wAm
 wAm
@@ -438127,7 +438120,7 @@ squ
 squ
 squ
 rTC
-vHd
+egz
 squ
 squ
 squ
@@ -438503,7 +438496,7 @@ tML
 teW
 tML
 tML
-uHk
+nAQ
 fnF
 tML
 aGb
@@ -438517,7 +438510,7 @@ wpe
 fQd
 eCn
 sNY
-vfw
+ebJ
 teW
 teW
 teW
@@ -438529,7 +438522,7 @@ squ
 squ
 squ
 rTC
-vHd
+egz
 rTC
 rTC
 rTC
@@ -438923,7 +438916,7 @@ eCn
 teW
 aor
 xfh
-eLb
+rKB
 teW
 squ
 squ
@@ -439319,8 +439312,8 @@ cfY
 cfY
 teW
 aTF
-qye
-vdx
+sIE
+lJI
 eCn
 mYi
 gbX
@@ -439721,8 +439714,8 @@ uZy
 cfY
 alk
 eCn
-nSF
-lsW
+pgU
+ste
 eCn
 mYi
 gbX
@@ -440105,14 +440098,14 @@ erZ
 fZJ
 fZJ
 rxp
-auL
+rKK
 uKB
 uBv
 tML
 tML
 tML
 xnv
-hbc
+dpF
 tML
 rMM
 cfY
@@ -440127,9 +440120,9 @@ eCn
 eCn
 eCn
 teW
-fxb
-tiv
-cOS
+wTe
+xDg
+ahV
 teW
 squ
 squ
@@ -440911,8 +440904,8 @@ fZJ
 rxp
 uKB
 uKB
-vBG
-qUs
+nnZ
+vwi
 uKB
 nIr
 swm
@@ -441710,14 +441703,14 @@ vIa
 vIa
 aUc
 teW
-lCN
+agJ
 teW
 uKB
 uKB
-hRM
-cGC
-lbf
-nCo
+uEX
+jSc
+fDi
+uee
 tML
 swm
 swm
@@ -442112,10 +442105,10 @@ vIa
 vIa
 aUc
 teW
-tXF
+eEQ
 teW
-mis
-eJL
+lcJ
+bFq
 tML
 tML
 ydR
@@ -442131,10 +442124,10 @@ idu
 sct
 sNp
 cfY
-jpw
-dQw
-pOH
-wos
+jkx
+nhm
+gWR
+xHe
 eCn
 teW
 lMZ
@@ -442522,21 +442515,21 @@ cgD
 tML
 hqI
 tML
-kKo
+mdB
 swm
 swm
 tML
-tTl
+mQr
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-jpw
-xtu
-qtL
-imB
+jkx
+kFh
+ibY
+uSz
 eCn
 teW
 lMZ
@@ -442930,15 +442923,15 @@ swm
 tML
 rMM
 eVa
-bLL
+tYB
 tcW
 tcW
 tcW
 eVa
-pyz
-gdw
-skh
-ghb
+vBk
+rHj
+wya
+pQS
 eCn
 teW
 lMZ
@@ -443318,7 +443311,7 @@ vIa
 vIa
 aUc
 teW
-nYl
+etM
 nMd
 uKB
 uKB
@@ -443327,7 +443320,7 @@ tML
 tML
 tML
 wAm
-hbc
+dpF
 wAm
 wAm
 teW
@@ -443722,14 +443715,14 @@ aUc
 teW
 teW
 teW
-qUs
+vwi
 uKB
 uKB
-fZo
+cYN
 iYx
-uEX
-iug
-iug
+wki
+bHX
+bHX
 teW
 iYx
 iYx
@@ -444124,18 +444117,18 @@ aUc
 lMZ
 lMZ
 teW
-qUs
+vwi
 uKB
 uKB
-qKm
+qlL
 iYx
 vaa
-iug
-dAq
+bHX
+rDI
 teW
-bty
-lhj
-bop
+qwp
+nIl
+urY
 iYx
 lMZ
 lMZ
@@ -444526,18 +444519,18 @@ vIa
 lAs
 lMZ
 teW
-qUs
+vwi
 uKB
 uKB
-mFF
+jCr
 iYx
-oxf
-iug
-iug
+svk
+bHX
+bHX
 teW
-tFq
-iug
-iug
+nGi
+bHX
+bHX
 iYx
 lMZ
 lAs
@@ -444928,18 +444921,18 @@ vIa
 lAs
 lMZ
 teW
-aok
+ioM
 uKB
 uKB
-qmo
+cvC
 iYx
-gjr
-iug
-iug
-vCy
-iug
-iug
-hVz
+aem
+bHX
+bHX
+vYh
+bHX
+bHX
+sZX
 iYx
 lMZ
 lAs
@@ -445335,13 +445328,13 @@ teW
 teW
 teW
 iYx
-gnI
-iug
-qGj
+cpS
+bHX
+eNu
 iYx
-rOz
-bsL
-oRp
+dwO
+nhT
+mQd
 iYx
 lMZ
 lAs
@@ -445737,9 +445730,9 @@ iYx
 iYx
 iYx
 iYx
-uEX
-iug
-qgY
+wki
+bHX
+fGT
 iYx
 iYx
 iYx
@@ -446136,16 +446129,16 @@ lAs
 lAs
 lMZ
 iYx
-qgY
-loE
+fGT
+tRN
 iYx
 iYx
-iug
-qGj
+bHX
+eNu
 iYx
-bty
-lhj
-bop
+qwp
+nIl
+urY
 iYx
 lMZ
 lAs
@@ -446538,16 +446531,16 @@ lAs
 lAs
 lMZ
 iYx
-tFq
-iug
-uHk
-iug
-iug
-iug
+nGi
+bHX
+nAQ
+bHX
+bHX
+bHX
 iYx
-tFq
-iug
-iug
+nGi
+bHX
+bHX
 iYx
 lMZ
 lAs
@@ -446940,16 +446933,16 @@ lAs
 lAs
 lMZ
 iYx
-iug
-iug
+bHX
+bHX
 iYx
-iug
-iug
-iug
-vCy
-iug
-iug
-hVz
+bHX
+bHX
+bHX
+vYh
+bHX
+bHX
+sZX
 iYx
 lMZ
 lAs
@@ -447342,16 +447335,16 @@ lAs
 lAs
 lMZ
 iYx
-uSR
-oRp
+mWk
+mQd
 iYx
-iug
-jHJ
-kKJ
+bHX
+umt
+dwk
 iYx
-rOz
-bsL
-oRp
+dwO
+nhT
+mQd
 iYx
 lMZ
 lAs
@@ -447743,18 +447736,18 @@ vIa
 vIa
 vIa
 aUc
-iKn
+rGS
 iYx
 iYx
 iYx
-mdt
+mbd
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-iKn
+rGS
 aUc
 vIa
 vIa
@@ -448148,7 +448141,7 @@ aUc
 aUc
 iYx
 iYx
-fAj
+jZP
 tWY
 tWY
 iyd
@@ -448549,8 +448542,8 @@ vIa
 vIa
 aUc
 iYx
-tMh
-hXa
+iqW
+bVa
 tWY
 tWY
 iyd
@@ -448951,8 +448944,8 @@ vIa
 vIa
 aUc
 iYx
-ivv
-hXa
+vbR
+bVa
 tWY
 tWY
 iyd
@@ -449353,8 +449346,8 @@ vIa
 vIa
 aUc
 iYx
-vCY
-hAr
+bPy
+dpx
 uZC
 uZC
 uZC
@@ -449757,9 +449750,9 @@ aUc
 iYx
 iYx
 iYx
-jEB
-jEB
-xET
+gvV
+gvV
+saN
 iYx
 lMZ
 lMZ
@@ -451755,16 +451748,16 @@ iyK
 iyK
 iyK
 iyK
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
 iyK
 iyK
 iyK
@@ -452156,17 +452149,17 @@ iyK
 iyK
 iyK
 iyK
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
 iyK
 iyK
 iyK
@@ -452559,16 +452552,16 @@ iyK
 iyK
 iyK
 iyK
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
 iyK
 iyK
 iyK
@@ -452961,16 +452954,16 @@ iyK
 iyK
 iyK
 iyK
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
-qRm
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
+nPQ
 iyK
 iyK
 iyK
@@ -486342,27 +486335,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-tar
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+loE
+eMs
 erZ
 erZ
 erZ
@@ -486744,27 +486737,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-uGf
-axp
-aac
-aac
-aac
-gnD
-uGf
-uGf
-uGf
-gnD
-rcr
-uGf
-aac
-jtq
-qfJ
-qHy
-htf
-jMf
-htf
-oiW
+loE
+kvj
+gkL
+loE
+loE
+loE
+tJC
+kvj
+kvj
+kvj
+tJC
+qYw
+kvj
+loE
+dht
+wyA
+mpG
+quL
+bzl
+quL
+xIo
 erZ
 erZ
 erZ
@@ -487146,27 +487139,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-uGf
-kMA
-aac
-aac
-aac
-uGf
-uGf
-hzR
-sEX
-sEX
-aac
-uGf
-sAp
-jMf
-aSD
-jMf
-aSD
-jMf
-jMf
-lOp
+loE
+kvj
+ixN
+loE
+loE
+loE
+kvj
+kvj
+eyb
+pAX
+pAX
+loE
+kvj
+mJj
+bzl
+ycz
+bzl
+ycz
+bzl
+bzl
+uzT
 erZ
 erZ
 erZ
@@ -487548,27 +487541,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-uGf
-uGf
-cSB
-aac
-mvx
-ila
-pcQ
-mYI
-aac
-aac
-aac
-rcr
-aac
-ssk
-jMf
-jMf
-jMf
-jMf
-jMf
-ghT
+loE
+kvj
+kvj
+dYw
+loE
+nBf
+nZq
+oiE
+pKQ
+loE
+loE
+loE
+qYw
+loE
+eza
+bzl
+bzl
+bzl
+bzl
+bzl
+vCX
 erZ
 erZ
 erZ
@@ -487950,27 +487943,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-uGf
-uGf
-cSB
-aac
-oCS
-uGf
-uGf
-cwd
-aac
-liA
-wFp
-uGf
-aac
-fLK
-lYH
-trg
-jMf
-jMf
-jMf
-oiW
+loE
+kvj
+kvj
+dYw
+loE
+ogC
+kvj
+kvj
+tCz
+loE
+lhd
+wTs
+kvj
+loE
+hiK
+cUb
+xnP
+bzl
+bzl
+bzl
+xIo
 erZ
 erZ
 erZ
@@ -488352,27 +488345,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-rcr
-aac
-aac
-aac
-oCS
-uGf
-uGf
-cwd
-aac
-wFp
-uGf
-uGf
-tar
-lPG
-akZ
-pML
+loE
+qYw
+loE
+loE
+loE
+ogC
+kvj
+kvj
+tCz
+loE
+wTs
+kvj
+kvj
+eMs
+pRL
+jxM
+aXe
+opC
+bzl
+ycz
 uzT
-jMf
-aSD
-lOp
 erZ
 erZ
 erZ
@@ -488753,28 +488746,28 @@ bqt
 bqt
 bqt
 bqt
-aac
-aac
-ifg
-ifg
-njN
-aac
-mvx
-mQA
+loE
+loE
+rRD
+rRD
+suN
+loE
+nBf
+xET
+kvj
 uGf
-jWz
-aac
-uGf
-pcQ
-wFp
-tar
+loE
+kvj
+oiE
+wTs
+eMs
 wQI
-mjP
+bRM
 wQI
-pnL
-jMf
-jMf
-ghT
+fqF
+bzl
+bzl
+vCX
 erZ
 erZ
 erZ
@@ -489155,28 +489148,28 @@ bqt
 bqt
 bqt
 bqt
-aac
-mvx
-mQA
-uGf
-mYI
-aac
-oCS
-pcQ
-pcQ
-cwd
-aac
-uGf
-uGf
-uGf
-tar
+loE
+nBf
+xET
+kvj
+pKQ
+loE
+ogC
+oiE
+oiE
+tCz
+loE
+kvj
+kvj
+kvj
+eMs
 wQI
 wQI
-vEP
-fab
-jMf
-jMf
-oiW
+ptS
+hPo
+bzl
+bzl
+xIo
 erZ
 erZ
 erZ
@@ -489557,28 +489550,28 @@ bqt
 bqt
 bqt
 bqt
-aac
-oCS
-uGf
-uGf
-cwd
-aac
-oCS
-uGf
-uGf
-cwd
-aac
-uGf
-wFp
-uGf
-tar
-kDh
+loE
+ogC
+kvj
+kvj
+tCz
+loE
+ogC
+kvj
+kvj
+tCz
+loE
+kvj
+wTs
+kvj
+eMs
+sYk
 wQI
-kDh
-bCb
-jMf
-jMf
-lOp
+sYk
+gwt
+bzl
+bzl
+uzT
 erZ
 erZ
 erZ
@@ -489959,28 +489952,28 @@ bqt
 bqt
 bqt
 bqt
-aac
-kwN
+loE
+wFq
+kvj
+rRD
+dYw
+loE
+nBf
+xET
+kvj
 uGf
-ifg
-cSB
-aac
-mvx
-mQA
-uGf
-jWz
-aac
-liA
-uGf
-pcQ
-aac
-aac
-aac
-aac
-mPb
-mPb
-mPb
-avq
+loE
+lhd
+kvj
+oiE
+loE
+loE
+loE
+loE
+mLH
+mLH
+mLH
+ePh
 erZ
 erZ
 erZ
@@ -490361,24 +490354,24 @@ bqt
 bqt
 bqt
 bqt
-aac
-qZr
-mQA
-uGf
-hzR
-aac
-kwN
-uGf
-uGf
-cSB
-aac
-uGf
-pcQ
-uGf
-uGf
-uGf
-iwj
-eoz
+loE
+wsV
+xET
+kvj
+eyb
+loE
+wFq
+kvj
+kvj
+dYw
+loE
+kvj
+oiE
+kvj
+kvj
+kvj
+dbH
+pcO
 erZ
 erZ
 erZ
@@ -490763,24 +490756,24 @@ bqt
 bqt
 bqt
 bqt
-aac
-dpd
-mQA
-uGf
-mYI
-aac
-oCS
-uGf
-uGf
-cwd
-aac
-uGf
-uGf
-uGf
-uGf
-qUD
-iWj
-eoz
+loE
+rWb
+xET
+kvj
+pKQ
+loE
+ogC
+kvj
+kvj
+tCz
+loE
+kvj
+kvj
+kvj
+kvj
+umK
+qzH
+pcO
 erZ
 erZ
 erZ
@@ -491165,24 +491158,24 @@ bqt
 bqt
 bqt
 bqt
-aac
-kwN
-ifg
+loE
+wFq
+rRD
+kvj
+tCz
+loE
+nBf
+xET
+kvj
 uGf
-cwd
-aac
-mvx
-mQA
-uGf
-jWz
-aac
-uGf
-uGf
-pcQ
-uGf
-iwj
-dUF
-kdz
+loE
+kvj
+kvj
+oiE
+kvj
+dbH
+hiq
+lpD
 erZ
 erZ
 erZ
@@ -491567,24 +491560,24 @@ bqt
 bqt
 bqt
 bqt
-aac
-oCS
-uGf
-uGf
-cSB
-aac
-cSB
-pcQ
-pcQ
-cwd
-aac
-liA
-uGf
-uGf
-uGf
-iwj
-iWj
-eoz
+loE
+ogC
+kvj
+kvj
+dYw
+loE
+dYw
+oiE
+oiE
+tCz
+loE
+lhd
+kvj
+kvj
+kvj
+dbH
+qzH
+pcO
 erZ
 erZ
 erZ
@@ -491969,24 +491962,24 @@ bqt
 bqt
 bqt
 bqt
-aac
-mvx
-mQA
-uGf
-xpM
-xpM
-xpM
-uGf
-uGf
-xpM
-xpM
-pcQ
-uGf
-uGf
-kxw
-ewU
-iWj
-eoz
+loE
+nBf
+xET
+kvj
+vGN
+vGN
+vGN
+kvj
+kvj
+vGN
+vGN
+oiE
+kvj
+kvj
+rhI
+vQV
+qzH
+pcO
 erZ
 erZ
 erZ
@@ -492371,24 +492364,24 @@ bqt
 bqt
 bqt
 bqt
-aac
-oCS
-ifg
-uGf
-erB
-aac
-nJy
-mQA
-uGf
-csg
-aac
-liA
-pcQ
-uGf
-uGf
-uGf
-ewU
-eoz
+loE
+ogC
+rRD
+kvj
+aBP
+loE
+cAC
+xET
+kvj
+hhq
+loE
+lhd
+oiE
+kvj
+kvj
+kvj
+vQV
+pcO
 erZ
 erZ
 erZ
@@ -492773,27 +492766,27 @@ bqt
 bqt
 bqt
 bqt
-aac
-oCS
-uGf
-ifg
-uGf
-rcr
-uGf
-uGf
-uGf
-aac
-aac
-aac
-aac
-aac
-oBZ
-uGf
-uGf
+loE
+ogC
+kvj
+rRD
+kvj
+qYw
+kvj
+kvj
+kvj
+loE
+loE
+loE
+loE
+loE
+lMg
+kvj
+kvj
 uLh
 uLh
-leM
-cld
+aHY
+cLL
 uLh
 erZ
 erZ
@@ -493175,29 +493168,29 @@ bqt
 bqt
 bqt
 bqt
-aac
-pYW
-mQA
-uGf
-oza
-aac
-aac
-aac
-aac
-aac
-aac
+loE
+beK
+xET
+kvj
+aIk
+loE
+loE
+loE
+loE
+loE
+loE
 bqt
 bqt
-aac
-uGf
-wFp
-wFp
+loE
+kvj
+wTs
+wTs
 uLh
-jPD
-tCz
-qdC
+gSO
+tlQ
+eXp
 uLh
-nOR
+ebe
 erZ
 erZ
 erZ
@@ -493577,12 +493570,12 @@ bqt
 bqt
 bqt
 bqt
-aac
-aac
-aac
-aac
-aac
-aac
+loE
+loE
+loE
+loE
+loE
+loE
 bqt
 bqt
 bqt
@@ -493590,17 +493583,17 @@ bqt
 bqt
 bqt
 bqt
-aac
-uGf
-uGf
-uGf
-avi
-tCz
-tCz
-fIs
-cld
-tCz
-tCz
+loE
+kvj
+kvj
+kvj
+hSF
+tlQ
+tlQ
+qTw
+cLL
+tlQ
+tlQ
 erZ
 erZ
 erZ
@@ -493982,9 +493975,9 @@ bqt
 bqt
 bqt
 bqt
-aac
-aac
-aac
+loE
+loE
+loE
 bqt
 bqt
 bqt
@@ -493992,17 +493985,17 @@ bqt
 bqt
 bqt
 bqt
-aac
-uGf
-uGf
-uGf
-avi
-tCz
-tCz
-tCz
-avi
-tCz
-tCz
+loE
+kvj
+kvj
+kvj
+hSF
+tlQ
+tlQ
+tlQ
+hSF
+tlQ
+tlQ
 erZ
 erZ
 erZ
@@ -494394,17 +494387,17 @@ bqt
 bqt
 bqt
 bqt
-aac
-liA
-wFp
-uGf
-avi
-tCz
-tCz
-tCz
-cld
-tCz
-tCz
+loE
+lhd
+wTs
+kvj
+hSF
+tlQ
+tlQ
+tlQ
+cLL
+tlQ
+tlQ
 erZ
 erZ
 erZ
@@ -494796,16 +494789,16 @@ bqt
 bqt
 bqt
 bqt
-aac
-wra
-nke
-uGf
+loE
+sCc
+ogB
+kvj
 uLh
-htv
-tCz
-tCz
+rRA
+tlQ
+tlQ
 uLh
-nOR
+ebe
 erZ
 erZ
 erZ
@@ -495192,21 +495185,21 @@ vIa
 vIa
 aUc
 bqt
-aac
-oIC
-oIC
-oIC
-oIC
-oIC
-oIC
-oIC
-rRD
-rRD
+loE
+dTa
+dTa
+dTa
+dTa
+dTa
+dTa
+dTa
+wDz
+wDz
 uLh
 uLh
-wYp
-wYp
-tzn
+kTm
+kTm
+rqw
 erZ
 erZ
 erZ
@@ -497215,14 +497208,14 @@ erZ
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -497612,19 +497605,19 @@ erZ
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -498014,24 +498007,24 @@ erZ
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -498416,24 +498409,24 @@ erZ
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -498816,26 +498809,26 @@ sri
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -499218,26 +499211,26 @@ sri
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -499620,26 +499613,26 @@ sri
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -500022,26 +500015,26 @@ erZ
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -500424,26 +500417,26 @@ erZ
 erZ
 erZ
 erZ
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -500826,7 +500819,7 @@ erZ
 erZ
 erZ
 erZ
-uDi
+dbt
 iJC
 bOK
 nEd
@@ -500834,18 +500827,18 @@ nEd
 nEd
 bOK
 iJC
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -501228,7 +501221,7 @@ erZ
 erZ
 erZ
 erZ
-uDi
+dbt
 bOK
 fVQ
 fVQ
@@ -501236,18 +501229,18 @@ bmG
 fVQ
 fVQ
 bOK
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -501630,7 +501623,7 @@ erZ
 erZ
 erZ
 erZ
-uDi
+dbt
 nEd
 fVQ
 lgN
@@ -501638,18 +501631,18 @@ jJC
 lgN
 fVQ
 nEd
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -502032,7 +502025,7 @@ erZ
 erZ
 erZ
 erZ
-uDi
+dbt
 nEd
 fVQ
 qxZ
@@ -502046,12 +502039,12 @@ vxC
 vxC
 vxC
 ppx
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -502434,7 +502427,7 @@ erZ
 erZ
 erZ
 erZ
-uDi
+dbt
 nEd
 fVQ
 fVQ
@@ -502448,12 +502441,12 @@ fZJ
 fZJ
 fZJ
 kZS
-uDi
-uDi
-uDi
-uDi
-uDi
-uDi
+dbt
+dbt
+dbt
+dbt
+dbt
+dbt
 erZ
 erZ
 erZ
@@ -543026,11 +543019,11 @@ qzV
 nLH
 pil
 aqS
-xbW
+veW
 fCM
 fCM
 fCM
-rgO
+uFp
 fCM
 nQU
 cGD
@@ -543819,8 +543812,8 @@ vIa
 vIa
 vIa
 vIa
-qYw
-qYw
+qeY
+qeY
 lAs
 woj
 qPA
@@ -544221,8 +544214,8 @@ vIa
 vIa
 vIa
 vIa
-qYw
-qYw
+qeY
+qeY
 lAs
 woj
 qPA
@@ -544623,8 +544616,8 @@ vIa
 vIa
 vIa
 vIa
-qYw
-qYw
+qeY
+qeY
 lAs
 woj
 qPA
@@ -545025,8 +545018,8 @@ vIa
 vIa
 vIa
 vIa
-qYw
-qYw
+qeY
+qeY
 lAs
 eJN
 bHY
@@ -545427,8 +545420,8 @@ vIa
 vIa
 vIa
 vIa
-qYw
-qYw
+qeY
+qeY
 lAs
 lAs
 lAs
@@ -545829,7 +545822,7 @@ vIa
 vIa
 vIa
 vIa
-qYw
+qeY
 vIa
 vIa
 vIa
@@ -546231,7 +546224,7 @@ vIa
 vIa
 vIa
 vIa
-qYw
+qeY
 vIa
 vIa
 vIa
@@ -546633,7 +546626,7 @@ vIa
 vIa
 vIa
 vIa
-qYw
+qeY
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,13 +7,16 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
 	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -500,11 +503,13 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -982,11 +987,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "adK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "adL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -1146,9 +1149,31 @@
 "aem" = (
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
+"aet" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"aeu" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "aev" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
@@ -1167,21 +1192,18 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"afj" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "afp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"afy" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "afz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -1240,10 +1262,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"agR" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "agS" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
@@ -1265,6 +1283,15 @@
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"ahS" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
@@ -1373,10 +1400,6 @@
 /obj/structure/table/church,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
-"amz" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "ans" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "tavern"
@@ -1397,11 +1420,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "aok" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/area/rogue/under/cave)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1465,6 +1489,19 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"arp" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
+"art" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1476,13 +1513,6 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"arY" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
 "arZ" = (
 /obj/structure/floordoor/gatehatch/outer{
 	redstone_id = "gatelava"
@@ -1549,10 +1579,9 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
-	},
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1565,26 +1594,25 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"auZ" = (
-/obj/structure/fluff/railing/border{
+"ava" = (
+/obj/structure/fluff/railing/wood{
 	dir = 4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"avf" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "avh" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"avA" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "avQ" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -1676,9 +1704,15 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1761,6 +1795,32 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
+"aBn" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"aBq" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"aCr" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1785,6 +1845,15 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"aDw" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1850,26 +1919,23 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"aFj" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+"aFh" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"aFE" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "aFS" = (
 /obj/structure/chair/wood/rogue,
 /obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
+"aFX" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "aFY" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
@@ -1877,8 +1943,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "aGb" = (
-/obj/structure/bars,
-/turf/closed/wall/mineral/rogue/stone/window,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "aGO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
@@ -1905,17 +1978,15 @@
 /obj/effect/landmark/map_load_mark/sewers_bottom,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"aHl" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aHo" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"aHq" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "aHs" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1950,10 +2021,6 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"aIo" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "aIx" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/closet/crate/roguecloset,
@@ -1992,6 +2059,12 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak/fried,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"aIK" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "aIQ" = (
 /obj/item/clothing/ring/psydon{
 	max_integrity = 99999999
@@ -2010,10 +2083,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"aJm" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "aJz" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -2071,6 +2140,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"aLg" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "aLo" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -2147,12 +2224,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"aOa" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "aOn" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -2161,6 +2232,15 @@
 "aOv" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"aOJ" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "aOT" = (
 /obj/structure/roguemachine/stockpile{
 	pixel_x = 32;
@@ -2172,6 +2252,20 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"aPg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aPn" = (
 /obj/structure/bars/pipe,
 /obj/structure/mineral_door/wood{
@@ -2199,12 +2293,8 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -2280,14 +2370,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2314,13 +2399,10 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"aTr" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+"aTq" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aTE" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2359,16 +2441,6 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"aUN" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "aUO" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2408,10 +2480,15 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"aVI" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+"aVK" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
@@ -2423,6 +2500,17 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"aWS" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aXa" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
@@ -2440,19 +2528,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"aXr" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
-"aXt" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "aXx" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/spacevine,
@@ -2471,6 +2546,10 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs)
+"aXQ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "aXR" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
@@ -2493,21 +2572,11 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"aZf" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "aZj" = (
 /obj/structure/table/vtable,
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
-"aZp" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "aZG" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/blocks,
@@ -2521,6 +2590,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"aZS" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "aZZ" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/leather,
@@ -2551,6 +2624,11 @@
 	dir = 10
 	},
 /area/rogue/indoors/town/manor)
+"bbA" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bbO" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
@@ -2567,13 +2645,6 @@
 "bcN" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/church/chapel)
-"bds" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "bdu" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -2597,6 +2668,12 @@
 "bdN" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
+"bea" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "bee" = (
 /obj/structure/glowshroom,
 /turf/open/water/swamp,
@@ -2684,6 +2761,12 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"bhe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bhg" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2733,12 +2816,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"bjq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "bjx" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/ruinedwood{
@@ -2800,10 +2877,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"bkT" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -2850,6 +2923,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"bmF" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "bmG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood{
@@ -2857,8 +2934,8 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2926,6 +3003,12 @@
 "bok" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
+"bor" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "bow" = (
 /obj/structure/mineral_door/wood{
@@ -3021,14 +3104,8 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3070,6 +3147,15 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"brz" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "brP" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
@@ -3106,11 +3192,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"bsy" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "bsC" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/churchmarble,
@@ -3244,6 +3325,12 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"bvV" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "bwc" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/cobble,
@@ -3297,10 +3384,14 @@
 /obj/item/roguegem/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"bxw" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"bxo" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "bxC" = (
 /obj/structure/stairs{
 	dir = 8
@@ -3313,16 +3404,6 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"bxG" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "bxR" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -3383,14 +3464,14 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3440,6 +3521,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"bAU" = (
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3456,10 +3541,7 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/rtfield)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
@@ -3498,6 +3580,13 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"bEn" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bEo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -3536,6 +3625,18 @@
 /obj/structure/fluff/littlebanners,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"bFu" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"bFx" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "bFC" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -3593,6 +3694,15 @@
 /obj/item/rogueweapon/stoneaxe/woodcut,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"bHT" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "bHV" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb,
@@ -3600,12 +3710,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3642,6 +3748,10 @@
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"bIM" = (
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "bIZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -3668,6 +3778,12 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"bJC" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bJE" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -3703,16 +3819,14 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"bLp" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+"bLl" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "bLD" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
@@ -3763,6 +3877,10 @@
 "bOu" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"bOC" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bOK" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/garrison)
@@ -3772,6 +3890,22 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"bON" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "bOP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "tavern"
@@ -3800,25 +3934,16 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"bPs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bPv" = (
-/obj/structure/chair/wood/rogue{
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
+"bPz" = (
+/obj/structure/roguewindow/openclose{
 	dir = 1
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"bPz" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3876,13 +4001,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
-"bRt" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "bRu" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -3891,6 +4009,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"bRy" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "bRF" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks/stonered,
@@ -3966,29 +4091,16 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
-"bUq" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/mountains)
 "bVa" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"bVk" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4125,6 +4237,10 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"caL" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4144,14 +4260,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "cbQ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "cca" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4190,14 +4303,6 @@
 /obj/structure/statue/saints/lady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"ccy" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ccK" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -4210,6 +4315,20 @@
 /obj/structure/statue/saints/magelady2_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"ccT" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ccX" = (
 /obj/structure/well,
 /turf/open/floor/rogue/dirt/road,
@@ -4221,9 +4340,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4256,6 +4378,16 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"cfm" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "cfw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4273,12 +4405,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
-"cfK" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "cfY" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
@@ -4419,9 +4545,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "cjJ" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4474,27 +4599,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"clh" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"clj" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -4511,6 +4619,12 @@
 /obj/item/roguekey/nightmaiden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"clR" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "clY" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/poo,
@@ -4588,6 +4702,10 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
+"coy" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "coE" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/carpet/royalblack,
@@ -4707,6 +4825,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"csH" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4784,12 +4909,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
@@ -4811,6 +4932,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"cwo" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "cwq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -4897,6 +5026,16 @@
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"cyy" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "czb" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
@@ -5039,9 +5178,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/tribalfort)
@@ -5077,12 +5216,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5107,6 +5242,11 @@
 /obj/item/roguekey/garrison,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"cDG" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "cDM" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/bog)
@@ -5138,13 +5278,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"cFo" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "cFF" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -5174,6 +5307,16 @@
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cGa" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cGc" = (
 /obj/structure/chair/wood/rogue,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -5334,13 +5477,27 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"cLX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "cMh" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -5352,13 +5509,21 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"cMs" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
+"cMm" = (
+/obj/structure/mineral_door/wood{
 	dir = 4;
-	icon_state = "rockwd"
+	locked = 1;
+	lockid = "garrison"
 	},
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"cMs" = (
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5367,6 +5532,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"cMR" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "cMU" = (
 /obj/structure/roguewindow,
 /turf/open/transparent/openspace,
@@ -5398,15 +5567,16 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"cNt" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "cNx" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"cNM" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cNN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf{
 	faction = list("undead")
@@ -5418,13 +5588,13 @@
 "cNY" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
-"cOw" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
+"cOb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "cOz" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -5437,13 +5607,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"cOK" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -5473,14 +5636,6 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"cPD" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/hexstone,
@@ -5498,6 +5653,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"cQs" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "cQz" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5537,10 +5697,8 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/item/clothing/ring/dragon_ring,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
@@ -5565,13 +5723,15 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
-"cSc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+"cSb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cSk" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
@@ -5603,6 +5763,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"cTc" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "cTr" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -5618,6 +5784,12 @@
 /obj/item/clothing/suit/roguetown/armor/silkcoat,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"cTP" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cTQ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/rogue/decowood,
@@ -5674,6 +5846,11 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"cVn" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "cVo" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -5747,6 +5924,12 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"cXu" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "cXy" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -5824,6 +6007,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"cZi" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "cZu" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -5832,6 +6021,10 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"cZU" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -5872,27 +6065,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"dbH" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"dbK" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+"dbH" = (
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -5919,12 +6100,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"dck" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "dcw" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/churchrough,
@@ -6039,14 +6214,6 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"dfG" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "dfK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -6058,25 +6225,6 @@
 /obj/item/quiver/bolts,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"dgh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "dgn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6184,6 +6332,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"diV" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "djA" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -6238,6 +6390,15 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
+"dkx" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dkI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -6247,14 +6408,6 @@
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"dkV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "dld" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/town/roofs)
@@ -6454,11 +6607,30 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"drL" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dsk" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/roguetown/shirt/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"dso" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "dsr" = (
 /obj/structure/statue/saints/cephine{
 	desc = "Her radiant angel that shall serve as our guiding light during end times."
@@ -6502,6 +6674,14 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"duo" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "duu" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -6548,6 +6728,13 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"dvG" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "dwa" = (
 /obj/structure/bars,
 /obj/machinery/light/rogue/torchholder{
@@ -6575,8 +6762,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6616,6 +6804,19 @@
 "dyF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/vikingarea)
+"dyH" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dyK" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -6639,6 +6840,24 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"dzB" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dzI" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur{
 	faction = list("undead")
@@ -6647,22 +6866,20 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"dzW" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
+"dzV" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dAf" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6691,12 +6908,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"dBS" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6704,10 +6915,23 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"dBW" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+"dCd" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/rtfield)
+"dCl" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6715,6 +6939,15 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"dCO" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dCP" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -6754,18 +6987,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dDU" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
-"dEe" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "dEA" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet,
@@ -6779,21 +7000,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"dET" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"dFp" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -6809,6 +7015,23 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
+"dFv" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
+"dFx" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dFz" = (
 /obj/item/reagent_containers/glass/cup/golden,
 /obj/structure/table/wood,
@@ -6823,6 +7046,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dFS" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -6875,6 +7104,13 @@
 "dHZ" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
+"dIl" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "dIo" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
 	dir = 1;
@@ -6904,13 +7140,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
-"dJl" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "dJr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7003,6 +7232,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"dNp" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "dNu" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
@@ -7010,14 +7246,16 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
+"dOj" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7050,6 +7288,17 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"dOE" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "dOH" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -7070,11 +7319,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"dPf" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "dPp" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -7239,10 +7483,9 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7284,6 +7527,19 @@
 	dir = 8
 	},
 /area/rogue/outdoors/exposed)
+"dUb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "dUk" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
@@ -7333,6 +7589,11 @@
 "dVO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"dVV" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "dWd" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/blocks,
@@ -7443,15 +7704,6 @@
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"eaH" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eaO" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -7459,11 +7711,16 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "ebe" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/basement)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7615,10 +7872,13 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"eeC" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"eeA" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "eeD" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -7711,6 +7971,16 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"ega" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "egl" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -7758,19 +8028,25 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"ehZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+"eik" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
+"eip" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "eit" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
 /turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
+"eiE" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "eiF" = (
 /obj/structure/rack/rogue/shelf/big,
@@ -7805,6 +8081,22 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ejk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "ejC" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/grass,
@@ -7832,13 +8124,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
-"ekl" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ekI" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/shop)
@@ -7875,10 +8160,6 @@
 "els" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"eml" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "emp" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road{
@@ -7909,16 +8190,14 @@
 /obj/structure/crabnest,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
+"emK" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "emM" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"emT" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "emX" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -7975,6 +8254,11 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"enQ" = (
+/obj/machinery/anvil,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "enW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder,
@@ -7999,9 +8283,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -8016,6 +8302,15 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"epI" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "epQ" = (
 /obj/structure/mineral_door/wood{
 	desc = "I shouldn't go in here...";
@@ -8085,6 +8380,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
+"erz" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "erN" = (
 /obj/structure/table/church{
 	dir = 1
@@ -8120,10 +8419,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"esE" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "esF" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
@@ -8136,11 +8431,19 @@
 "esR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"esT" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ete" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"etq" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "etr" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -8272,6 +8575,13 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"ewu" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ewB" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
@@ -8288,6 +8598,12 @@
 /obj/structure/pillory/town_square/reinforced,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
+"exy" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "exG" = (
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
@@ -8338,14 +8654,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8356,12 +8667,6 @@
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
-"ezG" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "eAh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
@@ -8371,16 +8676,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"eAz" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eAW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8396,6 +8691,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"eBn" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "eBp" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/adventurerlate{
@@ -8406,6 +8707,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"eBq" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "eBu" = (
 /obj/structure/fluff/statue/femalestatue,
 /turf/open/floor/rogue/grass,
@@ -8433,26 +8737,16 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"eBX" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"eCq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
-"eCt" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "eCK" = (
 /obj/structure/flora/rogueshroom2,
 /turf/open/floor/rogue/grass,
@@ -8501,12 +8795,6 @@
 "eEC" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"eEG" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "eEU" = (
 /obj/structure/fluff/statue{
@@ -8648,15 +8936,6 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
-"eIW" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "eIY" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/dirt/road{
@@ -8706,13 +8985,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"eKd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "eKe" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -8738,13 +9010,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"eLp" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "eLr" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -8753,6 +9018,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"eLK" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "eMc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -8775,6 +9048,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"eMV" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "eNa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8825,6 +9105,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"ePD" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ePQ" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = 1
@@ -8852,30 +9136,6 @@
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"eQM" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "eQW" = (
 /obj/structure/spacevine,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
@@ -8929,9 +9189,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8941,6 +9204,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
+"eSH" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 8
@@ -9060,6 +9331,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"eWd" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eWe" = (
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/grass,
@@ -9106,31 +9383,11 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"eXr" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "eXH" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
-"eYu" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "eYI" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora1";
@@ -9144,13 +9401,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"eYO" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "eZc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -9199,33 +9449,18 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"faa" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"fap" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "faE" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fbe" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
+"faN" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "fbf" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -9238,6 +9473,15 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"fbv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fbz" = (
 /obj/structure/mineral_door/wood,
 /obj/structure/spider/stickyweb,
@@ -9290,6 +9534,10 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"fcE" = (
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "fcJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9342,20 +9590,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/cavewet/bogcaves)
-"feB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "feE" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/bookcase/random,
@@ -9404,6 +9638,23 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"ffB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"ffD" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "fgl" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -9430,6 +9681,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"fhk" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "fhu" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -9456,13 +9714,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"fic" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "fiF" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/purple,
@@ -9575,15 +9826,6 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
-"flR" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "fmm" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -9646,9 +9888,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "fnP" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9709,6 +9954,16 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fqr" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
@@ -9825,12 +10080,12 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fuG" = (
-/obj/structure/chair/bench/church{
-	dir = 1
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "fuY" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -9883,6 +10138,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"fxa" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fxf" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/cooking/pan,
@@ -9950,9 +10213,18 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"fzf" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "fzk" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"fzv" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "fzO" = (
 /obj/structure/stairs{
 	dir = 4;
@@ -9977,19 +10249,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fAg" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "fAs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -10064,12 +10323,6 @@
 "fBT" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"fBY" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "fCh" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/woodturned,
@@ -10120,10 +10373,17 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -10155,11 +10415,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"fED" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "fEF" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/church,
@@ -10173,21 +10428,28 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"fEQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fFH" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"fFL" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
+"fGt" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "fGF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -10241,6 +10503,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"fIb" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fId" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
@@ -10275,8 +10543,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "fID" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -10311,25 +10582,14 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fJp" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
+"fJb" = (
 /obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/mountains)
-"fJG" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -10378,13 +10638,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"fLX" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10396,19 +10653,14 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"fMq" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+"fMl" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"fMS" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "fNa" = (
 /obj/structure/closet/crate/chest,
@@ -10425,18 +10677,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"fNu" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "fNw" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"fNW" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "fOo" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -10523,12 +10767,19 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10545,6 +10796,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"fQQ" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "fRa" = (
 /obj/machinery/anvil{
 	pixel_x = 9
@@ -10585,10 +10843,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"fRO" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -10646,17 +10900,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"fTS" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "fUc" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10721,8 +10964,13 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
+"fVN" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10738,6 +10986,16 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fWD" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fWH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10757,6 +11015,12 @@
 "fXg" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/town)
+"fXr" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "fXu" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -10778,6 +11042,13 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"fXP" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fXV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
@@ -10793,14 +11064,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fYr" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "fYH" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/dirt/road{
@@ -10845,6 +11108,13 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gbd" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "gbh" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/carpet/purple,
@@ -10928,15 +11198,6 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"gec" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "gei" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/hexstone,
@@ -10976,15 +11237,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"geZ" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "gfc" = (
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
@@ -11017,6 +11269,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"ggo" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "ggu" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/cobble,
@@ -11046,8 +11303,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/mountains)
 "giR" = (
 /obj/structure/table/wood,
@@ -11081,12 +11341,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"gjq" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gjB" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -11096,15 +11350,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"gjV" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "gke" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -11225,41 +11470,25 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
-"gnX" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "goa" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
-"goh" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
 	},
-/area/rogue/outdoors/rtfield)
-"goD" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "goK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -11280,13 +11509,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
-"gpK" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
 "gpP" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -11310,10 +11532,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"gqz" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+"gqA" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -11328,6 +11554,12 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
+"gqW" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "grd" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -11335,29 +11567,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"grg" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"grr" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "grQ" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood{
@@ -11371,6 +11584,13 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gsD" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "gsT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -11439,14 +11659,6 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"gue" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "gut" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -11457,30 +11669,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"guK" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "gvi" = (
 /obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"gvj" = (
-/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -11518,6 +11713,11 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
+"gwz" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11555,6 +11755,13 @@
 /obj/item/reagent_containers/glass/bottle/mercury,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"gxA" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "gxJ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -11585,6 +11792,14 @@
 /obj/structure/chair/bench/coucha,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/church/chapel)
+"gyr" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "gys" = (
 /obj/structure/chair/wood,
@@ -11678,6 +11893,10 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"gBe" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "gBs" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/large,
@@ -11736,6 +11955,23 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"gEt" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"gEy" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -11756,15 +11992,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"gFF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "gFQ" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/window/plasma/reinforced/spawner{
@@ -11777,6 +12004,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
+"gFU" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "gFZ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -11812,6 +12045,22 @@
 "gGu" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
+"gGw" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "gGH" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -11898,22 +12147,28 @@
 /obj/structure/bed/rogue/inn/wool,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"gIV" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "gJi" = (
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"gJj" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gJs" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"gJE" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "gJK" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -11931,13 +12186,6 @@
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"gKo" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "gKq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/fluff/statue/who,
@@ -11961,6 +12209,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"gKU" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gLf" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
@@ -11991,10 +12243,14 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"gLI" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"gLJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "gLO" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
@@ -12005,6 +12261,16 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"gMb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "gMg" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -12012,14 +12278,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"gMo" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "gMs" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -12028,6 +12286,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"gMG" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "gMO" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
@@ -12064,16 +12326,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"gNh" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "gNw" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -12145,6 +12397,10 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"gQF" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gQM" = (
 /obj/structure/fluff/statue/small{
 	desc = "An expertly carved figure of an elven woman baring a warm yet flirtatious smile.";
@@ -12282,6 +12538,10 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"gTQ" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "gTT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -12294,11 +12554,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"gUA" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "gUD" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
 	max_integrity = 99999
@@ -12347,13 +12602,6 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"gWf" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -12372,11 +12620,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
-"gWE" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "gWL" = (
 /obj/effect/landmark/start/shophand,
 /turf/open/floor/rogue/wood,
@@ -12398,6 +12641,13 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"gXT" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "gXW" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -12453,6 +12703,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"gZv" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "gZC" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/wood,
@@ -12473,15 +12727,9 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"haw" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+"har" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "hax" = (
 /obj/structure/mineral_door/wood{
@@ -12494,13 +12742,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"haC" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "haF" = (
 /obj/structure/bars/passage/shutter{
 	desc = "Extremely strong. I don't think I can easily get through this with brute force. Where might the way to open it be?";
@@ -12528,15 +12769,20 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"hbg" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
+"hbr" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12553,15 +12799,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"hbO" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
-"hbR" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "hbS" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/glass/bowl,
@@ -12573,14 +12810,6 @@
 "hcg" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/mountains)
-"hci" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2";
-	pixel_x = 16
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "hcm" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -12707,13 +12936,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"hej" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "heo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -12732,14 +12954,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"hes" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5";
-	pixel_x = 17
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
@@ -12805,6 +13019,16 @@
 	dir = 1;
 	icon_state = "vertw"
 	},
+/area/rogue/indoors/town)
+"hfU" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "hfW" = (
 /obj/structure/closet/crate/chest,
@@ -12905,6 +13129,15 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"hjs" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "hjt" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/churchrough,
@@ -12914,13 +13147,22 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"hjW" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "hkk" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -13028,6 +13270,9 @@
 	dir = 4
 	},
 /area/rogue/indoors)
+"hmF" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "hmK" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/junglebush/b,
@@ -13090,6 +13335,10 @@
 "hnC" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
+"hnJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "hnK" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/cup/silver,
@@ -13104,6 +13353,12 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"hoa" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hob" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -13113,22 +13368,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"hom" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "hox" = (
 /obj/structure/fluff/psycross,
 /obj/item/rogueweapon/woodstaff/aries,
@@ -13214,15 +13453,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"hqw" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "hqA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -13261,6 +13491,24 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"hre" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"hrh" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
@@ -13292,23 +13540,15 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/chair/wood{
+/obj/structure/stairs{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"htp" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "htA" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
@@ -13317,13 +13557,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"htH" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "priest"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "htU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -13394,6 +13627,10 @@
 "hwg" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors)
+"hwQ" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "hxe" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/naturalstone,
@@ -13463,6 +13700,10 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hzz" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13520,6 +13761,17 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"hCo" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "hCu" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/tile{
@@ -13550,6 +13802,14 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"hDE" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hDP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "velder"
@@ -13745,6 +14005,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"hJR" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "hKq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -13753,6 +14017,16 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hKF" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -13827,6 +14101,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"hNE" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "hNF" = (
 /obj/structure/stairs{
 	dir = 1
@@ -13868,6 +14150,10 @@
 /obj/structure/chair/bench/church/r,
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
+"hOC" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "hOF" = (
 /obj/structure/flora/roguegrass/thorn_bush,
@@ -13925,16 +14211,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"hQm" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hQE" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -13955,6 +14231,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hQU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"hQY" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "hRc" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -13968,16 +14255,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"hRg" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "hRl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -13987,6 +14264,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"hRr" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "hRv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/water/cleanshallow,
@@ -14019,21 +14302,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town)
-"hSx" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
-"hSy" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "hSz" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14049,29 +14317,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"hSO" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"hTc" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"hTo" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "hTz" = (
 /obj/item/natural/rock,
 /turf/open/water/swamp,
@@ -14127,15 +14372,15 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"hVO" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "hVZ" = (
 /turf/open/floor/rogue/tile/checkeralt{
 	max_integrity = 99999
 	},
 /area/rogue/indoors/town/shop)
-"hWj" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hWm" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14143,13 +14388,6 @@
 /obj/item/dice,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"hWp" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "hWK" = (
 /obj/structure/fluff/statue/knight/interior,
 /obj/structure/spacevine,
@@ -14300,17 +14538,6 @@
 /obj/item/natural/bundle/bone/full,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"ica" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "icc" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -14326,6 +14553,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"icE" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "icI" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
@@ -14409,10 +14643,6 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"ieI" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "ieL" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -14437,13 +14667,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -14470,16 +14696,17 @@
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"igr" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "igS" = (
 /obj/structure/spacevine{
 	opacity = 1
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"igV" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "iho" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -14510,6 +14737,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"iia" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "iim" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -14522,13 +14759,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"iiG" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "iiH" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/cobble/mossy,
@@ -14537,15 +14767,6 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"ijs" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "ijS" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -14555,11 +14776,24 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -14588,11 +14822,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -14670,15 +14902,10 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"inx" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+"inC" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14752,9 +14979,15 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"iqH" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
+"iqP" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "iqY" = (
 /obj/structure/stairs{
@@ -14800,17 +15033,22 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"isP" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "itv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -14859,11 +15097,6 @@
 	dir = 4
 	},
 /area/rogue/indoors)
-"iuK" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "iuL" = (
 /obj/structure/statue/saints/noble3_r,
 /turf/open/floor/rogue/blocks,
@@ -14883,6 +15116,13 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ivz" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -14928,16 +15168,6 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"ixi" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "ixt" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -14973,25 +15203,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"iys" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"iyt" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iyy" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -15057,12 +15268,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"izq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "izL" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobblerock,
@@ -15106,16 +15311,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"iBj" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
+"iBo" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "iBA" = (
@@ -15135,6 +15334,12 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"iBE" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iBJ" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
@@ -15196,6 +15401,12 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iDV" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -15229,13 +15440,6 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
-"iEv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -15265,10 +15469,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"iFj" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+"iFi" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "iFm" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "manor";
@@ -15304,6 +15512,21 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
+"iFY" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"iGe" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iGf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5;
@@ -15328,6 +15551,12 @@
 /obj/structure/timeddoor,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"iHs" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "iHz" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -15365,6 +15594,13 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/under/town/basement)
+"iJx" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iJC" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -15474,6 +15710,14 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"iMu" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "iMA" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -15482,11 +15726,9 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -15560,52 +15802,13 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"iOB" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "iOI" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"iOL" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "iPg" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
-"iPk" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "iPn" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -15687,15 +15890,14 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15722,10 +15924,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"iSf" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "iSs" = (
 /turf/open/water/river{
 	dir = 8;
@@ -15733,27 +15931,8 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
-"iSS" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
-"iTh" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15776,11 +15955,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"iUg" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "iUY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/neck/roguetown/gorget,
@@ -15826,10 +16000,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"iVX" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "iWh" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/veteran{
@@ -15838,13 +16008,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
@@ -15890,12 +16058,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"iXP" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "iXT" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -15938,16 +16100,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"iYE" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -15982,12 +16134,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
-"iZS" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
 "jad" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -16008,6 +16154,10 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"jax" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "jaF" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/purple,
@@ -16062,12 +16212,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"jck" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "jct" = (
 /obj/structure/flora/roguetree/stump/burnt,
 /turf/open/floor/rogue/dirt,
@@ -16120,11 +16264,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"jdO" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "jdW" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/metal/barograte,
@@ -16134,10 +16273,6 @@
 	icon_state = "stonewindow"
 	},
 /area/rogue/indoors/town/garrison)
-"jec" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "jem" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/river{
@@ -16145,6 +16280,19 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"jet" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
+"jeM" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jeR" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16162,15 +16310,21 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"jeX" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "jfe" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"jfl" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "jfq" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -16182,15 +16336,6 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"jfJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "jfK" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/wallfire/candle/l{
@@ -16230,11 +16375,15 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"jgn" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"jgo" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jgs" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
@@ -16242,29 +16391,6 @@
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
-"jhu" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4";
-	pixel_x = 13
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"jhv" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"jhP" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16290,16 +16416,15 @@
 "jis" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jit" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "jiv" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"jiL" = (
-/obj/structure/table/vtable,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "jiS" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks,
@@ -16307,13 +16432,6 @@
 "jiT" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"jiW" = (
-/obj/item/paper{
-	name = "HIT THINE BELL";
-	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "jiZ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -16321,22 +16439,6 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"jju" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -16377,6 +16479,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jkZ" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "jlf" = (
 /obj/structure/stairs{
 	dir = 1
@@ -16403,8 +16511,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
@@ -16441,10 +16553,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"jnd" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "jnl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -16454,6 +16562,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"jnw" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jod" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/feather,
@@ -16500,12 +16615,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "Nelly";
-	health = "1000"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16516,13 +16628,6 @@
 /obj/structure/roguemachine/camera,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"jpM" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jpS" = (
 /obj/structure/glowshroom,
 /turf/open/water/river{
@@ -16591,12 +16696,12 @@
 	},
 /area/rogue/outdoors/bog)
 "jti" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jtj" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16613,6 +16718,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"jtq" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "jtN" = (
 /obj/item/clothing/gloves/roguetown/plate/blk,
 /obj/item/rogueweapon/sword/rapier,
@@ -16636,10 +16745,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"juM" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -16653,6 +16758,21 @@
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement)
+"jvT" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"jvU" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jvW" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4;
@@ -16738,6 +16858,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"jyB" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "jyD" = (
 /obj/machinery/light/rogue/oven/south,
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison{
@@ -16775,6 +16899,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"jzT" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "jAb" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -16792,14 +16920,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"jAI" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "jAN" = (
 /obj/effect/landmark/start/farmer{
 	dir = 4
@@ -16820,12 +16940,13 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jBE" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+"jBN" = (
+/obj/structure/closet/crate/chest{
+	name = "INCASE OF VAMPYRE EMERGENCY"
 	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "jCh" = (
 /turf/open/transparent/openspace,
@@ -16835,16 +16956,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -16877,12 +16993,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"jCH" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "jCW" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -16893,6 +17003,17 @@
 "jDm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor)
+"jDv" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jDB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -16941,11 +17062,14 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "jEB" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -16966,10 +17090,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
-"jFn" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "jFF" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/blocks,
@@ -17004,6 +17124,19 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"jGB" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "jGT" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -17013,15 +17146,17 @@
 "jHc" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"jHh" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "jHj" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
-"jHv" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "jHz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
@@ -17058,9 +17193,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "jJf" = (
 /obj/structure/bars,
@@ -17079,13 +17213,6 @@
 /obj/structure/closet/crate/roguecloset/inn/chest,
 /obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"jJZ" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
 /area/rogue/indoors/town/garrison)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -17134,16 +17261,12 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -17172,10 +17295,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"jMQ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "jMT" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/concrete,
@@ -17193,37 +17312,20 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"jNc" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
-"jNp" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "jNC" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17417,6 +17519,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"jUl" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jUs" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
@@ -17439,35 +17545,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"jVt" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
-"jWb" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17490,8 +17567,13 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"jWZ" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
+/obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "jXe" = (
@@ -17560,10 +17642,6 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
-"jYZ" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jZd" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/magician)
@@ -17601,6 +17679,23 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"kat" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kau" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /turf/open/floor/rogue/grass,
@@ -17625,10 +17720,37 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"kaH" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kaO" = (
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"kaP" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "kaQ" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
@@ -17641,6 +17763,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"kbp" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kbR" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
@@ -17673,6 +17801,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"kde" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kds" = (
 /obj/structure/table/wood,
 /obj/item/dice{
@@ -17709,16 +17844,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"keJ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "keO" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -17802,21 +17927,20 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"kgK" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "kha" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/stairs{
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -17850,11 +17974,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"kiE" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "kiR" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -17910,6 +18029,11 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"kkP" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "kld" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/concrete,
@@ -17922,20 +18046,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"klx" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"kmo" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "kms" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper,
@@ -17950,6 +18060,10 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"knq" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "kns" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/herringbone,
@@ -17984,21 +18098,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"kpy" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
-"kpU" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kpZ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -18098,10 +18197,6 @@
 /obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
-"kss" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "kst" = (
 /obj/structure/spider/stickyweb,
 /turf/open/water/swamp,
@@ -18133,16 +18228,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/obj/item/listenstone,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -18165,6 +18256,10 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
+"ktb" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ktg" = (
 /obj/structure/bed/rogue,
 /obj/item/natural/cloth,
@@ -18220,6 +18315,10 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"kuG" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "kuP" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -18236,14 +18335,14 @@
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -18284,12 +18383,9 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18326,12 +18422,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/under/town/basement)
-"kya" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "kym" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -18346,6 +18436,12 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"kzc" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kzv" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -18387,6 +18483,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"kAg" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"kAi" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "kAH" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -18458,6 +18566,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"kCe" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kCh" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -18482,6 +18600,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"kCZ" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "kDc" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
@@ -18532,6 +18656,16 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"kEA" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "kEB" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -18547,25 +18681,14 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"kEU" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "kFc" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 8
 	},
 /area/rogue/indoors)
 "kFh" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18617,6 +18740,10 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
+"kHb" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "kHs" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -18642,28 +18769,17 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"kHO" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "kHR" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "kIf" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
 	},
-/turf/closed,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "kIu" = (
 /obj/structure/stairs,
@@ -18720,12 +18836,16 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"kKj" = (
-/obj/structure/chair/wood{
-	dir = 8
+"kKm" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kKr" = (
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
@@ -18745,6 +18865,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"kKN" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kKS" = (
 /obj/structure/mineral_door/bars{
 	lockid = "dungeon"
@@ -18769,11 +18894,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"kLD" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -18784,6 +18904,12 @@
 /obj/structure/chair/bench/couch,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"kLV" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kMb" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/machinery/light/rogue/torchholder/l,
@@ -18835,6 +18961,14 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"kNi" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "kNr" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt/road{
@@ -18969,16 +19103,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"kRd" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "kRA" = (
 /obj/effect/landmark/start/mercenary{
 	dir = 4
@@ -18986,6 +19110,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kRE" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kRN" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
@@ -19088,15 +19219,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"kVv" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "kVH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -19130,22 +19252,6 @@
 "kWa" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs)
-"kWA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "kWT" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -19200,24 +19306,6 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kZl" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "kZr" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
@@ -19366,6 +19454,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"lff" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -19428,6 +19524,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
+"lgJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "lgN" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/wool,
@@ -19460,6 +19563,21 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"lhH" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lhO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -19562,20 +19680,6 @@
 "lkM" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"lkV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "lli" = (
 /obj/structure/rogue/trophy/deer,
 /obj/item/natural/rock,
@@ -19586,6 +19690,12 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"llp" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "lls" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -19632,6 +19742,13 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"lnl" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lnq" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/cobble,
@@ -19647,14 +19764,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lnw" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6";
-	pixel_x = 9
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "lnL" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -19684,14 +19793,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -19729,14 +19834,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"lpB" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3";
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "lpC" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/blocks,
@@ -19761,10 +19858,20 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"lqv" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+"lpU" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"lqg" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -19774,12 +19881,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
-"lqG" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "lqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -19798,6 +19899,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lsA" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lsD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19806,13 +19917,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"lsK" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "lsX" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -19839,6 +19943,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"ltI" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "ltM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/rtfield)
@@ -19875,11 +19985,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"luS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "luV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19894,10 +19999,6 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"lvM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "lvO" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobblerock,
@@ -19907,6 +20008,16 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"lwy" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lwz" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -19919,6 +20030,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
+"lwO" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "lwV" = (
 /obj/structure/roguewindow/openclose,
@@ -19947,15 +20065,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"lyJ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1";
-	pixel_x = 9
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "lyK" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -19964,15 +20073,13 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"lyP" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
+"lyW" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -20029,11 +20136,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"lzR" = (
-/obj/structure/table/vtable/v2,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "lAb" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/manor)
@@ -20057,6 +20159,14 @@
 "lAB" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"lAE" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "lAO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -20067,16 +20177,6 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"lBD" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "lBK" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -20202,6 +20302,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"lFG" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lFP" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_x = -32
@@ -20213,9 +20320,23 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "lGI" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"lGN" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
@@ -20236,6 +20357,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"lHy" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lHK" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph2"
@@ -20370,19 +20501,19 @@
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
-"lLV" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"lMr" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+"lMg" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
+"lMu" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "lMD" = (
 /obj/item/natural/rock,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -20403,6 +20534,10 @@
 "lMZ" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/town/church/chapel)
+"lNo" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
@@ -20475,23 +20610,18 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
+"lQH" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "lQT" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 2;
 	pixel_y = 16
 	},
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
-"lRC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
 /area/rogue/indoors/town/church/chapel)
 "lRJ" = (
 /obj/structure/table/wood,
@@ -20516,12 +20646,6 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
-"lSX" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "lTj" = (
 /obj/structure/spacevine,
@@ -20599,15 +20723,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"lWV" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
@@ -20636,10 +20751,6 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"lXK" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "lXN" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -20713,10 +20824,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"lZz" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
+"lZC" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"lZE" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mab" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
@@ -20750,37 +20870,36 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"mbA" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"mbG" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "mbK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"mbO" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "mcm" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter)
+"mco" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "mcu" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -20809,6 +20928,11 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mdd" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "mdo" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20826,9 +20950,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20889,10 +21015,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"meQ" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"meH" = (
+/obj/structure/rack/rogue,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "meV" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/structure/table/wood{
@@ -21000,6 +21129,12 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"mjE" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "mjG" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
@@ -21016,9 +21151,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/town/roofs)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -21036,6 +21172,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"mky" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mkO" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -21093,11 +21239,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"mmw" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"mmY" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21228,6 +21378,10 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"mrQ" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "msk" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
@@ -21274,12 +21428,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
-"mtG" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "mtR" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
@@ -21327,10 +21475,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"mvI" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
 "mwd" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/grass,
@@ -21399,6 +21543,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"myM" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "myR" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -21424,11 +21576,6 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"mzo" = (
-/obj/structure/fluff/wallclock/l,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "mzq" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road{
@@ -21452,16 +21599,30 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"mAb" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mAM" = (
 /obj/item/clothing/suit/roguetown/shirt/rags,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"mAZ" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "mBn" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"mCh" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "mCz" = (
 /obj/effect/landmark/start/guardsman{
 	dir = 1
@@ -21506,20 +21667,6 @@
 	},
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
-"mDR" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "mDY" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21600,20 +21747,25 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"mGn" = (
-/obj/structure/roguewindow,
-/turf/closed,
+"mGh" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
 /area/rogue/outdoors/mountains)
+"mGn" = (
+/obj/structure/fluff/walldeco/painting,
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/shelter/mountains)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mGS" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "mHb" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -21631,10 +21783,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
-"mHp" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "mHD" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -21644,6 +21792,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"mJa" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -21654,13 +21809,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"mJO" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "mJS" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -21669,6 +21817,13 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"mJU" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "mKd" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -21717,14 +21872,6 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"mMD" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mMJ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -21779,6 +21926,14 @@
 "mOh" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
+"mOw" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "mOE" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/natural/feather,
@@ -21842,29 +21997,18 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"mQo" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "mQq" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mQA" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -21883,17 +22027,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"mRR" = (
-/obj/structure/mineral_door/wood{
-	dir = 4;
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "mRW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -21934,6 +22067,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"mTs" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "mTO" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -21950,12 +22090,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"mUg" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "mUi" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -21995,8 +22129,12 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -22028,17 +22166,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"mWP" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+"mWO" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "mWV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -22107,25 +22238,6 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"mYV" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
-"mZl" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "mZo" = (
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
@@ -22145,13 +22257,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"mZH" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "mZV" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/tile/checkeralt,
@@ -22217,10 +22322,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"nbA" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"nbI" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22228,6 +22333,20 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
+"nce" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"ncg" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "ncl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road{
@@ -22238,6 +22357,10 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"ncI" = (
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "nda" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/keyring,
@@ -22333,13 +22456,6 @@
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"nfO" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22363,9 +22479,14 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22399,14 +22520,6 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"njj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "njq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -22425,9 +22538,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "nku" = (
-/obj/structure/bed/rogue/shit,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22453,6 +22568,14 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"nlw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "nlG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -22506,14 +22629,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
-"nnm" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "nnz" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -22529,6 +22644,18 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"nnS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "noi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22547,13 +22674,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"npd" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "npm" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -22575,10 +22695,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"npZ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "nqf" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/blocks,
@@ -22617,13 +22733,6 @@
 "nqU" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors)
-"nre" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nrn" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/closet/crate/roguecloset/inn/south{
@@ -22639,24 +22748,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"nru" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"nrv" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "nrw" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
@@ -22711,6 +22802,18 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"ntT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ntY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -22740,7 +22843,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
@@ -22755,16 +22860,20 @@
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"nvC" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "nvF" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"nvH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nvS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -22848,6 +22957,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"nxC" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "nxF" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -22866,6 +22981,14 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
+"nxM" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nxO" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/tile/checker,
@@ -22945,12 +23068,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town/roofs)
-"nzV" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "nzW" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22961,14 +23078,6 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"nAu" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nAS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -22984,9 +23093,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/lava{
+	name = "an actual pit of lava"
+	},
+/area/rogue/under/cave)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -23016,10 +23126,6 @@
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"nBX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
@@ -23045,13 +23151,14 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"nDR" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nEd" = (
 /turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/garrison)
+"nEe" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
 "nEi" = (
 /obj/structure/chair/stool/rogue,
@@ -23063,13 +23170,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"nEs" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "nFg" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shield/wood,
@@ -23157,6 +23257,10 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"nHd" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nHi" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -23167,12 +23271,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"nIh" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nIk" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -23225,25 +23323,17 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"nIW" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "nJy" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
-"nJL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/church/chapel)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -23282,19 +23372,41 @@
 "nKx" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
-"nKI" = (
+"nKy" = (
 /obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
 	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
+"nKG" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"nLx" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "nLy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -23350,16 +23462,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"nNF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "nNJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -23403,13 +23505,13 @@
 /obj/structure/fluff/littlebanners/bluewhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"nOE" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+"nOR" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "nOX" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23422,31 +23524,17 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
-"nPv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "nPP" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23533,17 +23621,20 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"nRE" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "nRF" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/magelady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"nRH" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nRW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -23557,10 +23648,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nSr" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
@@ -23600,17 +23688,12 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23693,12 +23776,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"nWL" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "nWM" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -23783,13 +23860,15 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"nYg" = (
-/obj/effect/decal/cobbleedge{
+"nYb" = (
+/obj/structure/table/wood{
 	dir = 1;
-	icon_state = "borderfall"
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nYp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -23839,6 +23918,13 @@
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nZy" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "nZQ" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -23862,13 +23948,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "obq" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23905,9 +23988,6 @@
 "och" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"ocK" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
 "ocM" = (
 /obj/structure/floordoor/gatehatch/outer{
 	redstone_id = "gatelava"
@@ -23946,9 +24026,6 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "odo" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 34
-	},
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -23958,6 +24035,10 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"odH" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "odT" = (
 /obj/structure/flora/newleaf,
 /obj/structure/chair/bench/coucha{
@@ -24039,11 +24120,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bull,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -24118,13 +24200,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24150,6 +24230,14 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"ojQ" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -24201,6 +24289,16 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"olU" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "oma" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
@@ -24228,16 +24326,6 @@
 /obj/item/clothing/neck/roguetown/psicross/astrata,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"omp" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
@@ -24260,10 +24348,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"onQ" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "onR" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
@@ -24285,13 +24369,6 @@
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"ooA" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "ooJ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
@@ -24328,10 +24405,6 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"oqr" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -24467,11 +24540,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -24586,6 +24664,14 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"oyH" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "oyJ" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24653,11 +24739,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"oAj" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/loom,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "oAl" = (
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
@@ -24678,6 +24759,13 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"oAX" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "oAZ" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -24710,20 +24798,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"oBH" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
-"oBL" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -24747,13 +24821,6 @@
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
-"oCD" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oCL" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -24770,35 +24837,11 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"oDc" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "oDj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"oDr" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "oDx" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -24855,6 +24898,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"oFk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "oFw" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -24888,12 +24937,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"oGC" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "oGI" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -24923,18 +24966,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"oHc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "oHg" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
@@ -24966,8 +24997,15 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -24978,6 +25016,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"oJk" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "oJn" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -24996,13 +25038,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "oJO" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -25030,6 +25067,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"oLA" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "oLC" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
@@ -25045,9 +25092,11 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
 /area/rogue/indoors/town)
 "oMk" = (
 /obj/structure/bars/pipe{
@@ -25098,15 +25147,6 @@
 "oNE" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
-"oOf" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "oOh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -25134,21 +25174,17 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"oOv" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "oOx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"oON" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+"oOI" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oOQ" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -25165,23 +25201,24 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"oOY" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+"oOV" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
-"oPc" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "oPi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"oPp" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "oPv" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -25207,6 +25244,12 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"oQc" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "oQe" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -25246,12 +25289,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -25264,14 +25307,6 @@
 /obj/structure/statue/saints/father,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"oRP" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "oRQ" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 0;
@@ -25309,10 +25344,6 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"oSN" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "oSV" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25382,6 +25413,10 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"oVn" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "oVp" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town)
@@ -25458,6 +25493,10 @@
 /obj/structure/fluff/walldeco/painting/queen,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
+"oWT" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "oWX" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub/crafted,
@@ -25468,6 +25507,10 @@
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"oXj" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "oXn" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town)
@@ -25486,6 +25529,12 @@
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"oXt" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "oXE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -25691,11 +25740,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -25709,10 +25756,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wood,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
@@ -25817,12 +25861,6 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"phe" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "phk" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguegem/green,
@@ -25832,13 +25870,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"phB" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "phR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -25854,12 +25885,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"pik" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "pil" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph5"
@@ -25908,9 +25933,10 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "pjB" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "pjC" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -26012,12 +26038,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"pnq" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "pnD" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -26032,6 +26052,14 @@
 "pog" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"poP" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "poR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26040,17 +26068,12 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"poU" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+"ppc" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
-"ppc" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "ppi" = (
 /obj/structure/stairs{
 	dir = 1
@@ -26081,19 +26104,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
-"ppy" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "ppD" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/spear,
@@ -26117,10 +26127,19 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"ppM" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "ppS" = (
 /obj/structure/fluff/walldeco/rpainting/forest,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
+"pqg" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "pqr" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26263,13 +26282,15 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"pva" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+"puH" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town/church/chapel)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -26288,6 +26309,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"pvE" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "pvI" = (
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/table/wood{
@@ -26349,6 +26374,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pxP" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pxQ" = (
 /obj/structure/statue/saints/paladin2_l,
 /turf/open/floor/rogue/blocks,
@@ -26445,6 +26476,13 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"pzY" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "pAa" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
@@ -26490,27 +26528,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"pBp" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "pBx" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"pBE" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "pBJ" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26530,28 +26552,11 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"pCo" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "pCw" = (
 /obj/structure/chair/bench/church/mid,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"pCS" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "pCW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -26618,12 +26623,6 @@
 "pDZ" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/bog)
-"pEb" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "pEf" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -26663,12 +26662,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
-"pGU" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "pHa" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -26748,14 +26741,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"pKn" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "pKw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -26772,17 +26757,13 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"pKC" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "pKQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
@@ -26825,6 +26806,14 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"pMe" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "pMi" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
@@ -26838,13 +26827,7 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
@@ -26931,6 +26914,10 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"pOC" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "pOO" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood,
@@ -26993,12 +26980,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"pQL" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "pRj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -27129,6 +27110,15 @@
 /obj/item/quiver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"pUX" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "pVg" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27142,6 +27132,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"pVO" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "pVW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road{
@@ -27180,6 +27178,12 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"pXo" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "pXp" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -27203,6 +27207,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"pXF" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "pXH" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -27232,13 +27242,6 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
-"pYB" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/sword/long,
-/obj/item/rogueweapon/mace/steel,
-/obj/item/listenstone,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "pYO" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
@@ -27261,6 +27264,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pZJ" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qad" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -27352,10 +27361,6 @@
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/dwarfin)
-"qcq" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "qcC" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/tile,
@@ -27430,8 +27435,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -27471,6 +27481,21 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"qgi" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"qgz" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "qgC" = (
 /turf/open/water/river{
 	dir = 4;
@@ -27484,15 +27509,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"qgP" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qhg" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -27539,12 +27555,22 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qii" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "qil" = (
 /obj/structure/bars/passage{
 	redstone_id = "tourneytop"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"qir" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -27580,36 +27606,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/shop)
-"qjg" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
-"qji" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"qjk" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "qjp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -27708,6 +27704,16 @@
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qmJ" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qne" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/naturalstone,
@@ -27730,12 +27736,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"qnL" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "qnO" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -27786,13 +27786,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"qoP" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -27811,18 +27804,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qpp" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "qpt" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed,
+/area/rogue/indoors/town/garrison)
 "qpJ" = (
 /obj/structure/stairs/fancy/l{
 	dir = 1
@@ -27843,23 +27832,12 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -27870,21 +27848,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"qqd" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
 "qqm" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"qqn" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "qqp" = (
 /obj/structure/stairs{
 	dir = 1
@@ -27900,11 +27867,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"qqB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qqD" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -27912,6 +27874,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"qqM" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qqV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -27970,13 +27939,6 @@
 "qrN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"qrZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "qse" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/remains/human,
@@ -28038,13 +28000,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qtZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "qub" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile{
@@ -28069,8 +28024,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -28126,18 +28085,10 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qwd" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "qwp" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -28168,6 +28119,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"qwV" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qxH" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/structure/spider/stickyweb,
@@ -28189,12 +28146,11 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"qza" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+"qzb" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -28217,34 +28173,23 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"qzp" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qzy" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -28254,27 +28199,6 @@
 	icon_state = "tablewood2"
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
-"qzY" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"qAh" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "qAj" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
@@ -28302,15 +28226,6 @@
 /area/rogue/indoors/town/shop)
 "qBu" = (
 /turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
-"qBB" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh1";
-	aportalid = "wh2";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
 "qBF" = (
 /obj/machinery/light/rogue/torchholder{
@@ -28341,29 +28256,31 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
-"qDb" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"qDq" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -28398,6 +28315,14 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
+"qFI" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qFK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/churchbrick,
@@ -28412,13 +28337,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -28459,17 +28381,6 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"qHY" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
 "qIi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/villager,
@@ -28541,16 +28452,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28600,9 +28503,29 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"qMA" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"qNO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -28697,15 +28620,16 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
-	name = "Wild Hunt Reimagining"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "qRp" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -28715,6 +28639,22 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qRZ" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "qSc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/churchmarble,
@@ -28758,16 +28698,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"qTE" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "qTL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "archive"
@@ -28835,12 +28765,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"qWL" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -28885,12 +28809,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -28910,16 +28833,19 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"qZg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
+"qYK" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
 	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"qYR" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "qZh" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
@@ -28942,28 +28868,12 @@
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
-"raG" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "raL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"raQ" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "rbk" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -29020,16 +28930,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"rcn" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -29037,9 +28937,9 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -29072,18 +28972,19 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"rdi" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rdq" = (
 /obj/structure/spacevine{
 	opacity = 1
 	},
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"rds" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "rdA" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/concrete,
@@ -29120,23 +29021,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"reg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "ret" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"reD" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "reI" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
@@ -29160,26 +29050,6 @@
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"rff" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
-"rfk" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "rfl" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/bog)
@@ -29187,12 +29057,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
 	},
-/obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -29222,8 +29092,9 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -29265,21 +29136,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"rhY" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"rik" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/composter/full,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "rio" = (
 /obj/structure/winch{
 	gid = "forestgate1";
@@ -29354,6 +29210,16 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"rlu" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29373,6 +29239,17 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"rma" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "rmd" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -29398,10 +29275,6 @@
 	dir = 9
 	},
 /turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town)
-"rmE" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "rmJ" = (
 /obj/effect/decal/cobbleedge{
@@ -29439,6 +29312,16 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"rnE" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rnN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -29536,6 +29419,11 @@
 /obj/item/reagent_containers/food/snacks/grown/onion/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"rrd" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "rrg" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "velder";
@@ -29658,6 +29546,27 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"rvF" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
+"rvH" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29696,10 +29605,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"rwx" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "rwH" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -29741,9 +29646,8 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "rxp" = (
-/obj/structure/roguewindow/openclose,
-/obj/structure/bars,
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/church/chapel)
 "rxq" = (
 /obj/structure/table/wood{
@@ -29755,12 +29659,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"rxu" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rxx" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -29788,9 +29686,22 @@
 "ryg" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"ryk" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
+"ryM" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "rzq" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -29824,14 +29735,6 @@
 "rAz" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
-"rBd" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7";
-	pixel_x = 11
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "rBh" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -29864,10 +29767,31 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"rBB" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "rBC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"rBD" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rBO" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29897,19 +29821,13 @@
 /obj/structure/fluff/walldeco/bigpainting,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"rDp" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"rDF" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -29970,14 +29888,6 @@
 /obj/structure/roguewindow,
 /turf/closed,
 /area/rogue/indoors/town/church/chapel)
-"rFg" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "rFy" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/water/cleanshallow,
@@ -29998,12 +29908,6 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"rFS" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "rGm" = (
 /obj/structure/closet/crate/chest,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -30019,8 +29923,12 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
@@ -30128,6 +30036,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"rLE" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "rLL" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -30163,10 +30075,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"rMH" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "rMM" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/blocks/stonered,
@@ -30179,6 +30087,10 @@
 "rNl" = (
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"rNo" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rNB" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -30231,6 +30143,13 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
+"rPA" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "rPE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -30252,6 +30171,13 @@
 /obj/structure/crabnest,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"rPT" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "rPX" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -30297,19 +30223,10 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30323,25 +30240,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"rRF" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
@@ -30357,10 +30258,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"rSz" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rSC" = (
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
@@ -30412,27 +30309,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"rTw" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"rTx" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "rTA" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -30486,6 +30362,13 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
+"rUR" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "rVl" = (
 /obj/structure/fluff/traveltile{
@@ -30548,22 +30431,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"rXa" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "rXl" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -30588,14 +30455,6 @@
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"rXP" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rXZ" = (
 /obj/item/rogueweapon/mace/wsword,
 /obj/item/rogueweapon/mace/wsword,
@@ -30690,11 +30549,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"sah" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sao" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
@@ -30705,6 +30559,20 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"sat" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"saP" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "saS" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -30724,12 +30592,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30761,11 +30627,6 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"scS" = (
-/obj/structure/fluff/wallclock/r,
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "scT" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -30845,10 +30706,20 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"seK" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "seR" = (
 /obj/structure/crabnest,
@@ -30873,6 +30744,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"sfZ" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "sgi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -30939,6 +30814,12 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"shS" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "shV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -30990,6 +30871,9 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
+"sjG" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "sjH" = (
 /obj/structure/roguewindow,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -31048,14 +30932,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"slQ" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "slS" = (
 /obj/item/clothing/shoes/roguetown/boots/armoriron,
 /turf/open/floor/rogue/dirt/road{
@@ -31100,15 +30976,6 @@
 "smO" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
-	},
-/area/rogue/indoors/town/church/chapel)
-"smV" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/church/chapel)
 "sna" = (
@@ -31262,20 +31129,17 @@
 "squ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
+"sqI" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "sqW" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
-/area/rogue/outdoors/mountains)
-"sqX" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"sqZ" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "sri" = (
 /turf/open/floor/rogue/dirt,
@@ -31338,6 +31202,11 @@
 	},
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"stz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "stD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
@@ -31374,8 +31243,9 @@
 	},
 /area/rogue/outdoors/beach)
 "suN" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/effect/landmark/start/templar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "suY" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -31389,13 +31259,6 @@
 	dir = 9
 	},
 /area/rogue/outdoors/town)
-"svA" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "svE" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
@@ -31446,9 +31309,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -31479,6 +31342,16 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
+"syA" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "syL" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/woodturned,
@@ -31489,13 +31362,6 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
-"syR" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "syY" = (
 /obj/effect/landmark/start/royalguard{
@@ -31524,13 +31390,6 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"sAb" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
-"sAj" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "sAl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/long_sleep,
@@ -31562,6 +31421,12 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"sBo" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sBx" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/grass,
@@ -31577,6 +31442,11 @@
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"sBO" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "sBX" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -31588,10 +31458,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"sCh" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "sCJ" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/church,
@@ -31601,11 +31467,18 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town)
 "sDa" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -31628,6 +31501,16 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"sEa" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sFe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger/steel,
@@ -31677,13 +31560,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"sFQ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"sGf" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sGj" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -31713,12 +31595,6 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"sGW" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "sHe" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/chair/wood/rogue{
@@ -31737,12 +31613,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
-"sHB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sHG" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pick,
@@ -31774,7 +31644,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/turf/closed/wall/mineral/rogue/wood,
+/turf/closed/mineral/rogue/gem,
 /area/rogue/indoors/shelter/rtfield)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
@@ -31837,16 +31707,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"sLx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
+"sLD" = (
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31901,6 +31767,12 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
+"sOL" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sPj" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt,
@@ -31939,6 +31811,34 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"sQi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"sQl" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -31952,16 +31852,18 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sRY" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+"sRG" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"sSl" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "sSm" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/reagent_containers/powder,
@@ -32013,12 +31915,27 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"sTi" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "sTl" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"sTp" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "sTr" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter)
@@ -32095,6 +32012,11 @@
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sWG" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "sWL" = (
 /obj/effect/landmark/start/squire{
 	dir = 4
@@ -32116,16 +32038,17 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"sXc" = (
-/mob/living/simple_animal/hostile/rogue/gravelord{
-	name = "The Erlking";
-	health = 1500
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"sXS" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "sXU" = (
 /obj/structure/fermenting_barrel/random,
 /obj/effect/decal/cleanable/cobweb,
@@ -32167,6 +32090,10 @@
 /obj/effect/landmark/start/vampthralllate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"sYW" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "sYY" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -32184,6 +32111,28 @@
 "sZN" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"tab" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "tag" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -32191,12 +32140,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -32213,6 +32158,13 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"taD" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "taK" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -32249,10 +32201,6 @@
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
-"tbb" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "tbc" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -32319,9 +32267,8 @@
 	},
 /area/rogue/indoors)
 "tdJ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/ingot/silver,
-/turf/open/floor/rogue/churchrough,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "tei" = (
 /obj/effect/landmark/latejoin,
@@ -32372,11 +32319,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -32396,10 +32343,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"tgc" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "tgZ" = (
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
@@ -32439,9 +32382,28 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"tiW" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -32455,12 +32417,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"tjf" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "tjg" = (
 /obj/item/roguestatue/iron,
 /turf/open/floor/rogue/concrete,
@@ -32482,10 +32438,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"tjL" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "tjU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/flail/sflail,
@@ -32553,19 +32505,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
-"tle" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"tlq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -32573,11 +32512,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32656,19 +32592,15 @@
 "tou" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"toC" = (
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
-"tpg" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32685,17 +32617,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"tqu" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
-"tqx" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "tqA" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/dirt/road{
@@ -32721,33 +32642,10 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"tqI" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "tqJ" = (
 /obj/structure/roguemachine/money/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"trg" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "trv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "royal";
@@ -32786,13 +32684,10 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"tsE" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
+"tsF" = (
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32813,15 +32708,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"tub" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -32897,13 +32783,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"twy" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "twA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32980,24 +32859,10 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"txS" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "tyl" = (
 /obj/structure/dye_bin,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"typ" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tys" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/closet/crate/chest,
@@ -33027,15 +32892,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"tyI" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "tyK" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -33048,6 +32904,13 @@
 	},
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/exposed)
+"tyU" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tzf" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
@@ -33192,12 +33055,18 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"tCz" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
+"tCy" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
+"tCz" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
@@ -33238,12 +33107,12 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"tDO" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+"tDN" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tEs" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -33278,6 +33147,15 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tEL" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
+"tEQ" = (
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "tEU" = (
 /obj/structure/fluff/walldeco/stone{
 	pixel_y = 32
@@ -33334,6 +33212,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"tGA" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tGF" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/naturalstone,
@@ -33392,6 +33280,15 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
+"tIZ" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "tJp" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -33410,10 +33307,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -33445,6 +33347,10 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"tLn" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -33485,6 +33391,20 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"tNb" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
+"tNi" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "tNj" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -33513,12 +33433,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"tNC" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/axe{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tNH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
@@ -33588,6 +33502,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"tQK" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33600,11 +33524,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"tRF" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "tRV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -33632,6 +33551,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"tTq" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "tTF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -33665,7 +33588,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/turf/open/floor/rogue/wood,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
@@ -33675,14 +33602,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -33759,20 +33680,23 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "tXu" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tXC" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"tXF" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+"tXU" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -33780,12 +33704,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town)
-"tYO" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "tYP" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
@@ -33832,26 +33750,18 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
-"uaj" = (
-/obj/machinery/light/rogue/forge{
-	pixel_x = -1
-	},
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"uaj" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"uaQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "uaX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -33865,10 +33775,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"ubr" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "ubv" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -33878,12 +33784,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"ubM" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "ubZ" = (
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -33917,25 +33817,6 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
-"udH" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"udL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "udM" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -33960,14 +33841,6 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
-"uem" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "ueD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -34055,15 +33928,6 @@
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"uhv" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "uhw" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -34115,6 +33979,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"ujl" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ujO" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bog)
@@ -34177,6 +34048,10 @@
 /obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ulv" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ulY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -34187,6 +34062,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"umS" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "unm" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -34201,6 +34080,10 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"unD" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "unM" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -34209,10 +34092,6 @@
 /obj/structure/closet/crate/chest/gold/lootbox/trait,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"unY" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "uod" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/dirt/road{
@@ -34259,10 +34138,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
-"upw" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "upx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -34318,9 +34193,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34458,6 +34338,20 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
+"uuz" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uuA" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34474,13 +34368,18 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
+"uvn" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uvu" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34495,21 +34394,12 @@
 "uvF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
-"uvM" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uwa" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
+/obj/structure/well/fountain{
+	pixel_x = -14
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34558,23 +34448,19 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
 /obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
+	dir = 1
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -34609,6 +34495,15 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"uyS" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "uyU" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/transparent/openspace,
@@ -34629,13 +34524,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34695,12 +34585,6 @@
 "uAZ" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/shelter)
-"uBn" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "uBo" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/twig,
@@ -34713,6 +34597,9 @@
 /area/rogue/outdoors/rtfield)
 "uBv" = (
 /obj/structure/fluff/alch,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "uBE" = (
@@ -34760,12 +34647,13 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -34800,16 +34688,26 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -34830,13 +34728,10 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "uGo" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -34846,10 +34741,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"uGq" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uGt" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -34896,25 +34787,28 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"uHM" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "uHW" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/food/snacks/smallrat,
@@ -34923,17 +34817,6 @@
 "uIk" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
-"uIo" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "uJk" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -34945,6 +34828,10 @@
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
+"uKb" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -35046,18 +34933,17 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"uMC" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "uMO" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"uNc" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uNf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -35111,9 +34997,8 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -35187,16 +35072,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"uRv" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"uRy" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -35211,7 +35086,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/rtfield)
 "uSx" = (
-/obj/structure/chair/bench/church/r{
+/obj/structure/chair/bench/church{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -35279,16 +35154,6 @@
 /obj/structure/fluff/statue,
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/shelter/mountains)
-"uUo" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "uUv" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35299,12 +35164,10 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uVk" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"uUG" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -35439,6 +35302,16 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"uZf" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uZk" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -35453,10 +35326,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
@@ -35482,6 +35356,12 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"val" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "vat" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -35510,10 +35390,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"vbp" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "vbC" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -35537,11 +35413,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
-"vcg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
+"vcf" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "vcj" = (
 /obj/structure/rack/rogue{
@@ -35561,18 +35438,11 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"vcZ" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "vdg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -35648,8 +35518,19 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"veY" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16;
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35695,27 +35576,13 @@
 	dir = 1;
 	icon_state = "border"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"vgI" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "vgZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vha" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vhg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -35777,8 +35644,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/mountains)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -35828,19 +35696,23 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"vlE" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vlK" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"vlU" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+"vlS" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vlX" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -35863,6 +35735,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"vmD" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vmJ" = (
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt,
@@ -35934,8 +35813,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -36007,14 +35891,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"vrF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "vrG" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -36041,9 +35917,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/bed/rogue/inn/double,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -36054,6 +35933,14 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"vsl" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vsm" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/churchmarble,
@@ -36158,6 +36045,18 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"vvk" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vvJ" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/dirt,
@@ -36235,16 +36134,6 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
-"vyN" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -36277,6 +36166,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
+"vzi" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vzm" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
@@ -36302,16 +36197,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"vzO" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vzR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36373,6 +36258,13 @@
 /obj/item/listenstone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"vBh" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -36410,10 +36302,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"vCC" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "vCD" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -36504,6 +36392,10 @@
 /obj/structure/statue/saints/magelady2_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"vEN" = (
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
 "vEQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -36535,7 +36427,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/turf/open/floor/rogue/tile/checker,
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
@@ -36558,9 +36452,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "vGQ" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "vGT" = (
 /obj/structure/spacevine,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -36571,21 +36467,16 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
-"vHy" = (
-/turf/closed/mineral/rogue,
 /area/rogue/indoors/town)
 "vIa" = (
 /turf/closed/mineral/rogue,
@@ -36621,12 +36512,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
-"vJv" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "vJU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -36654,15 +36539,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -36684,6 +36563,30 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"vLJ" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "vLM" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36698,15 +36601,21 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"vMQ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+"vMx" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
+"vMQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vMT" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -36750,6 +36659,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vOD" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vOU" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/effect/decal/cleanable/cobweb,
@@ -36761,10 +36676,6 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"vPe" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "vPf" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/dirt,
@@ -36774,7 +36685,7 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "vPJ" = (
@@ -36817,9 +36728,24 @@
 	},
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
+"vQG" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "vQV" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36835,6 +36761,19 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"vRY" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "vSp" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -36920,34 +36859,33 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/roguemachine/scomm/l,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"vUp" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"vUD" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
 	},
 /area/rogue/indoors/town/shop)
+"vUP" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vUT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
@@ -36966,13 +36904,6 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"vVI" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "vVM" = (
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
@@ -37025,9 +36956,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -37164,16 +37094,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"wbF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -37184,6 +37104,12 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"wcc" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "wcd" = (
 /obj/structure/stairs{
 	dir = 1
@@ -37199,6 +37125,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"wdx" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wdJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
@@ -37278,11 +37214,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wgt" = (
@@ -37297,12 +37228,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"wgG" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "wgO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/silver,
@@ -37345,10 +37270,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"wjw" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
 "wjB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -37366,18 +37287,19 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wkB" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"wlk" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "wlq" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
@@ -37411,12 +37333,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"wmn" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "wmK" = (
 /obj/structure/stairs{
 	dir = 1
@@ -37445,17 +37361,17 @@
 "wnd" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"wni" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "wnv" = (
 /obj/structure/roguewindow,
 /obj/structure/bars,
 /turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
+"wny" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "wnG" = (
 /obj/structure/spacevine,
@@ -37472,17 +37388,15 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wou" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37510,18 +37424,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -37538,16 +37443,9 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "wqE" = (
 /obj/structure/fluff/traveltile{
@@ -37562,10 +37460,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"wqM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "wqN" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -37575,25 +37469,36 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
+"wse" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"wss" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "wsR" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37604,14 +37509,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "wte" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "wtl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -37626,6 +37531,14 @@
 "wtF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
+"wtJ" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "wtV" = (
 /obj/structure/closet/crate/chest{
 	lockid = "priest"
@@ -37633,6 +37546,18 @@
 /obj/item/clothing/cloak/stole/red,
 /obj/item/clothing/cloak/chasuble,
 /turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/church/chapel)
+"wtX" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "wue" = (
 /obj/structure/chair/wood/rogue/fancy{
@@ -37644,6 +37569,12 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wuD" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wve" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
@@ -37668,6 +37599,10 @@
 "wvE" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"wvI" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "wvM" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/bog)
@@ -37689,12 +37624,6 @@
 /obj/item/candle/skull/lit,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"wvV" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "wvW" = (
 /obj/item/clothing/ring/diamond{
 	desc = "A brilliant Ring to signify the beloved champion of Eora.";
@@ -37705,6 +37634,11 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"wwu" = (
+/obj/machinery/light/rogue/smelter,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -37738,9 +37672,20 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"wyU" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -37774,6 +37719,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"wzZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -37786,6 +37737,17 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"wAE" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "wAP" = (
 /obj/structure/rack/rogue,
 /obj/item/flint,
@@ -37871,10 +37833,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"wDb" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "wDj" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -37907,23 +37865,23 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"wDW" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "wDZ" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37948,12 +37906,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"wEY" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "wFc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -37971,13 +37923,12 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -38014,24 +37965,11 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"wGu" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "wGD" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"wGP" = (
-/obj/machinery/light/rogue/lanternpost{
-	pixel_x = 15
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "wHa" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/cobble,
@@ -38209,6 +38147,21 @@
 "wNb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bog)
+"wNj" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wNp" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -38217,6 +38170,11 @@
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wNv" = (
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wNH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -38373,18 +38331,12 @@
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wSg" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
 "wSl" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -38401,12 +38353,20 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"wTx" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
@@ -38430,11 +38390,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38476,6 +38438,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
+"wWU" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wXf" = (
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -38488,6 +38457,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"wXy" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wXz" = (
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -38525,10 +38502,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38543,6 +38518,10 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"wYZ" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "wZg" = (
 /obj/item/wisp_lantern,
 /obj/structure/closet/crate/chest/gold,
@@ -38563,31 +38542,17 @@
 /obj/item/rogueweapon/sword,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"wZQ" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH";
-	pixel_x = 19
+"xaa" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "wh2";
-	aportalid = "wh1";
-	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
-	pixel_x = 18
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xaf" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "xba" = (
 /obj/structure/mineral_door/wood{
@@ -38629,10 +38594,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38692,10 +38661,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"xdJ" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+"xdF" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38740,10 +38713,6 @@
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
-/area/rogue/indoors/town/church/chapel)
-"xfj" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "xfG" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -38813,6 +38782,12 @@
 "xhM" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/rtfield)
+"xhT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "xhX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -38927,19 +38902,25 @@
 "xkm" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
-"xkF" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
+"xkD" = (
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 4
 	},
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
+"xkE" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"xkF" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -38995,12 +38976,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"xmQ" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xna" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -39059,6 +39034,19 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"xnV" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "xob" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39090,6 +39078,16 @@
 /obj/item/roguekey/shop,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"xot" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "xou" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
@@ -39136,15 +39134,28 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
-"xpW" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"xpV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -39177,19 +39188,13 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"xqZ" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
-	name = "Butler"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xrd" = (
 /obj/structure/bars/pipe,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "xrf" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -39213,18 +39218,6 @@
 "xrI" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/shop)
-"xrY" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "xse" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -39235,27 +39228,25 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
+"xsf" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xsp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"xsD" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "xsG" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"xsV" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "xtc" = (
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
@@ -39288,6 +39279,10 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"xtx" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "xtA" = (
 /obj/structure/stairs{
 	dir = 4
@@ -39337,6 +39332,16 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
+"xuF" = (
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
+"xvd" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "xvs" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -39366,6 +39371,13 @@
 /obj/item/natural/worms,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"xvC" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "xvK" = (
 /obj/item/rogueweapon/hammer/claw,
 /turf/open/floor/rogue/metal/barograte,
@@ -39385,16 +39397,17 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"xwh" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "xwi" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39503,6 +39516,14 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"xzp" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "xzN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road{
@@ -39551,30 +39572,9 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"xBh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/garrison)
-"xBk" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "xBl" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
-"xBv" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "xBB" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/tile{
@@ -39688,12 +39688,6 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/beach)
-"xDa" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "xDi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
@@ -39701,10 +39695,13 @@
 "xDn" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
-"xDp" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+"xDw" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "xDJ" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -39742,9 +39739,8 @@
 	},
 /area/rogue/outdoors/town)
 "xET" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39755,11 +39751,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xFp" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "xFt" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder{
@@ -39775,6 +39766,14 @@
 /obj/effect/landmark/start/barkeep,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"xFX" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "xFZ" = (
 /obj/structure/spacevine,
 /turf/open/water/cleanshallow,
@@ -39785,11 +39784,25 @@
 	icon_state = "ice"
 	},
 /area/rogue/indoors/shelter/mountains)
+"xGj" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "xGp" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"xGr" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xGz" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/dirt/road{
@@ -39825,24 +39838,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"xGV" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "xGW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"xGY" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xHe" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39899,15 +39908,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "xJe" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39946,14 +39952,6 @@
 "xKF" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/church/chapel)
-"xKH" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "xKK" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/shoes/roguetown/boots/leather,
@@ -39965,6 +39963,12 @@
 /obj/item/clothing/shoes/roguetown/boots/leather,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"xKZ" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "xLf" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -40128,6 +40132,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"xQH" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xQK" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -40160,10 +40174,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"xRn" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "xRr" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -40173,6 +40183,14 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"xRu" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40211,6 +40229,12 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"xTa" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "xTp" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -40254,6 +40278,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"xUb" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "xUf" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -40283,11 +40314,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"xUK" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "xUQ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -40328,27 +40354,12 @@
 /obj/structure/roguewindow/stained/silver,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"xVN" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "xWm" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"xWA" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "xWN" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
@@ -40553,9 +40564,9 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -40564,9 +40575,23 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
+"ydj" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ydm" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
+"ydx" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ydR" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt,
@@ -40580,10 +40605,6 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
-"yel" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "yer" = (
 /obj/structure/bars/passage/shutter,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -40666,6 +40687,18 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"yfy" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "yfz" = (
 /obj/structure/pillory/dungeon/reinforced,
 /obj/effect/decal/cleanable/blood,
@@ -40674,6 +40707,21 @@
 "yfY" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"ygs" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"ygt" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ygF" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -40688,14 +40736,6 @@
 /obj/item/natural/bundle/cloth,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"yhr" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "yhs" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -40710,6 +40750,16 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"yhG" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "yhO" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/rogue/trophy/deer,
@@ -40744,14 +40794,13 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
 	},
-/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -40779,8 +40828,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -40832,6 +40884,12 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"ylw" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ylC" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/basement)
@@ -183622,18 +183680,18 @@ bpD
 bpD
 bpD
 bpD
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
 bpD
 bpD
 bpD
@@ -184024,7 +184082,7 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 sYw
 sYw
@@ -184034,8 +184092,8 @@ sYw
 sYw
 sYw
 sYw
-auL
-auL
+nBf
+nBf
 bpD
 bpD
 bpD
@@ -184426,7 +184484,7 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
 xAh
@@ -184436,11 +184494,11 @@ xAh
 xAh
 xAh
 sYw
-auL
-auL
-auL
-auL
-auL
+nBf
+nBf
+nBf
+nBf
+nBf
 bpD
 bpD
 bpD
@@ -184828,21 +184886,21 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
-sAj
-fVM
-fVM
-wgG
-sAj
+vjs
+xHe
+xHe
+ppc
+vjs
 xAh
 sYw
 sYw
 sYw
 sYw
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -185230,21 +185288,21 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
-fVM
-fVM
-wgG
-fVM
-mjP
+xHe
+xHe
+ppc
+xHe
+ulv
 xAh
 xAh
 xAh
 xAh
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -185632,21 +185690,21 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
-jti
-wni
-fVM
-fVM
-fVM
-fVM
-fVM
-sAj
+ygt
+bEn
+xHe
+xHe
+xHe
+xHe
+xHe
+vjs
 xAh
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -186034,21 +186092,21 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
-auL
-auL
-jNF
-pnq
-poU
-fVM
-wgG
-sAj
+nBf
+nBf
+sQi
+xaa
+rcr
+xHe
+ppc
+vjs
 xAh
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -186436,21 +186494,21 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
-xGV
-auL
-auL
-ccy
-fnP
-fVM
-jiW
-fVM
-sRY
+fIB
+nBf
+nBf
+ffB
+wou
+xHe
+xGY
+xHe
+dFS
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -186838,21 +186896,21 @@ bpD
 bpD
 bpD
 bpD
-auL
+nBf
 sYw
 xAh
-nIh
-auL
-auL
-nAu
-fnP
-qBB
-fVM
-fVM
-sRY
+woq
+nBf
+nBf
+nxM
+wou
+nRH
+xHe
+xHe
+dFS
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -187240,21 +187298,21 @@ sSS
 sSS
 sSS
 sSS
-auL
+nBf
 sYw
 xAh
-auL
-auL
-hRg
-fVM
-poU
-fVM
-wgG
-sAj
+nBf
+nBf
+rnE
+xHe
+rcr
+xHe
+ppc
+vjs
 xAh
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -187642,21 +187700,21 @@ sSS
 sSS
 sSS
 sSS
-auL
+nBf
 sYw
 xAh
-aTr
-nre
-fVM
-fVM
-fVM
-fVM
-fVM
-sAj
+ujl
+wkB
+xHe
+xHe
+xHe
+xHe
+xHe
+vjs
 xAh
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -188044,21 +188102,21 @@ sSS
 sSS
 sSS
 sSS
-auL
+nBf
 sYw
 xAh
-fVM
-fVM
-fVM
-fVM
-mjP
+xHe
+xHe
+xHe
+xHe
+ulv
 xAh
 xAh
 xAh
 xAh
 xAh
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -188446,21 +188504,21 @@ sSS
 sSS
 sSS
 sSS
-auL
+nBf
 sYw
 xAh
-sAj
-rBd
-wgG
-wgG
-sAj
+vjs
+cwo
+ppc
+ppc
+vjs
 xAh
 sYw
 sYw
 sYw
 sYw
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -188848,7 +188906,7 @@ sSS
 sSS
 sSS
 sSS
-auL
+nBf
 sYw
 xAh
 xAh
@@ -188858,11 +188916,11 @@ xAh
 xAh
 xAh
 sYw
-auL
-auL
-auL
-auL
-auL
+nBf
+nBf
+nBf
+nBf
+nBf
 bpD
 bpD
 bpD
@@ -189250,7 +189308,7 @@ sSS
 sSS
 sSS
 sSS
-auL
+nBf
 sYw
 sYw
 sYw
@@ -189260,7 +189318,7 @@ sYw
 sYw
 sYw
 sYw
-auL
+nBf
 bpD
 bpD
 bpD
@@ -189652,17 +189710,17 @@ sSS
 sSS
 sSS
 sSS
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auL
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
+nBf
 bpD
 bpD
 bpD
@@ -202888,15 +202946,15 @@ vRu
 vRu
 vRu
 fjw
-ebe
-ebe
-ebe
-ebe
-ebe
-ebe
-ebe
-ebe
-ebe
+tUR
+tUR
+tUR
+tUR
+tUR
+tUR
+tUR
+tUR
+tUR
 vup
 iTw
 iTw
@@ -203290,7 +203348,7 @@ vRu
 vRu
 fjw
 fjw
-ebe
+tUR
 txa
 txa
 txa
@@ -206907,8 +206965,8 @@ sYw
 sYw
 sYw
 sYw
-ebe
-ebe
+tUR
+tUR
 txa
 cFQ
 cBf
@@ -227815,7 +227873,7 @@ acD
 acD
 fhw
 acD
-sLx
+iia
 acD
 acD
 acD
@@ -228218,8 +228276,8 @@ acD
 acD
 acD
 vuH
-cMs
-sbF
+cdn
+aok
 acD
 azH
 azH
@@ -228617,7 +228675,7 @@ vRu
 vRu
 acD
 qgC
-sbF
+aok
 qgC
 vuH
 qgC
@@ -229018,12 +229076,12 @@ vRu
 vRu
 vRu
 acD
-sbF
+aok
 qgC
-cMs
+cdn
 vuH
-cMs
-sbF
+cdn
+aok
 acD
 qgC
 qgC
@@ -229421,11 +229479,11 @@ vRu
 vRu
 acD
 qgC
-sbF
+aok
 qgC
 vuH
-cMs
-sbF
+cdn
+aok
 acD
 qgC
 qgC
@@ -229822,12 +229880,12 @@ vRu
 vRu
 vRu
 acD
-sbF
+aok
 qgC
 qgC
 vuH
-cMs
-sbF
+cdn
+aok
 acD
 qgC
 qgC
@@ -230226,9 +230284,9 @@ vRu
 acD
 qgC
 qgC
-jec
+odH
 vuH
-cMs
+cdn
 qgC
 acD
 vRu
@@ -230629,7 +230687,7 @@ acD
 acD
 acD
 acD
-flR
+jEB
 acD
 acD
 acD
@@ -231430,12 +231488,12 @@ vRu
 vRu
 acD
 qgC
-sbF
-qKU
+aok
+dso
 vuH
 ffw
 qgC
-sbF
+aok
 acD
 vRu
 vRu
@@ -231833,7 +231891,7 @@ vRu
 acD
 qgC
 qgC
-qKU
+dso
 qgC
 vuH
 vuH
@@ -232234,9 +232292,9 @@ vRu
 vRu
 acD
 qgC
-sbF
+aok
 qgC
-qKU
+dso
 vuH
 vuH
 qgC
@@ -233038,9 +233096,9 @@ vRu
 vRu
 acD
 qgC
-onQ
+emK
 qgC
-onQ
+emK
 ffw
 vuH
 qgC
@@ -233441,11 +233499,11 @@ vRu
 acD
 qgC
 vRu
-qKU
+dso
 vuH
 vuH
 vuH
-sbF
+aok
 acD
 vRu
 vRu
@@ -233845,8 +233903,8 @@ acD
 acD
 acD
 acD
-hbR
-vgI
+mdd
+inC
 acD
 acD
 vRu
@@ -280914,12 +280972,12 @@ hcW
 hcW
 hcW
 cWT
-sIE
-sIE
-sIE
-sIE
-sIE
-sIE
+tlQ
+tlQ
+tlQ
+tlQ
+tlQ
+tlQ
 uSw
 uSw
 uSw
@@ -280939,35 +280997,35 @@ uSw
 uSw
 uSw
 uSw
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 cWT
 hcW
 hcW
@@ -281315,12 +281373,12 @@ uaL
 uaL
 uaL
 uaL
-veW
-tXu
-uHk
-vQV
-vQV
-omp
+bCb
+cCS
+hVO
+dNL
+dNL
+kEA
 nrw
 nrw
 nrw
@@ -281350,26 +281408,26 @@ ykt
 ykt
 ykt
 ykt
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
+bCb
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 cWT
 hcW
 hcW
@@ -281717,61 +281775,61 @@ wSn
 wSn
 uaL
 uaL
-veW
-tXu
-rcr
-vQV
-vQV
-vQV
+bCb
+cCS
+wpm
+dNL
+dNL
+dNL
 nrw
 nrw
-nNF
-xqZ
-qzy
-qji
-qji
-fDB
+hfU
+hRr
+bVa
+uKb
+uKb
+aHl
 nrw
-iiG
-vFz
-vFz
-uBn
+ryk
+bmL
+bmL
+iHs
 kzQ
-qgP
-wYv
-wYv
-aXr
-ica
+xsf
+rRA
+rRA
+aVK
+rvF
 nrw
-vQV
-vQV
-uEX
+dNL
+dNL
+mQA
 uaL
 uaL
 paf
 qvR
 qvR
-mHp
+rgO
 uaL
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
-veW
-kVc
-kVc
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 cWT
 hcW
 hcW
@@ -282119,62 +282177,62 @@ wSn
 wSn
 tzK
 uaL
-veW
-tXu
-jdO
-vQV
-kss
-kmo
+bCb
+cCS
+fzv
+dNL
+fVN
+unD
 nrw
 nrw
-rhY
-qzy
-qzy
-nku
-nku
-nku
+pKQ
+bVa
+bVa
+ePD
+ePD
+ePD
 nrw
 jlO
-vFz
-qjg
-vFz
+bmL
+dvG
+bmL
 jlO
-qgP
-wYv
-wYv
-lBD
-pCo
+xsf
+rRA
+rRA
+tGA
+tJC
 nrw
-vQV
-vQV
-uEX
-ogC
+dNL
+dNL
+mQA
+qii
 uaL
 paf
 qvR
 qvR
-mHp
+rgO
 uaL
 uaL
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 cWT
 cWT
 cWT
@@ -282521,65 +282579,65 @@ wSn
 uaL
 uaL
 uaL
-veW
-tXu
-fJG
-vQV
-vQV
-kmo
+bCb
+cCS
+jax
+dNL
+dNL
+unD
 nrw
 nrw
-uDi
-qzy
-qzy
-xqZ
-qzy
-qzy
-dAf
+tyU
+bVa
+bVa
+hRr
+bVa
+bVa
+aym
 jlO
-vFz
-cwd
-vFz
+bmL
+lAE
+bmL
 jlO
 evo
-wTs
-wYv
-raQ
-wYv
+qeY
+rRA
+aDw
+rRA
 nrw
-vQV
-vQV
-uEX
-tYO
+dNL
+dNL
+mQA
+ppM
 uaL
 paf
 qvR
 qvR
-mHp
+rgO
 fxx
 aJj
 wSn
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 cWT
 hcW
 hcW
@@ -282923,66 +282981,66 @@ wSn
 uaL
 uaL
 uaL
+bCb
+cCS
+cCS
+tEQ
+tEQ
+knq
+cCS
+nrw
+fIb
 veW
-tXu
-tXu
-wsR
-wsR
-tqu
-tXu
-nrw
-xDa
-bPv
-qzy
-qzy
-qzy
-qzy
-dAf
+bVa
+bVa
+bVa
+bVa
+aym
 jlO
-vFz
-aSD
-vFz
+bmL
+isP
+bmL
 jlO
 nrw
-rXa
-wYv
-wYv
-wYv
-mbO
-vQV
-vQV
-uEX
+qRZ
+rRA
+rRA
+rRA
+rPA
+dNL
+dNL
+mQA
 uaL
 uaL
-qwd
+tfp
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 wSn
 wSn
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 hcW
 hcW
 hcW
@@ -283325,68 +283383,68 @@ wSn
 wSn
 uaL
 uaL
-veW
-tXu
-fJG
-wsR
-wsR
-tqu
-tXu
+bCb
+cCS
+jax
+tEQ
+tEQ
+knq
+cCS
 nrw
-jpM
-xqZ
-qzy
-vWY
-vWY
-vWY
+nPQ
+hRr
+bVa
+xkF
+xkF
+xkF
 nrw
-kFh
-vFz
-xrY
-vFz
-kFh
+cTc
+bmL
+aeu
+bmL
+cTc
 nrw
-nzV
-wYv
-vQV
-vQV
-mbO
-vQV
-vQV
-uEX
+ncg
+rRA
+dNL
+dNL
+rPA
+dNL
+dNL
+mQA
 ykt
 ykt
 ykt
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 wSn
 aJj
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 hcW
 hcW
 uaL
@@ -283688,7 +283746,7 @@ cWT
 hcW
 hcW
 hcW
-qzH
+kaP
 wSn
 wSn
 wSn
@@ -283727,69 +283785,69 @@ uaL
 uaL
 uaL
 uaL
-veW
-tXu
-uHk
-wsR
-jFn
-wsR
-ixi
-qzy
-qzy
-qzy
-fRO
-nku
-nku
-kgK
+bCb
+cCS
+hVO
+tEQ
+tLn
+tEQ
+vUp
+bVa
+bVa
+bVa
+aTq
+ePD
+ePD
+kKN
 nrw
-lyJ
-vFz
-vFz
-vFz
+nhR
+bmL
+bmL
+bmL
 jlO
 nrw
-wTs
-wYv
-vQV
-vQV
-mbO
-nBf
-vQV
-uEX
+qeY
+rRA
+dNL
+dNL
+rPA
+cwd
+dNL
+mQA
 uaL
 uaL
-qwd
+tfp
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 wSn
 uaL
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 uaL
 uaL
 wSn
@@ -284129,15 +284187,15 @@ hcW
 hcW
 uaL
 uaL
-veW
-tXu
-rcr
-wsR
-wsR
-wsR
-tXu
+bCb
+cCS
+wpm
+tEQ
+tEQ
+tEQ
+cCS
 nrw
-dAf
+aym
 nrw
 nrw
 nrw
@@ -284146,51 +284204,51 @@ nrw
 nrw
 nrw
 jlO
-sCh
-kFh
+aXQ
+cTc
 jlO
 nrw
-hSy
-wYv
-vQV
-fic
+fXr
+rRA
+dNL
+ewu
 nrw
-hbc
-vQV
-uEX
-kya
+ycz
+dNL
+mQA
+shS
 uaL
 paf
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
 wSn
 uaL
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 wSn
@@ -284531,67 +284589,67 @@ hcW
 hcW
 uaL
 uaL
-veW
-tXu
-jdO
-lpB
-wsR
-wsR
-lSX
-vQV
-vQV
-mzo
-vQV
-tgc
-tgc
-vQV
+bCb
+cCS
+fzv
+bFu
+tEQ
+tEQ
+ltI
+dNL
+dNL
+sBO
+dNL
+har
+har
+dNL
 mwq
 nrw
-uUo
+gEy
 nrw
 jlO
 jlO
 nrw
-vUD
-qYw
-vQV
-fQq
+fMl
+nZy
+dNL
+mJU
 nrw
-nBf
-vQV
-uEX
-goz
+cwd
+dNL
+mQA
+val
 uaL
 paf
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
 uaL
 wSn
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 qvR
@@ -284933,65 +284991,65 @@ hcW
 hcW
 hcW
 uaL
-veW
-tXu
-tXu
-tXu
-tXu
+bCb
+cCS
+cCS
+cCS
+cCS
 nrw
 nrw
 mwq
-vQV
-kss
-vQV
-kss
-vQV
-vQV
-vQV
-vQV
-vQV
+dNL
+fVN
+dNL
+fVN
+dNL
+dNL
+dNL
+dNL
+dNL
 nrw
-tsE
-nrw
-nrw
+jNF
 nrw
 nrw
-gpK
 nrw
 nrw
-vQV
-vQV
-uEX
+oMa
+nrw
+nrw
+dNL
+dNL
+mQA
 lsD
 lsD
-hqw
+pUX
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
 fxx
 wSn
-veW
+bCb
 kVc
-veW
-kVc
-kVc
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
@@ -285335,65 +285393,65 @@ hcW
 hcW
 uaL
 uaL
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
 evo
 nrw
 nrw
-cfK
-cfK
-nYg
-suN
-xVN
-xVN
-xVN
-suN
-vQV
+wTx
+wTx
+pzY
+eBq
+xvd
+xvd
+xvd
+eBq
+dNL
 nrw
-qzy
-fMS
-mUg
+bVa
+eWd
+xkE
 nrw
-vPe
-nBf
-hbc
-nBf
-vQV
-vQV
-uEX
+uxV
+cwd
+ycz
+cwd
+dNL
+dNL
+mQA
 rhD
 rhD
 rhD
 rhD
 rhD
-mHp
+rgO
 rZt
 fxx
 fxx
 fxx
 uaL
-veW
+bCb
 kVc
-veW
-kVc
-kVc
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 uaL
 uaL
@@ -285741,31 +285799,31 @@ uaL
 uaL
 qvR
 qvR
-veW
-evo
-agR
-hbc
-cbG
-cbG
-qjk
-suN
-jAI
-hej
-dfG
-avf
-vQV
-nrw
-qzy
-kKj
-qzy
-bRt
-vQV
-vQV
-nBf
-vQV
-vQV
-vQV
 bCb
+evo
+hJR
+ycz
+cbG
+cbG
+tiW
+eBq
+sTi
+dIl
+hDE
+gKU
+dNL
+nrw
+bVa
+xGr
+bVa
+vsg
+dNL
+dNL
+cwd
+dNL
+dNL
+dNL
+jkZ
 fxx
 fxx
 fxx
@@ -285778,24 +285836,24 @@ fxx
 fxx
 aJj
 wSn
-veW
-veW
+bCb
+bCb
 kVc
 kVc
-veW
+bCb
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 uaL
 uaL
@@ -286143,34 +286201,34 @@ uaL
 uaL
 qvR
 qvR
-dwO
+bHX
 evo
-lZz
-hbc
+fVM
+ycz
 cbG
 cbG
-dkV
-suN
-goh
-aFj
-twy
-suN
-vQV
-haw
-qzy
-cdn
-qzy
-tsE
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-bCb
+jlY
+eBq
+kNi
+vox
+xDw
+eBq
+dNL
+yhG
+bVa
+rNo
+bVa
+jNF
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+jkZ
 fxx
 fxx
-uxV
+uwa
 fxx
 fxx
 fxx
@@ -286180,24 +286238,24 @@ fxx
 fxx
 uaL
 wSn
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 uaL
 wSn
@@ -286545,61 +286603,61 @@ uaL
 uaL
 qvR
 qvR
-dwO
+bHX
 evo
-fLX
-hbc
+kHb
+ycz
 cbG
 cbG
-nYg
-suN
-wFp
-oBH
-eLp
-suN
-vQV
+pzY
+eBq
+eSH
+rUR
+seK
+eBq
+dNL
 nrw
-rTw
-rTw
-cdn
-tsE
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
+bJC
+bJC
+rNo
+jNF
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+jkZ
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+uaL
+uaL
+kVc
 bCb
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-kVc
-veW
-veW
+bCb
 kVc
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 uaL
@@ -286911,7 +286969,7 @@ uaL
 uaL
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -286947,37 +287005,37 @@ uaL
 uaL
 qvR
 qvR
-dwO
+bHX
 evo
 nrw
 nrw
-nrv
-nrv
-nYg
-avf
-cCS
-cCS
-cCS
-suN
-vQV
+htf
+htf
+pzY
+gKU
+sTp
+sTp
+sTp
+eBq
+dNL
 nrw
-fBY
-htp
-qzy
-bRt
-vQV
-vQV
-nBf
-vQV
-vQV
-vQV
-uEX
+sOL
+csH
+bVa
+vsg
+dNL
+dNL
+cwd
+dNL
+dNL
+dNL
+mQA
 rhD
 rhD
 rhD
 rhD
 rhD
-mHp
+rgO
 rZt
 fxx
 fxx
@@ -286985,23 +287043,23 @@ fxx
 fxx
 aJj
 kVc
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 uaL
@@ -287349,37 +287407,37 @@ uaL
 uaL
 qvR
 qvR
-veW
+bCb
 evo
 nrw
 mwq
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-vQV
-kss
-vQV
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+fVN
+dNL
 nrw
 nrw
 nrw
-xJe
+fqr
 nrw
-vPe
-nBf
-hbc
-nBf
-vQV
-vQV
-uEX
-bPz
+uxV
+cwd
+ycz
+cwd
+dNL
+dNL
+mQA
+afy
 qvR
 qvR
 qvR
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -287387,23 +287445,23 @@ fxx
 fxx
 uaL
 aJj
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
-veW
+bCb
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
-veW
+bCb
 kVc
 qvR
 qvR
@@ -287751,37 +287809,37 @@ uaL
 uaL
 uaL
 qvR
-veW
+bCb
 evo
 nrw
-hci
-xET
-scS
-vQV
-xET
-xET
-vQV
+wUw
+lMg
+vFz
+dNL
+lMg
+lMg
+dNL
 mwq
 nrw
 nrw
 nrw
 nrw
-vPA
-qzy
+rRD
+bVa
 nrw
 nrw
-qWL
+cXu
 nrw
 nrw
-nBf
-vQV
-uEX
+cwd
+dNL
+mQA
 uaL
 uaL
 uaL
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -287789,23 +287847,23 @@ fxx
 fxx
 wSn
 aJj
-veW
-veW
-veW
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 uaL
 wSn
@@ -288122,7 +288180,7 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -288151,9 +288209,9 @@ uaL
 uaL
 uaL
 hcW
-veW
-veW
-veW
+bCb
+bCb
+bCb
 evo
 nrw
 nrw
@@ -288165,25 +288223,25 @@ nrw
 nrw
 nrw
 nrw
-pKQ
-pKQ
+gLJ
+gLJ
 nrw
-vPA
-qzy
-vPA
-jYZ
-fFH
-qji
+rRD
+bVa
+rRD
+bOC
+hQY
+uKb
 nrw
-hbc
-vQV
-uEX
+ycz
+dNL
+mQA
 uaL
 uaL
 uaL
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -288192,20 +288250,20 @@ fxx
 wSn
 aJj
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-qqd
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+sxM
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
@@ -288555,37 +288613,37 @@ hcW
 hcW
 hcW
 cWT
-sIE
-sIE
-sIE
-sIE
+tlQ
+tlQ
+tlQ
+tlQ
+rRD
+rRD
+rRD
+gLJ
+gLJ
+rRD
+rRD
+rRD
+bVa
 vPA
-vPA
-vPA
-pKQ
-pKQ
-vPA
-vPA
-vPA
-qzy
-jlY
 nrw
-seC
-qzy
-cdn
-qzy
-kKj
-qzy
-gWf
-nBf
-vQV
-uEX
+dbH
+bVa
+rNo
+bVa
+xGr
+bVa
+vBh
+cwd
+dNL
+mQA
 qvR
 qvR
 qvR
 qvR
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -288594,20 +288652,20 @@ fxx
 wSn
 wSn
 kVc
-veW
+bCb
 kVc
-veW
+bCb
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 kVc
@@ -288954,40 +289012,40 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 cWT
-sIE
+tlQ
 iJR
-wjw
-jVt
-qzy
-qqB
-jlY
-oMa
-qqB
-qqB
-jlY
-qqB
-bPs
-qzy
-lZz
-fFH
-qzy
-qzy
-qzy
-cdn
-qzy
-bRt
-vQV
-vQV
-uEX
+wDz
+dCd
+bVa
+qDn
+vPA
+stz
+qDn
+qDn
+vPA
+qDn
+bhe
+bVa
+fVM
+hQY
+bVa
+bVa
+bVa
+rNo
+bVa
+vsg
+dNL
+dNL
+mQA
 uaL
 uaL
 uaL
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -289002,15 +289060,15 @@ kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 lyL
@@ -289320,25 +289378,22 @@ uaL
 uaL
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
-rgO
-hcW
-hcW
-hcW
-hcW
-rgO
+sIE
 hcW
 hcW
 hcW
+hcW
+sIE
 hcW
 hcW
 hcW
@@ -289347,11 +289402,14 @@ hcW
 hcW
 hcW
 hcW
-rgO
 hcW
 hcW
 hcW
-rgO
+sIE
+hcW
+hcW
+hcW
+sIE
 hcW
 hcW
 hcW
@@ -289359,37 +289417,37 @@ hcW
 hcW
 hcW
 cWT
-sIE
+tlQ
 iJR
-uFp
-jVt
-qzy
-qqB
-jlY
-iEv
-qqB
-jlY
-oMa
-jlY
-jlY
-qzy
+gJE
+dCd
+bVa
+qDn
+vPA
+hQU
+qDn
+vPA
+stz
+vPA
+vPA
+bVa
 nrw
-qzy
-qzy
-vWY
-vWY
-qzy
-qzy
-bRt
-vQV
-vQV
-uEX
+bVa
+bVa
+xkF
+xkF
+bVa
+bVa
+vsg
+dNL
+dNL
+mQA
 uaL
 uaL
 uaL
 uaL
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -289397,22 +289455,22 @@ fxx
 fxx
 uaL
 wSn
-veW
+bCb
 kVc
 kVc
 kVc
-veW
+bCb
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 qvR
@@ -289756,42 +289814,42 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 cWT
-sIE
-sIE
-sIE
-sIE
-vPA
-vPA
-vPA
-oJO
-oJO
-vPA
-vPA
-vPA
-oMa
-qzy
-lyP
-qzy
-qzy
-aac
-uGq
-gqz
-vPA
+tlQ
+tlQ
+tlQ
+tlQ
+rRD
+rRD
+rRD
+nlw
+nlw
+rRD
+rRD
+rRD
+stz
+bVa
+cSb
+bVa
+bVa
+hNE
+jWZ
+coy
+rRD
 nrw
-vQV
-vQV
-uEX
 dNL
+dNL
+mQA
+bHT
 qvR
 qvR
 qvR
 qvR
-mHp
+rgO
 fxx
 fxx
 fxx
@@ -289799,22 +289857,22 @@ fxx
 fxx
 fxx
 wSn
-veW
+bCb
 kVc
-veW
-kVc
-kVc
+bCb
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+kVc
+kVc
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 qvR
@@ -290151,22 +290209,22 @@ hcW
 hcW
 hcW
 hcW
-rgO
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-cWT
-cWT
-cWT
-cWT
 sIE
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+cWT
+cWT
+cWT
+cWT
+tlQ
 nrw
 nrw
 nrw
@@ -290203,20 +290261,20 @@ fxx
 uaL
 kVc
 kVc
-veW
+bCb
 kVc
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 uaL
@@ -290535,7 +290593,7 @@ qvR
 uaL
 uaL
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -290553,14 +290611,14 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -290569,10 +290627,10 @@ hcW
 hcW
 hcW
 cWT
-dwO
-dwO
-vHy
-vHy
+bHX
+bHX
+sjG
+sjG
 evo
 ykt
 ykt
@@ -290607,17 +290665,17 @@ aJj
 kVc
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 kVc
 qvR
@@ -290938,7 +290996,7 @@ qvR
 qvR
 hcW
 hcW
-rgO
+sIE
 hcW
 kYc
 kYS
@@ -290947,7 +291005,7 @@ mzx
 kYc
 mzx
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -290971,8 +291029,8 @@ hcW
 hcW
 hcW
 hcW
-vHy
-dwO
+sjG
+bHX
 evo
 evo
 evo
@@ -291007,19 +291065,19 @@ fxx
 uaL
 uaL
 uaL
-veW
+bCb
 uaL
 kVc
 kVc
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
-veW
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 kVc
 qvR
 qvR
@@ -291352,16 +291410,16 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -291752,18 +291810,18 @@ msk
 ntQ
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -291816,13 +291874,13 @@ uaL
 uaL
 fxx
 fxx
-raG
-wUw
-wUw
-wUw
-wUw
-wUw
-raG
+xwh
+cLL
+cLL
+cLL
+cLL
+cLL
+xwh
 wSn
 uaL
 uaL
@@ -292143,7 +292201,7 @@ sJZ
 sJZ
 qvR
 hcW
-rgO
+sIE
 hcW
 hcW
 ldI
@@ -292218,13 +292276,13 @@ fxx
 fxx
 fxx
 fxx
-rRF
+xUb
 peN
 peN
 peN
 peN
 peN
-qqn
+rfO
 fxx
 fxx
 fxx
@@ -292533,7 +292591,7 @@ uaL
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 qvR
@@ -292565,13 +292623,13 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -292620,13 +292678,13 @@ fxx
 fxx
 fxx
 fxx
-wUw
+cLL
 peN
 peN
 peN
-aVI
+wYZ
 peN
-wUw
+cLL
 fxx
 fxx
 fxx
@@ -292970,10 +293028,10 @@ hcW
 hcW
 hcW
 hcW
-rgO
-rgO
+sIE
+sIE
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -292994,14 +293052,14 @@ wSn
 wSn
 wSn
 xKz
-nJL
-bqt
+xdF
+urF
 lLa
 xKz
 xKz
-fTS
-slQ
-geZ
+nKy
+bLl
+aOJ
 xKz
 jeb
 jeb
@@ -293367,8 +293425,8 @@ hcW
 hcW
 hcW
 hcW
-rgO
-rgO
+sIE
+sIE
 hcW
 hcW
 hcW
@@ -293396,18 +293454,18 @@ wSn
 wSn
 wSn
 xKz
-fLK
+vMQ
 iYQ
 fVQ
-jJZ
-kIf
-sDa
+iGe
+qpt
+wgn
 peN
 rUr
-vLA
-jJZ
+kKm
+iGe
 fVQ
-hSO
+vMx
 xKz
 qvR
 qvR
@@ -293424,13 +293482,13 @@ wSn
 uaL
 fTe
 wSn
-eKd
-pCS
-izq
-izq
-izq
-pCS
-eKd
+jet
+nOR
+oiE
+oiE
+oiE
+nOR
+jet
 uaL
 uaL
 uaL
@@ -293771,7 +293829,7 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -293798,18 +293856,18 @@ wSn
 wSn
 wSn
 xKz
-xFp
-bqt
+wyA
+urF
 fVQ
 lLa
-kIf
-sDa
+qpt
+wgn
 peN
 rUr
-vLA
+kKm
 lLa
 fVQ
-uaQ
+aet
 xKz
 qvR
 qvR
@@ -293829,7 +293887,7 @@ uaL
 xKz
 bOK
 jeb
-xKH
+iMu
 jeb
 bOK
 xKz
@@ -294166,14 +294224,14 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -294200,18 +294258,18 @@ wSn
 wSn
 wSn
 xKz
-fLK
+vMQ
 iYQ
 fVQ
-qpX
-kIf
-sDa
+dzB
+qpt
+wgn
 peN
 rUr
-vLA
+kKm
 hmU
 fVQ
-uaQ
+aet
 xKz
 qvR
 qvR
@@ -294231,7 +294289,7 @@ uaL
 bOK
 tYP
 tYP
-vJv
+mdB
 tYP
 tYP
 xKz
@@ -294544,7 +294602,7 @@ uaL
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 qvR
 qvR
@@ -294566,7 +294624,7 @@ ndD
 kYc
 msk
 nxV
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -294602,18 +294660,18 @@ wSn
 wSn
 wSn
 xKz
-xFp
-bqt
+wyA
+urF
 fVQ
 jeb
 jeb
-sDa
+wgn
 peN
 rUr
 jeb
 jeb
 fVQ
-mZH
+wFp
 xKz
 qvR
 qvR
@@ -294630,11 +294688,11 @@ uaL
 qvR
 qvR
 uaL
-xpW
+jnw
 tYP
-nfO
+gsD
 tYP
-ekl
+rds
 tYP
 xKz
 qvR
@@ -295004,18 +295062,18 @@ wSn
 wSn
 wSn
 xKz
-qrZ
+lgJ
 iYQ
 fVQ
 fVQ
 jeb
-txS
+cOb
 peN
 rUr
 jeb
 fVQ
 tYP
-mYV
+ffD
 xKz
 qvR
 qvR
@@ -295033,7 +295091,7 @@ qvR
 uaL
 wSn
 xKz
-vcZ
+dNp
 tYP
 tYP
 tYP
@@ -295358,7 +295416,7 @@ uaL
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -295406,18 +295464,18 @@ wSn
 wSn
 wSn
 xKz
-rdi
+wuD
 lLa
 fVQ
 fVQ
-mRR
-sDa
+cMm
+wgn
 peN
 rUr
-mRR
+cMm
 fVQ
 sCg
-iuK
+qYR
 xKz
 qvR
 uaL
@@ -295436,10 +295494,10 @@ uaL
 wSn
 bOK
 tYP
-vCC
+mQr
 tYP
 sCg
-qCT
+lNo
 xKz
 qvR
 qvR
@@ -295767,7 +295825,7 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -295808,18 +295866,18 @@ xKz
 xKz
 xKz
 xKz
-rdi
+wuD
 lLa
 kMi
-gKo
+qCT
 jeb
-txS
+cOb
 peN
 rUr
 jeb
 fVQ
 sCg
-iuK
+qYR
 xKz
 qvR
 uaL
@@ -295839,9 +295897,9 @@ wSn
 xKz
 xKz
 xKz
-avA
+vUP
 sCg
-iuK
+qYR
 xKz
 qvR
 qvR
@@ -296213,15 +296271,15 @@ fVQ
 fVQ
 fVQ
 kMi
-qrZ
+lgJ
 jeb
-sDa
+wgn
 peN
 rUr
 jeb
 fVQ
 tYP
-iuK
+qYR
 xKz
 qvR
 qvR
@@ -296243,7 +296301,7 @@ xKz
 xKz
 tYP
 sCg
-iuK
+qYR
 xKz
 qvR
 qvR
@@ -296553,7 +296611,7 @@ hcW
 wSn
 uaL
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -296616,14 +296674,14 @@ fVQ
 lhd
 fVQ
 fVQ
-kIf
-sDa
+qpt
+wgn
 peN
 rUr
-vLA
+kKm
 lLa
 fVQ
-qza
+sBo
 xKz
 qvR
 uaL
@@ -296643,9 +296701,9 @@ wSn
 xKz
 xKz
 xKz
-avA
+vUP
 sCg
-qCT
+lNo
 xKz
 qvR
 uaL
@@ -296955,7 +297013,7 @@ wSn
 wSn
 uaL
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
@@ -296964,7 +297022,7 @@ hcW
 hcW
 hcW
 hcW
-rgO
+sIE
 wSn
 wSn
 qvR
@@ -297011,21 +297069,21 @@ xqL
 wSn
 wSn
 xKz
-gKo
+qCT
 gqa
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-kIf
-sDa
+qpt
+wgn
 peN
 rUr
-vLA
+kKm
 lLa
 fVQ
-typ
+qqM
 xKz
 qvR
 qvR
@@ -297045,7 +297103,7 @@ uaL
 xKz
 xKz
 xKz
-klx
+uZf
 xKz
 xKz
 xKz
@@ -297354,19 +297412,19 @@ fyc
 cWT
 cWT
 wSn
-rgO
-rgO
-rgO
-rgO
+sIE
+sIE
+sIE
+sIE
 hcW
-rgO
+sIE
 hcW
 hcW
 hcW
-rgO
-rgO
-rgO
-rgO
+sIE
+sIE
+sIE
+sIE
 wSn
 wSn
 qvR
@@ -297413,21 +297471,21 @@ aJj
 uaL
 qvR
 xKz
-fLK
+vMQ
 iYQ
 lLa
 fVQ
 lhd
 fVQ
 fVQ
-kIf
-sDa
+qpt
+wgn
 peN
 rUr
-vLA
-jWb
+kKm
+ijU
 fVQ
-uvM
+wWU
 xKz
 uaL
 uaL
@@ -297756,9 +297814,9 @@ fyc
 cWT
 cWT
 uaL
-rgO
-rgO
-rgO
+sIE
+sIE
+sIE
 hcW
 hcW
 hcW
@@ -297815,18 +297873,18 @@ evo
 evo
 evo
 xKz
-qrZ
-bqt
+lgJ
+urF
 kds
-mQo
+saP
 xKz
-qpX
+dzB
 fVQ
 xKz
-wgn
-kEU
-nPQ
-xBh
+jDv
+mOw
+kIf
+nEe
 xKz
 xKz
 xKz
@@ -298226,29 +298284,29 @@ xKz
 xKz
 xKz
 uWL
-khc
-khc
+pZJ
+pZJ
 xKz
 xKz
-bmL
-bmL
-dTa
-dTa
-dTa
-dTa
-dTa
-dTa
-ocK
-ocK
-dTa
-dTa
-bmL
-bmL
-bmL
-bmL
-dTa
-dTa
-dTa
+uPa
+uPa
+uGf
+uGf
+uGf
+uGf
+uGf
+uGf
+hmF
+hmF
+uGf
+uGf
+uPa
+uPa
+uPa
+uPa
+uGf
+uGf
+uGf
 axq
 dnx
 axl
@@ -305463,7 +305521,7 @@ xKz
 wVI
 wbg
 wbg
-sxM
+xpM
 wbg
 wbg
 wbg
@@ -305819,7 +305877,7 @@ mcK
 nBW
 mOY
 nBW
-aJm
+jtq
 nBW
 wtF
 wbg
@@ -307433,7 +307491,7 @@ wtF
 wbg
 wbg
 wbg
-sxM
+xpM
 wbg
 wbg
 wbg
@@ -309556,9 +309614,9 @@ bwS
 lVe
 bwS
 lVe
-tDO
+wSl
 goK
-fNu
+tNb
 sux
 pYf
 pYf
@@ -310692,14 +310750,14 @@ wbg
 wbg
 wbg
 wVI
-wGP
-mdB
+iDV
+uaj
 nHz
 wVI
 wVI
 wVI
-iTh
-wGP
+hbr
+iDV
 wVI
 tUw
 wVI
@@ -310735,7 +310793,7 @@ fxx
 fxx
 fxx
 fxx
-cBG
+lMu
 fxx
 boU
 fxx
@@ -310753,13 +310811,13 @@ qvR
 wSn
 cyr
 hHF
-tXF
+nTR
 wlD
 sIG
 wlD
 wlD
 wlD
-fNu
+tNb
 wlD
 sIG
 wlD
@@ -311060,7 +311118,7 @@ wbg
 xXq
 yhZ
 yhZ
-wqM
+ikM
 yhZ
 yhZ
 xXq
@@ -311473,13 +311531,13 @@ xez
 wbg
 wbg
 wbg
-sxM
+xpM
 wbg
 wbg
 wbg
 wbg
 wbg
-sxM
+xpM
 wbg
 wbg
 wbg
@@ -311527,7 +311585,7 @@ fxx
 fxx
 fxx
 fxx
-cBG
+lMu
 fxx
 fxx
 fxx
@@ -311895,7 +311953,7 @@ wbg
 wbg
 wbg
 wbg
-sxM
+xpM
 wbg
 wbg
 wbg
@@ -311903,7 +311961,7 @@ wbg
 wbg
 wbg
 wbg
-sxM
+xpM
 wbg
 wbg
 wbg
@@ -313102,17 +313160,17 @@ wbg
 wbg
 wbg
 wbg
-rfO
+qzH
 hUt
 vFj
-rfO
+qzH
 wbg
 wbg
 wbg
 xGM
 xGM
-rfO
-adK
+qzH
+wsR
 ukb
 wvE
 rLt
@@ -313153,7 +313211,7 @@ trG
 ryI
 fZw
 fxx
-cBG
+lMu
 rhD
 qvR
 qvR
@@ -313511,10 +313569,10 @@ wew
 wxZ
 nRo
 bQf
-qTE
+lqg
 iPY
-aok
-adK
+llp
+wsR
 ukb
 wvE
 wvE
@@ -313868,7 +313926,7 @@ aOn
 aOn
 lpa
 nCh
-sxM
+xpM
 wbg
 wbg
 hOh
@@ -313901,22 +313959,22 @@ pUl
 rJX
 tCr
 guP
-hSx
-aym
-tlq
+qgz
+vLA
+ogC
 wbg
 qtV
 iPY
 iPY
 iPY
-pcQ
+tCz
 wVI
 weX
 wVI
-gec
+uyS
 hRv
-aok
-adK
+llp
+wsR
 xMr
 yho
 wvE
@@ -314303,22 +314361,22 @@ rJX
 eai
 tCr
 guP
-oHc
-wGu
+wra
+dCl
 iGf
 viq
 qtV
 iPY
 aOn
 aOn
-syR
+rPT
 wxZ
 wVI
 bQf
-tqI
+ava
 nXd
-bLp
-adK
+qmJ
+wsR
 dHZ
 xww
 wvE
@@ -314707,20 +314765,20 @@ fQm
 guP
 guP
 guP
-aym
+vLA
 uTQ
 qtV
 nXd
-cSc
-cSc
-loE
+kRE
+kRE
+aCr
 wVI
 wVI
 wVI
 wVI
 wVI
 rmJ
-adK
+wsR
 pht
 vwQ
 vwQ
@@ -314777,7 +314835,7 @@ lVe
 uxL
 sZI
 xlx
-eSt
+mWO
 iTv
 cXU
 iTv
@@ -315055,7 +315113,7 @@ uOL
 jxy
 vbO
 oif
-lvM
+tTq
 oif
 uJk
 tOz
@@ -315112,16 +315170,16 @@ sxR
 sxR
 abh
 wbg
-ovj
-ovj
+qzy
+qzy
 aSH
-ovj
+qzy
 wVI
 wVI
 wVI
 wVI
 wVI
-dBS
+loE
 oUn
 xMr
 vwQ
@@ -315503,7 +315561,7 @@ tYm
 oAn
 wbg
 wbg
-pKn
+oyH
 dTB
 tVP
 tVP
@@ -315512,7 +315570,7 @@ tCG
 tVP
 tVP
 tCG
-kpy
+hrh
 wbg
 wVI
 wVI
@@ -315914,9 +315972,9 @@ tVP
 tVP
 tVP
 tVP
-vlU
+qMA
 qtV
-oON
+iJx
 rZY
 wVI
 wxZ
@@ -316304,21 +316362,21 @@ pAS
 sZN
 sZN
 xdq
-oGC
+cbQ
 wbg
 wbg
-pKn
+oyH
 rJC
 tVP
-dck
-cNt
+yjP
+mAZ
 tVP
-tZZ
+kwN
 tVP
 tVP
-vlU
+qMA
 qtV
-oON
+iJx
 rZY
 wVI
 wxZ
@@ -316328,7 +316386,7 @@ wVI
 bQf
 wVI
 rZY
-phB
+gXT
 kjH
 kjH
 kjH
@@ -316358,7 +316416,7 @@ vLS
 uaL
 sjP
 wSn
-cBG
+lMu
 fxx
 lcg
 fQg
@@ -316706,23 +316764,23 @@ sZN
 sZN
 sZN
 xdq
-pcQ
+tCz
 wbg
 wbg
 wKT
 kFS
 tVP
-jHv
-mZl
-iPk
-kLD
+pvE
+wdx
+tab
+aFX
 tVP
 tCG
-vlU
+qMA
 wbg
 wbg
 wVI
-tiH
+hwQ
 wVI
 wVI
 wVI
@@ -317058,7 +317116,7 @@ oif
 oif
 oif
 oif
-upw
+cMR
 eUJ
 eUJ
 jxy
@@ -317108,7 +317166,7 @@ sZN
 sZN
 lzC
 xdq
-oGC
+cbQ
 wbg
 wbg
 wKT
@@ -317116,8 +317174,8 @@ eWj
 yfY
 ijS
 mmb
-lMr
-uaj
+tZZ
+vGQ
 yfY
 yfY
 wKT
@@ -317126,8 +317184,8 @@ qEa
 vXm
 vXm
 vXm
-lkV
-trg
+aPg
+rvH
 wVI
 wVI
 wVI
@@ -317528,12 +317586,12 @@ wbg
 uqe
 ewM
 uqe
-dgh
-pcQ
+xpV
+tCz
 wVI
 wVI
 rZY
-oDr
+fQq
 rZY
 jXw
 xgi
@@ -317912,7 +317970,7 @@ pDy
 sZN
 sZN
 xdq
-oGC
+cbQ
 wbg
 wbg
 cCQ
@@ -317924,18 +317982,18 @@ yfY
 yfY
 yfY
 yfY
-wte
+hjW
 wbg
-rmE
+xtx
 uqe
 uqe
 uqe
-eCq
+bRy
 wew
 weX
 wVI
 rZY
-rTx
+lhH
 rZY
 jXw
 xgi
@@ -317977,7 +318035,7 @@ gkv
 hLK
 njv
 fxx
-cBG
+lMu
 wxd
 wxd
 wSn
@@ -318283,7 +318341,7 @@ wrj
 jDm
 jDm
 mwE
-eoz
+gZv
 mwE
 wbg
 wbg
@@ -318314,25 +318372,25 @@ pAS
 sZN
 sZN
 xdq
-pcQ
+tCz
 wbg
 wbg
 cJz
 yfY
-amz
+mCh
 ijS
-wEY
-uaj
-lMr
+xTa
+vGQ
+tZZ
 kfr
-nPv
+yfy
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-eCq
+bRy
 wew
 wVI
 wVI
@@ -318716,7 +318774,7 @@ ygF
 ygF
 uDv
 xdq
-oGC
+cbQ
 wbg
 wbg
 wKT
@@ -318734,8 +318792,8 @@ qEa
 gGZ
 gGZ
 gGZ
-eQM
-xBk
+vLJ
+mky
 xdw
 xdw
 xdw
@@ -319122,14 +319180,14 @@ qls
 wbg
 wbg
 wKT
-aOa
-pEb
-urF
-xbW
-urF
-xbW
-urF
-xbW
+tCy
+eik
+bPv
+qRm
+bPv
+qRm
+bPv
+qRm
 wKT
 wbg
 wbg
@@ -319922,7 +319980,7 @@ pMj
 pPI
 xdq
 xdq
-oGC
+cbQ
 wbg
 wbg
 wKT
@@ -319940,13 +319998,13 @@ wbg
 usR
 ncb
 ncb
-uem
+vgA
 wbg
 wVI
 wVI
 wVI
 wVI
-nBX
+hnJ
 wVI
 wVI
 wbg
@@ -320324,17 +320382,17 @@ pOs
 pRW
 xdq
 qls
-mtG
+wzZ
 wbg
 wbg
 wKT
 wKT
 jCs
-urF
+bPv
 rHj
-urF
+bPv
 rHj
-urF
+bPv
 rHj
 wKT
 wbg
@@ -320342,7 +320400,7 @@ wbg
 usR
 xAt
 xAt
-vgA
+vHd
 wbg
 kjH
 xxF
@@ -320725,7 +320783,7 @@ xdq
 xdq
 xdq
 xdq
-wss
+uMC
 wbg
 wbg
 wbg
@@ -320743,7 +320801,7 @@ wbg
 wbg
 vAB
 bnQ
-ehZ
+fFL
 nWM
 wbg
 kjH
@@ -321127,7 +321185,7 @@ xMr
 xMr
 xMr
 xMr
-pcQ
+tCz
 wbg
 wbg
 wbg
@@ -321529,7 +321587,7 @@ dCV
 csA
 dCV
 hXf
-oGC
+cbQ
 wbg
 wbg
 wbg
@@ -321931,7 +321989,7 @@ dCV
 dCV
 dCV
 qee
-mtG
+wzZ
 wbg
 wbg
 wbg
@@ -322737,11 +322795,11 @@ xMr
 xMr
 gGZ
 qCy
-qGh
+iFY
 wVI
 weX
 wVI
-rDp
+lGI
 wbg
 ekQ
 qDx
@@ -323138,7 +323196,7 @@ bmi
 mgx
 xMr
 xAt
-oDc
+cfm
 wbg
 wVI
 wVI
@@ -323541,11 +323599,11 @@ oVp
 xMr
 qnO
 oZC
-uwa
+qYK
 wVI
 xbo
 wVI
-rDp
+lGI
 wbg
 hOh
 qDx
@@ -323943,11 +324001,11 @@ nTe
 qhC
 wbg
 wbg
-uwa
+qYK
 wVI
 wVI
 wVI
-rDp
+lGI
 wbg
 hOh
 qDx
@@ -324343,7 +324401,7 @@ oXn
 oXn
 oXn
 xMr
-eCt
+cyy
 wbg
 wbg
 wVI
@@ -324745,13 +324803,13 @@ paz
 bmi
 bmi
 xMr
-wss
+uMC
 wbg
-qGh
+iFY
 wVI
 weX
 wVI
-rDp
+lGI
 wbg
 lHf
 rfx
@@ -325147,7 +325205,7 @@ gVS
 gVS
 bmi
 xMr
-oGC
+cbQ
 wbg
 wbg
 wbg
@@ -325549,7 +325607,7 @@ poR
 pPs
 bmi
 qhR
-wss
+uMC
 wbg
 wbg
 wbg
@@ -325975,7 +326033,7 @@ bJG
 wbg
 jpZ
 aOv
-tJC
+gwz
 aOv
 aOv
 aOv
@@ -326353,7 +326411,7 @@ orY
 orY
 bmi
 xMr
-oGC
+cbQ
 wbg
 wbg
 wbg
@@ -326376,7 +326434,7 @@ ewt
 cEF
 wbg
 xll
-tRF
+sWG
 aOn
 jHc
 mwE
@@ -326755,7 +326813,7 @@ bmi
 mou
 bmi
 xMr
-oGC
+cbQ
 wbg
 wbg
 wbg
@@ -327157,7 +327215,7 @@ xMr
 xMr
 xMr
 xMr
-pcQ
+tCz
 wbg
 wbg
 wbg
@@ -328443,7 +328501,7 @@ kVc
 kVc
 hcW
 cWT
-veW
+bCb
 hcW
 hcW
 hcW
@@ -328844,8 +328902,8 @@ kVc
 kVc
 kVc
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -329246,8 +329304,8 @@ wxd
 kVc
 kVc
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -329648,8 +329706,8 @@ wxd
 kVc
 kVc
 kVc
-veW
-veW
+bCb
+bCb
 hcW
 hcW
 hcW
@@ -329962,9 +330020,9 @@ xKF
 xKF
 xKF
 xKF
-cFo
-vbp
-iFj
+mTs
+dTa
+aPR
 xKF
 xKF
 xKF
@@ -330050,8 +330108,8 @@ xqL
 kVc
 kVc
 kVc
-veW
-veW
+bCb
+bCb
 hcW
 hcW
 hcW
@@ -330358,10 +330416,10 @@ uaL
 xAt
 xAt
 xKF
-oiE
-oOv
-oOv
-xfj
+nce
+wDZ
+wDZ
+qir
 xKF
 xKF
 eBN
@@ -330369,7 +330427,7 @@ eBN
 eBN
 iug
 iug
-qnL
+pXo
 trI
 aem
 aem
@@ -330452,8 +330510,8 @@ wxd
 kVc
 kVc
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -330760,10 +330818,10 @@ paf
 xAt
 xAt
 xKF
-lqv
-oOv
-oOv
-xfj
+pOC
+wDZ
+wDZ
+qir
 xKF
 xKF
 ejY
@@ -330854,8 +330912,8 @@ sJZ
 wxd
 wxd
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -331162,10 +331220,10 @@ afX
 xAt
 xAt
 xKF
-pYB
-oOv
-oOv
-xfj
+ksK
+wDZ
+wDZ
+qir
 xKF
 xKF
 xKF
@@ -331256,8 +331314,8 @@ sJZ
 sJZ
 feP
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -331564,19 +331622,19 @@ paf
 xAt
 xAt
 xKF
-nIW
-oOv
-oOv
-ezG
+diV
+wDZ
+wDZ
+bor
 xKF
 ofq
 ofq
 xKF
-wou
+tEL
 ofq
 eBN
 aem
-uHj
+suN
 aem
 bok
 aem
@@ -331658,8 +331716,8 @@ sJZ
 sJZ
 wxd
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -331966,10 +332024,10 @@ paf
 xAt
 xAt
 xKF
-aZp
-oOv
-oOv
-kHO
+eip
+wDZ
+wDZ
+wtX
 xKF
 ofq
 ofq
@@ -331978,14 +332036,14 @@ ofq
 ofq
 eBN
 bok
-uHj
+suN
 aem
 nrx
 idG
 obL
 xKF
 vtw
-wOR
+vEN
 wOR
 vtw
 eEC
@@ -332060,8 +332118,8 @@ qet
 sJZ
 wxd
 kVc
-veW
-veW
+bCb
+bCb
 kVc
 hcW
 hcW
@@ -332368,10 +332426,10 @@ paf
 xAt
 xAt
 xKF
-qcq
-oOv
-iME
-nRE
+jyB
+wDZ
+kCZ
+xKZ
 xKF
 ofq
 ofq
@@ -332380,7 +332438,7 @@ ofq
 ofq
 eBN
 aem
-uHj
+suN
 aem
 iIl
 xKF
@@ -332462,8 +332520,8 @@ qet
 qet
 wxd
 kVc
-veW
-veW
+bCb
+bCb
 hcW
 hcW
 hcW
@@ -332770,10 +332828,10 @@ paf
 xAt
 xAt
 xKF
-oPc
-oPc
+tUp
+tUp
 xKF
-nWL
+bea
 xKF
 xKF
 xKF
@@ -332782,14 +332840,14 @@ xKF
 ofq
 eBN
 bok
-uHj
+suN
 aem
 tkZ
 xKF
 vtw
 vtw
 vtw
-wOR
+vEN
 gLx
 vtw
 rkf
@@ -332864,8 +332922,8 @@ qet
 qet
 wxd
 kVc
-veW
-veW
+bCb
+bCb
 hcW
 hcW
 hcW
@@ -333171,20 +333229,20 @@ uaL
 afX
 xAt
 xAt
-hbO
+gTQ
 fCM
 fCM
 cNo
 twX
 cNo
-iBj
+kvj
 eeO
 sKd
-jMf
+aac
 eBN
 eBN
 aem
-uHj
+suN
 aem
 vCr
 xKF
@@ -333573,13 +333631,13 @@ uaL
 paf
 xAt
 xAt
-hbO
+gTQ
 fCM
 fCM
 fCM
 fCM
-oSN
-jBE
+qwp
+wny
 dsW
 sKd
 xgL
@@ -333976,16 +334034,16 @@ uaL
 xAt
 xAt
 xKF
-jMQ
+oVn
 iuo
 iuo
 iuo
-oSN
+qwp
 wPC
 dsW
 sKd
 xgL
-oIv
+sSl
 aem
 aem
 aem
@@ -334378,15 +334436,15 @@ paf
 xAt
 xAt
 xKF
-tlQ
-tlQ
-tlQ
+bvV
+bvV
+bvV
 iuo
 fCM
 sKd
 sKd
 vSM
-qHY
+oIv
 aem
 aem
 wIl
@@ -334403,7 +334461,7 @@ vtw
 qZh
 ltk
 mwE
-eoz
+gZv
 mwE
 mwE
 aOv
@@ -334780,11 +334838,11 @@ paf
 xAt
 xAt
 xKF
-lsK
-bVa
-nEs
+xvC
+hCo
+fQQ
 iuo
-ubM
+aIK
 sKd
 sKd
 xKF
@@ -335190,7 +335248,7 @@ xKF
 xKF
 xKF
 xKF
-njj
+ojQ
 eCn
 eCn
 xKF
@@ -383827,31 +383885,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-fIB
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+iSJ
+iSJ
+iSJ
+iSJ
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
 erZ
 erZ
 erZ
@@ -383865,8 +383923,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -384229,31 +384287,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-fIB
-ebb
-hTo
-ijU
-quL
-tCz
-ebb
-quL
-quL
-ebb
-nDR
-fIB
-yel
-fIB
-tpg
-yel
-yel
-itC
-fIB
-fIB
-yel
-tfp
+iSJ
+iSJ
+iSJ
+iSJ
+wYv
+sLD
+cNM
+xaD
+cZi
+wYv
+xaD
+xaD
+wYv
+wqq
+iSJ
+caL
+iSJ
+lsA
+caL
+caL
+fXP
+iSJ
+iSJ
+caL
+bPz
 erZ
 erZ
 erZ
@@ -384267,8 +384325,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -384631,31 +384689,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-fIB
-ebb
-hTo
-wSg
-quL
-tCz
-ebb
-quL
-quL
-ebb
-reD
-tNC
-tNC
-reD
-ebb
-kwN
-gjq
-ebb
-sqX
-fIB
-aFE
-tfp
+iSJ
+iSJ
+iSJ
+iSJ
+wYv
+sLD
+xFX
+xaD
+cZi
+wYv
+xaD
+xaD
+wYv
+ifg
+jeM
+jeM
+ifg
+wYv
+ydx
+ylw
+wYv
+hzz
+iSJ
+tXu
+bPz
 erZ
 erZ
 erZ
@@ -384670,8 +384728,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385033,31 +385091,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-fIB
-ebb
-ebb
-ebb
-wra
-quL
-ebb
-quL
-quL
-ebb
-eXr
-sHB
-fIB
-xkF
-ebb
-wlk
-wlk
-ebb
-htf
-cOw
-vsg
-tfp
+iSJ
+iSJ
+iSJ
+iSJ
+wYv
+wYv
+wYv
+wvI
+xaD
+wYv
+xaD
+xaD
+wYv
+khc
+uxZ
+iSJ
+sDa
+wYv
+cTP
+cTP
+wYv
+faN
+jMf
+jIP
+bPz
 erZ
 erZ
 erZ
@@ -385072,8 +385130,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385435,31 +385493,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-fIB
-ebb
-ebb
-ebb
-wra
-tCz
-ebb
-quL
-quL
-ebb
-cRP
-fIB
-fIB
-gip
-ebb
-kpU
-kpU
-ebb
-ebb
-ebb
-ebb
-ebb
+iSJ
+iSJ
+iSJ
+iSJ
+wYv
+wYv
+wYv
+wvI
+cZi
+wYv
+xaD
+xaD
+wYv
+kbp
+iSJ
+iSJ
+uEX
+wYv
+sGf
+sGf
+wYv
+wYv
+wYv
+wYv
+wYv
 erZ
 erZ
 erZ
@@ -385474,8 +385532,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385837,31 +385895,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-fIB
-ebb
-ebb
-ebb
-luS
-quL
-ebb
-quL
-quL
-ebb
-cjJ
-fIB
-fIB
-gip
-ebb
-hjD
-fIB
-ebb
-ebb
-ebb
-ebb
-ebb
+iSJ
+iSJ
+iSJ
+iSJ
+wYv
+wYv
+wYv
+bbA
+xaD
+wYv
+xaD
+xaD
+wYv
+dFx
+iSJ
+iSJ
+uEX
+wYv
+tsF
+iSJ
+wYv
+wYv
+wYv
+wYv
+wYv
 erZ
 erZ
 erZ
@@ -385876,8 +385934,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385896,8 +385954,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 aUc
 vIa
 erZ
@@ -386239,31 +386297,31 @@ erZ
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-ebb
-ebb
-ebb
-ebb
-ebb
-hQm
-ebb
-ebb
-ebb
-ebb
-wbF
-sHB
-fIB
-ppy
-ebb
-tNC
-tNC
-itC
-fIB
-aFE
-yel
-tfp
+iSJ
+iSJ
+iSJ
+wYv
+wYv
+wYv
+wYv
+wYv
+qDq
+wYv
+wYv
+wYv
+wYv
+xot
+uxZ
+iSJ
+vRY
+wYv
+jeM
+jeM
+fXP
+iSJ
+tXu
+caL
+bPz
 erZ
 erZ
 erZ
@@ -386278,8 +386336,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386298,9 +386356,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386641,31 +386699,31 @@ vIa
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-ebb
-vVI
-quL
-xdJ
-quL
-quL
-aev
-ebb
-iUg
-fIB
-fIB
-fIB
-tNC
-reD
-ebb
-fIB
-fIB
-ebb
-fIB
-fIB
-fIB
-tfp
+iSJ
+iSJ
+iSJ
+wYv
+eeA
+xaD
+esT
+xaD
+xaD
+oXj
+wYv
+bVk
+iSJ
+iSJ
+iSJ
+jeM
+ifg
+wYv
+iSJ
+iSJ
+wYv
+iSJ
+iSJ
+iSJ
+bPz
 erZ
 erZ
 erZ
@@ -386680,8 +386738,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386699,10 +386757,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387043,31 +387101,31 @@ vIa
 erZ
 erZ
 erZ
-fIB
-fIB
-fIB
-ebb
-qoP
-quL
-quL
-quL
-tCz
-unY
-ebb
-iUg
-fIB
-jhu
-fIB
-hWj
-reD
-ebb
-hjD
-fIB
-ebb
-sah
-sqZ
-vsg
-tfp
+iSJ
+iSJ
+iSJ
+wYv
+aBn
+xaD
+xaD
+xaD
+cZi
+iME
+wYv
+bVk
+iSJ
+dkx
+iSJ
+jUl
+ifg
+wYv
+tsF
+iSJ
+wYv
+igr
+dOj
+jIP
+bPz
 erZ
 erZ
 erZ
@@ -387082,8 +387140,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387100,11 +387158,11 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387445,31 +387503,31 @@ vIa
 vIa
 erZ
 erZ
-fIB
-fIB
-fIB
-ebb
-igV
-quL
-quL
-tCz
-quL
-unY
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-afj
-afj
-ebb
-ebb
-ebb
-ebb
-ebb
+iSJ
+iSJ
+iSJ
+wYv
+oJk
+xaD
+xaD
+cZi
+xaD
+iME
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+oLA
+oLA
+wYv
+wYv
+wYv
+wYv
+wYv
 erZ
 erZ
 erZ
@@ -387485,7 +387543,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -387502,10 +387560,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387850,24 +387908,24 @@ erZ
 erZ
 erZ
 erZ
-ebb
-jnd
-quL
-quL
-quL
-quL
-aev
-ebb
-iqH
-clj
-bkT
-xdJ
-bkT
-clj
-rFS
-quL
-jhP
-xsD
+wYv
+erz
+xaD
+xaD
+xaD
+xaD
+oXj
+wYv
+bmF
+nuH
+cBG
+esT
+cBG
+nuH
+exy
+xaD
+vOD
+nHd
 erZ
 erZ
 erZ
@@ -387887,7 +387945,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -387903,9 +387961,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -388252,24 +388310,24 @@ erZ
 erZ
 erZ
 erZ
-ebb
-haC
-tCz
-quL
-pKC
-quL
-iVX
-ebb
-quL
-jCH
-jCH
-quL
-oRp
-oRp
-quL
-tCz
-quL
-xsD
+wYv
+lwO
+cZi
+xaD
+lpU
+xaD
+hjD
+wYv
+xaD
+kAi
+kAi
+xaD
+iWj
+iWj
+xaD
+cZi
+xaD
+nHd
 erZ
 erZ
 erZ
@@ -388289,7 +388347,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -388305,9 +388363,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -388654,24 +388712,24 @@ erZ
 erZ
 erZ
 erZ
-ebb
-xBv
-quL
-iqH
-jiL
-quL
-nuH
-iYE
-quL
-tCz
-quL
-tCz
-quL
-quL
-quL
-quL
-quL
-xsD
+wYv
+qGh
+xaD
+bmF
+dVV
+xaD
+bqt
+wTs
+xaD
+cZi
+xaD
+cZi
+xaD
+xaD
+xaD
+xaD
+xaD
+nHd
 erZ
 erZ
 erZ
@@ -388691,7 +388749,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -388707,9 +388765,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389056,24 +389114,24 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ubr
-quL
-iqH
-lzR
-quL
-iVX
-ebb
-quL
-pGU
-pGU
-quL
-quL
-lqG
-lqG
-quL
-tCz
-xsD
+wYv
+cjJ
+xaD
+bmF
+wNv
+xaD
+hjD
+wYv
+xaD
+tDN
+tDN
+xaD
+xaD
+pxP
+pxP
+xaD
+cZi
+nHd
 erZ
 erZ
 erZ
@@ -389093,7 +389151,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -389109,9 +389167,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389458,24 +389516,24 @@ erZ
 erZ
 erZ
 erZ
-ebb
-gWE
-quL
-quL
-quL
-quL
-rSz
-ebb
-iqH
-bkT
-bkT
-rFS
-jhP
-quL
-ijU
-abZ
-quL
-xsD
+wYv
+cDG
+xaD
+xaD
+xaD
+xaD
+cRP
+wYv
+bmF
+cBG
+cBG
+exy
+vOD
+xaD
+cNM
+qRp
+xaD
+nHd
 erZ
 erZ
 erZ
@@ -389495,8 +389553,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389510,10 +389568,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389860,24 +389918,24 @@ erZ
 erZ
 erZ
 erZ
-ebb
-wyA
-quL
-iqH
-jiL
-quL
-rSz
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-gNh
-gNh
-ebb
+wYv
+rDF
+xaD
+bmF
+dVV
+xaD
+cRP
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+rlu
+rlu
+wYv
 erZ
 erZ
 erZ
@@ -389897,8 +389955,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389912,10 +389970,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -390262,28 +390320,28 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ubr
-quL
-iqH
-lzR
-quL
-dPf
-ebb
-gvj
+wYv
+cjJ
 xaD
-vrF
-bxG
-vrF
+bmF
+wNv
 xaD
-bxG
-abZ
-quL
-ebb
-ebb
-ebb
-ebb
-ebb
+mAb
+wYv
+sqI
+hjs
+gvi
+gMb
+gvi
+hjs
+gMb
+qRp
+xaD
+wYv
+wYv
+wYv
+wYv
+wYv
 erZ
 erZ
 erZ
@@ -390300,7 +390358,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -390314,10 +390372,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -390663,29 +390721,29 @@ erZ
 erZ
 aUc
 erZ
-ebb
-ebb
-wra
-quL
-quL
-jNp
-quL
-dFp
-ebb
-quL
-quL
-quL
-quL
-quL
-quL
-quL
-xDp
-quL
-itC
-fIB
-fIB
-yel
-tfp
+wYv
+wYv
+wvI
+xaD
+xaD
+vmD
+xaD
+uvn
+wYv
+xaD
+xaD
+xaD
+xaD
+xaD
+xaD
+xaD
+eiE
+xaD
+fXP
+iSJ
+iSJ
+caL
+bPz
 erZ
 erZ
 erZ
@@ -390702,7 +390760,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -390716,10 +390774,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -391065,29 +391123,29 @@ vIa
 vIa
 aUc
 aUc
-ebb
-ebb
-wra
-tCz
-quL
-quL
-quL
-nuH
-ebb
-eml
-quL
-quL
-jpw
-quL
-xDp
-quL
-quL
-quL
-ebb
-gJj
-fIB
-fIB
-tfp
+wYv
+wYv
+wvI
+cZi
+xaD
+xaD
+xaD
+bqt
+wYv
+dAf
+xaD
+xaD
+qpX
+xaD
+eiE
+xaD
+xaD
+xaD
+wYv
+hoa
+iSJ
+iSJ
+bPz
 erZ
 erZ
 erZ
@@ -391104,7 +391162,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -391118,10 +391176,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -391467,29 +391525,29 @@ vIa
 vIa
 aUc
 aUc
-cLL
-cLL
-wra
-lnw
-nuH
-quL
-tCz
-quL
-aUN
-quL
-xDp
-quL
-quL
-quL
-quL
-quL
-quL
-quL
-ebb
-sqX
-fIB
-fIB
-tfp
+ebe
+ebe
+wvI
+wtJ
+bqt
+xaD
+cZi
+xaD
+tQK
+xaD
+eiE
+xaD
+xaD
+xaD
+xaD
+xaD
+xaD
+xaD
+wYv
+hzz
+iSJ
+iSJ
+bPz
 erZ
 erZ
 erZ
@@ -391506,7 +391564,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -391520,9 +391578,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -391870,28 +391928,28 @@ vIa
 vIa
 vIa
 aUc
-cLL
-cLL
-cLL
-nuH
-nuH
-quL
-quL
-bUq
-hes
-quL
-quL
-quL
-quL
-quL
-quL
-xDp
-quL
-ebb
-hjD
-fIB
-fIB
-tfp
+ebe
+ebe
+ebe
+bqt
+bqt
+xaD
+xaD
+sEa
+aLg
+xaD
+xaD
+xaD
+xaD
+xaD
+xaD
+eiE
+xaD
+wYv
+tsF
+iSJ
+iSJ
+bPz
 erZ
 erZ
 erZ
@@ -391908,7 +391966,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -391922,9 +391980,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392274,26 +392332,26 @@ vIa
 vIa
 aUc
 aUc
-cLL
-cLL
-nbA
-nuH
-nuH
-ebb
-ebb
-jfJ
-jfJ
-iWj
-jfJ
-abZ
-quL
-quL
-quL
-ebb
-meQ
-vsg
-jgn
-tfp
+ebe
+ebe
+uUG
+bqt
+bqt
+wYv
+wYv
+ahS
+ahS
+mGh
+ahS
+qRp
+xaD
+xaD
+xaD
+wYv
+gQF
+jIP
+qzb
+bPz
 erZ
 erZ
 erZ
@@ -392310,7 +392368,7 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -392324,9 +392382,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392677,25 +392735,25 @@ vIa
 vIa
 aUc
 aUc
-cLL
-cLL
-cLL
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-gLI
-gLI
-gLI
-gLI
-ebb
-ebb
-ebb
-ebb
-ebb
+ebe
+ebe
+ebe
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+adK
+adK
+adK
+adK
+wYv
+wYv
+wYv
+wYv
+wYv
 erZ
 erZ
 erZ
@@ -392712,8 +392770,8 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392726,9 +392784,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -393083,7 +393141,7 @@ aUc
 aUc
 aUc
 aUc
-mVz
+oJO
 erZ
 erZ
 erZ
@@ -393114,9 +393172,9 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -393127,10 +393185,10 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -393518,20 +393576,20 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -393924,15 +393982,15 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -394327,13 +394385,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-lGI
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+xwi
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -394729,13 +394787,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-nOE
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+xJe
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -395107,12 +395165,12 @@ xKz
 xKz
 xKz
 xKz
-iOL
-uNc
-iyt
-eAz
-yhr
-mMD
+ydj
+wXy
+hKF
+xQH
+drL
+jvU
 xKz
 erZ
 erZ
@@ -395131,13 +395189,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-lGI
-qeY
-lGI
-wSl
-qeY
-nJy
+sfZ
+xwi
+pdm
+xwi
+mrQ
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -395504,10 +395562,10 @@ erZ
 fVQ
 fVQ
 xKz
-dbK
-gjV
-gjV
-wpm
+lwy
+nYb
+nYb
+dyH
 xKz
 fVQ
 fVQ
@@ -395533,13 +395591,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-qeY
-qeY
-nOE
-lGI
-qeY
-nJy
+sfZ
+pdm
+pdm
+xJe
+xwi
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -395914,14 +395972,14 @@ xKz
 fVQ
 fVQ
 jeb
-xHe
+uvu
 fVQ
-uzT
+gqA
 xKz
 fVQ
 bvN
 tYP
-esE
+pcQ
 jeb
 erZ
 erZ
@@ -395935,13 +395993,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-qeY
-qeY
-lGI
-wSl
-qeY
-nJy
+sfZ
+pdm
+pdm
+xwi
+mrQ
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -396312,18 +396370,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-qzp
+xbW
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-qzp
+xbW
 fVQ
 bvN
 tYP
-bds
+icE
 jeb
 erZ
 erZ
@@ -396337,13 +396395,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-lGI
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+xwi
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -396708,24 +396766,24 @@ erZ
 erZ
 erZ
 xKz
-iOB
-jEB
+fGt
+clR
 fVQ
 fVQ
 lLa
-nru
+vQV
 jeb
-eza
-vha
-eaH
-faa
+rBD
+cGa
+dCO
+jgo
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-eYO
+fhk
 jeb
 erZ
 erZ
@@ -396739,13 +396797,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-nOE
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+xJe
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -397110,12 +397168,12 @@ erZ
 erZ
 erZ
 xKz
-pva
-jEB
+mco
+clR
 fVQ
 fVQ
 lLa
-nru
+vQV
 jeb
 xKz
 xKz
@@ -397127,7 +397185,7 @@ xKz
 fVQ
 tYP
 tYP
-fYr
+myM
 jeb
 erZ
 erZ
@@ -397141,13 +397199,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-lGI
-qeY
-lGI
-wSl
-qeY
-nJy
+sfZ
+xwi
+pdm
+xwi
+mrQ
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -397512,24 +397570,24 @@ erZ
 erZ
 erZ
 xKz
-hTc
-jEB
+lQH
+clR
 fVQ
 fVQ
 fVQ
 fVQ
-qzp
+xbW
 fVQ
-nnm
-vHd
-gMo
+fxa
+wyU
+uDi
 fVQ
-fap
+lff
 xKz
 fVQ
 bvN
 tYP
-esE
+pcQ
 jeb
 erZ
 erZ
@@ -397543,13 +397601,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-qeY
-qeY
-nOE
-lGI
-qeY
-nJy
+sfZ
+pdm
+pdm
+xJe
+xwi
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -397914,24 +397972,24 @@ erZ
 erZ
 erZ
 xKz
-rFg
-jEB
+ygs
+clR
 fVQ
-ikM
+qwV
 fVQ
 fVQ
 jeb
-oRP
+bxo
 fVQ
 fVQ
 fVQ
 fVQ
-xmQ
+kLV
 xKz
 fVQ
 bvN
 tYP
-bds
+icE
 jeb
 erZ
 erZ
@@ -397945,13 +398003,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-lGI
-qeY
-lGI
-wSl
-qeY
-nJy
+sfZ
+xwi
+pdm
+xwi
+mrQ
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -398320,20 +398378,20 @@ xKz
 xKz
 xKz
 xKz
-grg
+aWS
 xKz
 xKz
-rxu
+iBE
 fVQ
 jeb
-xHe
+uvu
 fVQ
-tub
+seC
 xKz
 fVQ
 tYP
 tYP
-eYO
+fhk
 jeb
 erZ
 erZ
@@ -398347,13 +398405,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-nOE
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+xJe
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -398725,7 +398783,7 @@ fVQ
 fVQ
 fVQ
 xKz
-rXP
+lGN
 fVQ
 fVQ
 fVQ
@@ -398735,7 +398793,7 @@ xKz
 fVQ
 tYP
 tYP
-fYr
+myM
 jeb
 erZ
 erZ
@@ -398749,13 +398807,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-lGI
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+xwi
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -399127,17 +399185,17 @@ vZP
 lLa
 fVQ
 xKz
-kRd
-vyN
-mbA
-hom
+kCe
+fWD
+vvk
+gGw
 fVQ
-udL
+ntT
 xKz
 fVQ
 lhd
 tYP
-esE
+pcQ
 jeb
 erZ
 erZ
@@ -399151,13 +399209,13 @@ erZ
 erZ
 erZ
 erZ
-nhR
-qeY
-qeY
-qeY
-qeY
-qeY
-nJy
+sfZ
+pdm
+pdm
+pdm
+pdm
+pdm
+uHk
 erZ
 erZ
 erZ
@@ -399527,7 +399585,7 @@ fVQ
 lLa
 noC
 lLa
-uzT
+gqA
 xKz
 xKz
 xKz
@@ -399553,10 +399611,10 @@ erZ
 erZ
 erZ
 erZ
-nhR
-qeY
+sfZ
+pdm
 xKz
-vzO
+goz
 bOK
 jeb
 xKz
@@ -399938,7 +399996,7 @@ fVQ
 fVQ
 xKz
 xKz
-grg
+aWS
 xKz
 xKz
 xKz
@@ -399955,8 +400013,8 @@ erZ
 erZ
 erZ
 erZ
-nhR
-qeY
+sfZ
+pdm
 jeb
 fVQ
 ugK
@@ -419211,7 +419269,7 @@ ygF
 ygF
 ygF
 ygF
-mGS
+gMG
 jYR
 lHe
 lHe
@@ -432071,8 +432129,8 @@ wAm
 wAm
 wAm
 wAm
-tyI
-tyI
+yiI
+yiI
 wAm
 wAm
 wAm
@@ -432470,22 +432528,22 @@ teW
 kwf
 nRx
 rwH
-fuG
+uSx
 teW
 kqc
-rff
+dFv
 jjS
-kWA
-vMQ
+ejk
+wte
 vsf
 rwH
 nKu
 jiv
 rwH
 teW
-dET
-mDR
-vMQ
+nJy
+nLx
+wte
 enq
 fZJ
 fZJ
@@ -432872,10 +432930,10 @@ teW
 dvD
 jiv
 jiv
-uSx
+gyr
 teW
-nSr
-lRC
+jti
+cLX
 jiv
 jiv
 jiv
@@ -432886,7 +432944,7 @@ jiv
 jjS
 teW
 hqI
-bUi
+xuF
 hqI
 enq
 fZJ
@@ -433276,8 +433334,8 @@ jiv
 jiv
 teW
 teW
-vMQ
-lRC
+wte
+cLX
 jiv
 jiv
 jiv
@@ -433288,11 +433346,11 @@ jiv
 vIX
 teW
 hqI
-bUi
+xuF
 hqI
-wvV
-rik
-grr
+oFk
+oFk
+ebb
 fZJ
 fZJ
 fZJ
@@ -433683,18 +433741,18 @@ jiv
 jiv
 jiv
 qfh
-npd
+kde
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-bUi
+xuF
 hqI
 jFM
 jFM
-oAj
+hbc
 fZJ
 fZJ
 fZJ
@@ -434084,19 +434142,19 @@ xSI
 jiv
 jiv
 jiv
-iys
-oqr
+aBq
+nSr
 htU
 teW
 ael
 hqI
 hqI
 hqI
-bUi
+xuF
 hqI
 jFM
 jFM
-inx
+iRN
 fZJ
 fZJ
 fZJ
@@ -434481,24 +434539,24 @@ mrE
 vAK
 xSI
 tML
+wAm
+wAm
+tIZ
+tIZ
+wAm
+wAE
 tML
+wAE
 tML
-uhv
-uhv
-tML
-aGb
-tML
-aGb
-teW
 pDA
 hqI
 hqI
 hqI
-bUi
+xuF
 hqI
 jFM
 jFM
-inx
+iRN
 fZJ
 fZJ
 fZJ
@@ -434883,24 +434941,24 @@ wAm
 wAm
 wAm
 wAm
+wAm
 tML
-teW
 nyc
 ntK
 gbA
 cAe
 cAe
-eEG
+jHh
 teW
 ulu
 hqI
 fVE
-bUi
+bAU
 lLK
 hqI
-bjq
-bjq
-kvj
+eBn
+eBn
+rBB
 fZJ
 fZJ
 fZJ
@@ -435290,15 +435348,15 @@ swm
 nyc
 ntK
 lYl
-xrf
-xrf
-xrf
+tak
+tak
+tak
 teW
 uNz
 hqI
 hqI
-bUi
-jju
+xuF
+bON
 ojc
 enq
 fZJ
@@ -435691,11 +435749,11 @@ pLs
 swm
 nyc
 ntK
-iRN
+tNi
 rSg
 rSg
 rSg
-teW
+tML
 ajj
 lLK
 lLK
@@ -436093,16 +436151,16 @@ vrG
 wtl
 ntK
 ntK
-yiI
-sGW
-sGW
-sGW
+nKG
+xrf
+xrf
+xrf
 ohA
 bcN
 bcN
 bcN
 vWe
-iZS
+vdg
 ffv
 fZJ
 fZJ
@@ -436493,7 +436551,7 @@ oBU
 sUQ
 xXs
 ntK
-qAh
+kuG
 ntK
 uTT
 swm
@@ -436894,10 +436952,10 @@ uKB
 aur
 uZa
 cPw
-jck
+pXF
 ntK
 ntK
-tak
+syA
 ybm
 ybm
 ybm
@@ -436906,7 +436964,7 @@ bcN
 bcN
 bcN
 vWe
-mvI
+auL
 ffv
 fZJ
 fZJ
@@ -437300,10 +437358,10 @@ swm
 nyc
 ntK
 gbA
-eEG
-eEG
-eEG
-teW
+jHh
+jHh
+jHh
+tML
 eYI
 vGN
 vGN
@@ -437702,13 +437760,13 @@ swm
 nyc
 ntK
 lYl
-xrf
-xrf
-xrf
-tML
-uIo
-uIo
-uIo
+tak
+tak
+tak
+teW
+rma
+rma
+rma
 tML
 tML
 tML
@@ -438097,20 +438155,20 @@ fZJ
 teW
 ePd
 wAm
-tML
 wAm
-tML
+wAm
+wAm
 aXE
 nyc
 ntK
-fAg
-xwi
-xwi
-eYu
-tML
-juM
-juM
-juM
+jGB
+ega
+ega
+olU
+teW
+dwO
+dwO
+dwO
 wAm
 wAm
 wAm
@@ -438127,7 +438185,7 @@ squ
 squ
 squ
 rTC
-rGY
+qKU
 squ
 squ
 squ
@@ -438503,9 +438561,9 @@ tML
 teW
 tML
 tML
-rfk
+xRu
 fnF
-tML
+wAm
 aGb
 tML
 aGb
@@ -438517,7 +438575,7 @@ wpe
 fQd
 eCn
 sNY
-cOK
+sat
 teW
 teW
 teW
@@ -438529,7 +438587,7 @@ squ
 squ
 squ
 rTC
-rGY
+qKU
 rTC
 rTC
 rTC
@@ -438923,7 +438981,7 @@ eCn
 teW
 aor
 xfh
-qDn
+uHj
 teW
 squ
 squ
@@ -439319,8 +439377,8 @@ cfY
 cfY
 teW
 aTF
-jCr
-ppc
+dOE
+lyW
 eCn
 mYi
 gbX
@@ -439701,12 +439759,12 @@ erZ
 erZ
 erZ
 fZJ
-fZJ
+eQa
 teW
 wAm
 wAm
 wAm
-teW
+tML
 btc
 bkD
 swm
@@ -439721,8 +439779,8 @@ uZy
 cfY
 alk
 eCn
-qpt
-ooA
+xGj
+mVz
 eCn
 mYi
 gbX
@@ -440103,16 +440161,16 @@ erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
-dzW
+mjP
+hIC
+mjE
 uKB
 uBv
 tML
 tML
 tML
 xnv
-dDU
+pMe
 tML
 rMM
 cfY
@@ -440127,9 +440185,9 @@ eCn
 eCn
 eCn
 teW
-kZl
-oOf
-smV
+sQl
+puH
+arp
 teW
 squ
 squ
@@ -440505,9 +440563,9 @@ erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
+mjP
 uKB
+oWT
 uKB
 uKB
 uKB
@@ -440907,12 +440965,12 @@ erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
+mjP
 uKB
+bIM
 uKB
-lLV
-xRn
+ktb
+umS
 uKB
 nIr
 swm
@@ -441306,12 +441364,12 @@ vIa
 vIa
 vIa
 vIa
-aUc
-teW
+lIW
 teW
 teW
 teW
 rou
+uKB
 uKB
 uKB
 uKB
@@ -441710,14 +441768,14 @@ vIa
 vIa
 aUc
 teW
-aPR
+fuG
 teW
+eMV
 uKB
-uKB
-qpp
-eeC
-uRy
-fNW
+hOC
+wwu
+nbI
+enQ
 tML
 swm
 swm
@@ -442112,15 +442170,15 @@ vIa
 vIa
 aUc
 teW
-ieI
+sYW
 teW
-dbH
-wDz
+pVO
+poP
 tML
 tML
 ydR
 tML
-cbQ
+tML
 swm
 swm
 tML
@@ -442131,10 +442189,10 @@ idu
 sct
 sNp
 cfY
-obq
-qtZ
-jhv
-uxZ
+xzp
+vcf
+nvH
+oOV
 eCn
 teW
 lMZ
@@ -442520,23 +442578,23 @@ uKB
 uKB
 cgD
 tML
+veY
 hqI
-tML
-kVv
+pjB
 swm
 swm
 tML
-tjf
+gqW
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-obq
-lXK
-kiE
-uvu
+xzp
+cZU
+rrd
+eBX
 eCn
 teW
 lMZ
@@ -442916,29 +442974,29 @@ vIa
 vIa
 aUc
 teW
+toC
 uKB
 uKB
 uKB
-uKB
-tdJ
+jBN
 tML
 gdJ
-tML
+hqI
 vaa
 swm
-swm
+lDq
 tML
 rMM
 eVa
-tUR
+jeX
 tcW
 tcW
 tcW
 eVa
-cPD
-dJl
-fMq
-gvi
+eLK
+eSt
+sXS
+duo
 eCn
 teW
 lMZ
@@ -443318,7 +443376,7 @@ vIa
 vIa
 aUc
 teW
-tjL
+rLE
 nMd
 uKB
 uKB
@@ -443327,11 +443385,11 @@ tML
 tML
 tML
 wAm
-dDU
+pMe
 wAm
 wAm
-teW
-teW
+wAm
+wAm
 wAm
 wAm
 wAm
@@ -443722,15 +443780,15 @@ aUc
 teW
 teW
 teW
-xRn
+bzl
 uKB
 uKB
-sFQ
+fnP
 iYx
-vcg
-tUp
-tUp
-teW
+iBo
+uzT
+uzT
+iYx
 iYx
 iYx
 iYx
@@ -444124,18 +444182,18 @@ aUc
 lMZ
 lMZ
 teW
-xRn
+umS
 uKB
 uKB
-udH
+oRp
 iYx
 vaa
-tUp
-uVk
-teW
-iSS
-iXP
-aIo
+uzT
+gFU
+iYx
+epI
+wDW
+vUf
 iYx
 lMZ
 lMZ
@@ -444526,18 +444584,18 @@ vIa
 lAs
 lMZ
 teW
-xRn
+meH
 uKB
 uKB
-jNc
+gEt
 iYx
-vdg
-tUp
-tUp
-teW
-woq
-tUp
-tUp
+oPp
+uzT
+uzT
+iYx
+lZE
+uzT
+uzT
 iYx
 lMZ
 lAs
@@ -444928,18 +444986,18 @@ vIa
 lAs
 lMZ
 teW
-bsy
+cQs
 uKB
 uKB
-qzY
+kat
 iYx
-xUK
-tUp
-tUp
-ifg
-tUp
-tUp
-uGf
+cVn
+uzT
+uzT
+abZ
+uzT
+uzT
+uzT
 iYx
 lMZ
 lAs
@@ -445335,13 +445393,13 @@ teW
 teW
 teW
 iYx
-fED
-tUp
-qRp
+kkP
+uzT
+gBe
 iYx
-gUA
-bxw
-mmw
+vlS
+tdJ
+sbF
 iYx
 lMZ
 lAs
@@ -445737,9 +445795,9 @@ iYx
 iYx
 iYx
 iYx
-vcg
-tUp
-phe
+iBo
+uzT
+xhT
 iYx
 iYx
 iYx
@@ -446130,22 +446188,22 @@ vIa
 vIa
 vIa
 vIa
-vIa
+mGn
 lAs
 lAs
 lAs
 lMZ
 iYx
-phe
-hWp
+xhT
+wse
 iYx
 iYx
-tUp
-qRp
+uzT
+gBe
 iYx
-iSS
-iXP
-aIo
+epI
+wDW
+vUf
 iYx
 lMZ
 lAs
@@ -446538,16 +446596,16 @@ lAs
 lAs
 lMZ
 iYx
-woq
-tUp
-rfk
-tUp
-tUp
-tUp
+lZE
+uzT
+abZ
+uzT
+uzT
+uzT
 iYx
-woq
-tUp
-tUp
+lZE
+uzT
+uzT
 iYx
 lMZ
 lAs
@@ -446940,16 +446998,16 @@ lAs
 lAs
 lMZ
 iYx
-tUp
-tUp
+uzT
+uzT
 iYx
-tUp
-tUp
-tUp
-ifg
-tUp
-tUp
-uGf
+uzT
+uzT
+uzT
+abZ
+uzT
+uzT
+uzT
 iYx
 lMZ
 lAs
@@ -447342,16 +447400,16 @@ lAs
 lAs
 lMZ
 iYx
-rMH
-mmw
+bFx
+sbF
 iYx
-tUp
-wDb
-rRA
+uzT
+dbt
+uuz
 iYx
-gUA
-bxw
-mmw
+vlS
+tdJ
+sbF
 iYx
 lMZ
 lAs
@@ -447743,18 +447801,18 @@ vIa
 vIa
 vIa
 aUc
-sAb
+pqg
 iYx
 iYx
 iYx
-pBE
+gIV
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-sAb
+pqg
 aUc
 vIa
 vIa
@@ -448148,7 +448206,7 @@ aUc
 aUc
 iYx
 iYx
-aXt
+jpw
 tWY
 tWY
 iyd
@@ -448549,8 +448607,8 @@ vIa
 vIa
 aUc
 iYx
-rwx
-vox
+jzT
+vWY
 tWY
 tWY
 iyd
@@ -448951,8 +449009,8 @@ vIa
 vIa
 aUc
 iYx
-dEe
-vox
+rxp
+vWY
 tWY
 tWY
 iyd
@@ -449353,8 +449411,8 @@ vIa
 vIa
 aUc
 iYx
-hbg
-tbb
+ryM
+aFh
 vGN
 vGN
 vGN
@@ -449757,9 +449815,9 @@ aUc
 iYx
 iYx
 iYx
-vGQ
-vGQ
-qDb
+etq
+etq
+fzf
 iYx
 lMZ
 lMZ
@@ -451755,16 +451813,16 @@ iyK
 iyK
 iyK
 iyK
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
 iyK
 iyK
 iyK
@@ -452156,17 +452214,17 @@ iyK
 iyK
 iyK
 iyK
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
 iyK
 iyK
 iyK
@@ -452559,16 +452617,16 @@ iyK
 iyK
 iyK
 iyK
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
 iyK
 iyK
 iyK
@@ -452961,16 +453019,16 @@ iyK
 iyK
 iyK
 iyK
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
-vjs
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
+itC
 iyK
 iyK
 iyK
@@ -486333,36 +486391,36 @@ vIa
 aUc
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-uPa
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+aSD
 erZ
 erZ
 erZ
@@ -486732,39 +486790,39 @@ vIa
 vIa
 vIa
 vIa
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fIB
-gnX
-ebb
-ebb
-ebb
-yel
-fIB
-fIB
-fIB
-yel
-itC
-fIB
-ebb
-clh
-guK
-eIW
-emT
-jIP
-emT
-bzl
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iSJ
+vQG
+wYv
+wYv
+wYv
+caL
+iSJ
+iSJ
+iSJ
+caL
+fXP
+iSJ
+wYv
+lZC
+aev
+hre
+vzi
+fLK
+vzi
+xkD
 erZ
 erZ
 erZ
@@ -487134,39 +487192,39 @@ vIa
 erZ
 erZ
 erZ
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fIB
-wmn
-ebb
-ebb
-ebb
-fIB
-fIB
-keJ
-reg
-reg
-ebb
-fIB
-ijs
-jIP
-uRv
-jIP
-uRv
-jIP
-jIP
-rcn
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iSJ
+oXt
+wYv
+wYv
+wYv
+iSJ
+iSJ
+dzV
+gbd
+gbd
+wYv
+iSJ
+tXU
+fLK
+jCr
+fLK
+jCr
+fLK
+fLK
+lHy
 erZ
 erZ
 erZ
@@ -487536,39 +487594,39 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fIB
-fIB
-gip
-ebb
-eXr
-oCD
-pjB
-qZg
-ebb
-ebb
-ebb
-itC
-ebb
-pik
-jIP
-jIP
-jIP
-jIP
-jIP
-lWV
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iSJ
+iSJ
+uEX
+wYv
+khc
+lFG
+tiH
+iqP
+wYv
+wYv
+wYv
+fXP
+wYv
+nxC
+fLK
+fLK
+fLK
+fLK
+fLK
+brz
 erZ
 erZ
 erZ
@@ -487938,39 +487996,39 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fIB
-fIB
-gip
-ebb
-wDZ
-fIB
-fIB
-dBW
-ebb
-hjD
-qRm
-fIB
-ebb
-xWA
-gFF
-uHM
-jIP
-jIP
-jIP
-bzl
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iSJ
+iSJ
+uEX
+wYv
+obq
+iSJ
+iSJ
+cMs
+wYv
+tsF
+eoz
+iSJ
+wYv
+fJb
+fbv
+vsl
+fLK
+fLK
+fLK
+xkD
 erZ
 erZ
 erZ
@@ -488340,39 +488398,39 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-itC
-ebb
-ebb
-ebb
-wDZ
-fIB
-fIB
-dBW
-ebb
-qRm
-fIB
-fIB
-uPa
-mJO
-xsV
-pMn
-vUf
-jIP
-uRv
-rcn
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+fXP
+wYv
+wYv
+wYv
+obq
+iSJ
+iSJ
+cMs
+wYv
+eoz
+iSJ
+iSJ
+aSD
+ivz
+uZC
+mmY
+kaH
+fLK
+jCr
+lHy
 erZ
 erZ
 erZ
@@ -488742,39 +488800,39 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-ebb
-ycz
-ycz
-gue
-ebb
-eXr
-sHB
-fIB
-xkF
-ebb
-fIB
-pjB
-qRm
-uPa
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+wYv
+eza
+eza
+qFI
+wYv
+khc
+uxZ
+iSJ
+sDa
+wYv
+iSJ
+tiH
+eoz
+aSD
 wQI
-oOY
+oQc
 wQI
-fJp
-jIP
-jIP
-lWV
+wNj
+fLK
+fLK
+brz
 erZ
 erZ
 erZ
@@ -489144,39 +489202,39 @@ erZ
 erZ
 erZ
 erZ
-mVz
+oJO
 fIL
 wQD
 aUc
 aUc
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-eXr
-sHB
-fIB
-qZg
-ebb
-wDZ
-pjB
-pjB
-dBW
-ebb
-fIB
-fIB
-fIB
-uPa
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+khc
+uxZ
+iSJ
+iqP
+wYv
+obq
+tiH
+tiH
+cMs
+wYv
+iSJ
+iSJ
+iSJ
+aSD
 wQI
 wQI
-iSf
-nKI
-jIP
-jIP
-bzl
+aZS
+dUb
+fLK
+fLK
+xkD
 erZ
 erZ
 erZ
@@ -489551,34 +489609,34 @@ eNY
 hby
 aUc
 aUc
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-wDZ
-fIB
-fIB
-dBW
-ebb
-wDZ
-fIB
-fIB
-dBW
-ebb
-fIB
-qRm
-fIB
-uPa
-npZ
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+obq
+iSJ
+iSJ
+cMs
+wYv
+obq
+iSJ
+iSJ
+cMs
+wYv
+iSJ
+eoz
+iSJ
+aSD
+art
 wQI
-npZ
-wqq
-jIP
-jIP
-rcn
+art
+nnS
+fLK
+fLK
+lHy
 erZ
 erZ
 erZ
@@ -489954,33 +490012,33 @@ twI
 aUc
 aUc
 aUc
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-cjJ
-fIB
-ycz
-gip
-ebb
-eXr
-sHB
-fIB
-xkF
-ebb
-hjD
-fIB
-pjB
-ebb
-ebb
-ebb
-ebb
-mQA
-mQA
-mQA
-nTR
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+dFx
+iSJ
+eza
+uEX
+wYv
+khc
+uxZ
+iSJ
+sDa
+wYv
+tsF
+iSJ
+tiH
+wYv
+wYv
+wYv
+wYv
+vlE
+vlE
+vlE
+fDB
 erZ
 erZ
 erZ
@@ -490355,30 +490413,30 @@ twI
 twI
 twI
 aUc
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-svA
-sHB
-fIB
-keJ
-ebb
-cjJ
-fIB
-fIB
-gip
-ebb
-fIB
-pjB
-fIB
-fIB
-fIB
-aHq
-dbt
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+oAX
+uxZ
+iSJ
+dzV
+wYv
+dFx
+iSJ
+iSJ
+uEX
+wYv
+iSJ
+tiH
+iSJ
+iSJ
+iSJ
+gxA
+sRG
 erZ
 erZ
 erZ
@@ -490756,31 +490814,31 @@ aUc
 aUc
 xGC
 oWI
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fEQ
-sHB
-fIB
-qZg
-ebb
-wDZ
-fIB
-fIB
-dBW
-ebb
-fIB
-fIB
-fIB
-fIB
-mWP
-jfl
-dbt
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+taD
+uxZ
+iSJ
+iqP
+wYv
+obq
+iSJ
+iSJ
+cMs
+wYv
+iSJ
+iSJ
+iSJ
+iSJ
+qNO
+pMn
+sRG
 erZ
 erZ
 erZ
@@ -491158,31 +491216,31 @@ vIa
 aUc
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-cjJ
-ycz
-fIB
-dBW
-ebb
-eXr
-sHB
-fIB
-xkF
-ebb
-fIB
-fIB
-pjB
-fIB
-aHq
-qwp
-wZQ
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+dFx
+eza
+iSJ
+cMs
+wYv
+khc
+uxZ
+iSJ
+sDa
+wYv
+iSJ
+iSJ
+tiH
+iSJ
+gxA
+qgi
+ccT
 erZ
 erZ
 erZ
@@ -491557,34 +491615,34 @@ erZ
 erZ
 erZ
 bQB
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-wDZ
-fIB
-fIB
-gip
-ebb
-gip
-pjB
-pjB
-dBW
-ebb
-hjD
-fIB
-fIB
-fIB
-aHq
-jfl
-dbt
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+obq
+iSJ
+iSJ
+uEX
+wYv
+uEX
+tiH
+tiH
+cMs
+wYv
+tsF
+iSJ
+iSJ
+iSJ
+gxA
+pMn
+sRG
 erZ
 erZ
 erZ
@@ -491959,34 +492017,34 @@ erZ
 erZ
 erZ
 bQB
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-eXr
-sHB
-fIB
-uZC
-uZC
-uZC
-fIB
-fIB
-uZC
-uZC
-pjB
-fIB
-fIB
-aZf
-ksK
-jfl
-dbt
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+khc
+uxZ
+iSJ
+nku
+nku
+nku
+iSJ
+iSJ
+nku
+nku
+tiH
+iSJ
+iSJ
+cld
+ovj
+pMn
+sRG
 erZ
 erZ
 erZ
@@ -492361,34 +492419,34 @@ erZ
 erZ
 erZ
 bQB
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-wDZ
-ycz
-fIB
-rRD
-ebb
-wbF
-sHB
-fIB
-ppy
-ebb
-hjD
-pjB
-fIB
-fIB
-fIB
-ksK
-dbt
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+obq
+eza
+iSJ
+xnV
+wYv
+xot
+uxZ
+iSJ
+vRY
+wYv
+tsF
+tiH
+iSJ
+iSJ
+iSJ
+ovj
+sRG
 erZ
 erZ
 erZ
@@ -492763,37 +492821,37 @@ erZ
 erZ
 erZ
 bQB
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-wDZ
-fIB
-ycz
-fIB
-itC
-fIB
-fIB
-fIB
-ebb
-ebb
-ebb
-ebb
-ebb
-oBL
-fIB
-fIB
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+obq
+iSJ
+eza
+iSJ
+fXP
+iSJ
+iSJ
+iSJ
+wYv
+wYv
+wYv
+wYv
+wYv
+rGY
+iSJ
+iSJ
 uLh
 uLh
-fbe
-mGn
+ggo
+ncI
 uLh
 erZ
 erZ
@@ -493165,39 +493223,39 @@ erZ
 erZ
 erZ
 bQB
-mVz
+oJO
 uXW
 oRe
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-cld
-sHB
-fIB
-feB
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-mVz
-mVz
-ebb
-fIB
-qRm
-qRm
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+mbG
+uxZ
+iSJ
+uFp
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+oJO
+oJO
+wYv
+iSJ
+eoz
+eoz
 uLh
-pQL
-yjP
-bHX
+kAg
+bUi
+jvT
 uLh
-mQr
+fcE
 erZ
 erZ
 erZ
@@ -493561,46 +493619,46 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 hqA
 pCW
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fIB
-fIB
-fIB
-tqx
-yjP
-yjP
-goD
-mGn
-yjP
-yjP
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+wYv
+wYv
+wYv
+wYv
+wYv
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iSJ
+iSJ
+iSJ
+gip
+bUi
+bUi
+oOI
+ncI
+bUi
+bUi
 erZ
 erZ
 erZ
@@ -493958,13 +494016,13 @@ erZ
 erZ
 erZ
 erZ
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 lgg
 lgg
 lgg
@@ -493976,33 +494034,33 @@ lgg
 lgg
 lgg
 lgg
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-ebb
-ebb
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-fIB
-fIB
-fIB
-tqx
-yjP
-yjP
-yjP
-tqx
-yjP
-yjP
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+wYv
+wYv
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iSJ
+iSJ
+iSJ
+gip
+bUi
+bUi
+bUi
+gip
+bUi
+bUi
 erZ
 erZ
 erZ
@@ -494356,13 +494414,13 @@ vIa
 vIa
 vIa
 vIa
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 lgg
 lgg
 lgg
@@ -494382,29 +494440,29 @@ lgg
 lgg
 vIa
 vIa
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-hjD
-qRm
-fIB
-tqx
-yjP
-yjP
-yjP
-mGn
-yjP
-yjP
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+tsF
+eoz
+iSJ
+gip
+bUi
+bUi
+bUi
+ncI
+bUi
+bUi
 erZ
 erZ
 erZ
@@ -494761,7 +494819,7 @@ vIa
 erZ
 erZ
 erZ
-mVz
+oJO
 lgg
 lgg
 lgg
@@ -494787,25 +494845,25 @@ vIa
 vIa
 vIa
 vIa
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-mVz
-ebb
-pBp
-sXc
-fIB
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+wYv
+iFi
+lnl
+iSJ
 uLh
-nvC
-yjP
-yjP
+jit
+bUi
+bUi
 uLh
-mQr
+fcE
 erZ
 erZ
 erZ
@@ -495191,22 +495249,22 @@ vIa
 vIa
 vIa
 aUc
-mVz
-ebb
-pdm
-pdm
-pdm
-pdm
-pdm
-pdm
-pdm
-auZ
-auZ
+oJO
+wYv
+wcc
+wcc
+wcc
+wcc
+wcc
+wcc
+wcc
+qYw
+qYw
 uLh
 uLh
-tle
-tle
-arY
+kzc
+kzc
+mJa
 erZ
 erZ
 erZ
@@ -495593,8 +495651,8 @@ vIa
 vIa
 vIa
 vIa
-mVz
-mVz
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -497215,14 +497273,14 @@ erZ
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -497612,19 +497670,19 @@ erZ
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -498014,24 +498072,24 @@ erZ
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -498416,24 +498474,24 @@ erZ
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -498816,26 +498874,26 @@ sri
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -499218,26 +499276,26 @@ sri
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -499620,26 +499678,26 @@ sri
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -500022,26 +500080,26 @@ erZ
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -500424,26 +500482,26 @@ erZ
 erZ
 erZ
 erZ
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -500826,7 +500884,7 @@ erZ
 erZ
 erZ
 erZ
-xpM
+kFh
 iJC
 bOK
 nEd
@@ -500834,18 +500892,18 @@ nEd
 nEd
 bOK
 iJC
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -501228,7 +501286,7 @@ erZ
 erZ
 erZ
 erZ
-xpM
+kFh
 bOK
 fVQ
 fVQ
@@ -501236,18 +501294,18 @@ bmG
 fVQ
 fVQ
 bOK
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -501630,7 +501688,7 @@ erZ
 erZ
 erZ
 erZ
-xpM
+kFh
 nEd
 fVQ
 lgN
@@ -501638,18 +501696,18 @@ jJC
 lgN
 fVQ
 nEd
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -502032,7 +502090,7 @@ erZ
 erZ
 erZ
 erZ
-xpM
+kFh
 nEd
 fVQ
 qxZ
@@ -502046,12 +502104,12 @@ vxC
 vxC
 vxC
 ppx
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -502434,7 +502492,7 @@ erZ
 erZ
 erZ
 erZ
-xpM
+kFh
 nEd
 fVQ
 fVQ
@@ -502448,12 +502506,12 @@ fZJ
 fZJ
 fZJ
 kZS
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+kFh
+kFh
+kFh
+kFh
+kFh
+kFh
 erZ
 erZ
 erZ
@@ -543026,11 +543084,11 @@ qzV
 nLH
 pil
 aqS
-htH
+quL
 fCM
 fCM
 fCM
-oPc
+tUp
 fCM
 nQU
 cGD
@@ -543819,8 +543877,8 @@ vIa
 vIa
 vIa
 vIa
-iSJ
-iSJ
+xET
+xET
 lAs
 woj
 qPA
@@ -544221,8 +544279,8 @@ vIa
 vIa
 vIa
 vIa
-iSJ
-iSJ
+xET
+xET
 lAs
 woj
 qPA
@@ -544623,8 +544681,8 @@ vIa
 vIa
 vIa
 vIa
-iSJ
-iSJ
+xET
+xET
 lAs
 woj
 qPA
@@ -545025,8 +545083,8 @@ vIa
 vIa
 vIa
 vIa
-iSJ
-iSJ
+xET
+xET
 lAs
 eJN
 bHY
@@ -545427,8 +545485,8 @@ vIa
 vIa
 vIa
 vIa
-iSJ
-iSJ
+xET
+xET
 lAs
 lAs
 lAs
@@ -545829,7 +545887,7 @@ vIa
 vIa
 vIa
 vIa
-iSJ
+xET
 vIa
 vIa
 vIa
@@ -546231,7 +546289,7 @@ vIa
 vIa
 vIa
 vIa
-iSJ
+xET
 vIa
 vIa
 vIa
@@ -546633,7 +546691,7 @@ vIa
 vIa
 vIa
 vIa
-iSJ
+xET
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,11 +7,8 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -498,21 +495,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -990,10 +975,7 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "adK" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
 "adL" = (
@@ -1146,19 +1128,23 @@
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4;
+	icon_state = "torchwall1"
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
-"aev" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"aev" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1260,13 +1246,6 @@
 /obj/item/clothing/neck/roguetown/chaincoif/iron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"ahX" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
@@ -1282,6 +1261,9 @@
 /area/rogue/indoors/town/church/chapel)
 "ajj" = (
 /obj/structure/statue/saints/father,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "ajo" = (
@@ -1318,14 +1300,15 @@
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"akm" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "akn" = (
 /obj/item/roguebin/crackers,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"aky" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "akM" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -1334,6 +1317,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"akZ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "alk" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -1342,12 +1332,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"als" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
+"alz" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "alL" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -1378,19 +1370,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"ams" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "amt" = (
 /obj/structure/table/church,
 /turf/open/floor/rogue/churchmarble,
@@ -1415,12 +1394,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "aok" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1454,6 +1431,10 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"apx" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "aqc" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks,
@@ -1501,10 +1482,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"asr" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "asE" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -1515,6 +1492,13 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"atl" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "atx" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/church,
@@ -1565,9 +1549,11 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1586,6 +1572,25 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"avi" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"avq" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "avQ" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -1593,6 +1598,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"avX" = (
+/obj/structure/gate/bars{
+	gid = "viking1";
+	redstone_id = "viking1"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "avY" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
@@ -1640,6 +1652,14 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"awV" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "axk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -1652,6 +1672,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/garrison)
+"axp" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "axq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -1677,10 +1703,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "ayt" = (
@@ -1744,6 +1767,12 @@
 /obj/item/clothing/cloak/stabard/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"aAh" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aAs" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
@@ -1789,6 +1818,10 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"aDb" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1857,13 +1890,6 @@
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"aFJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aFS" = (
 /obj/structure/chair/wood/rogue,
 /obj/item/rogueweapon/whip,
@@ -1921,6 +1947,9 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"aHC" = (
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "aHK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/tavern)
@@ -1942,13 +1971,6 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"aIp" = (
-/obj/structure/gate/bars{
-	gid = "viking1";
-	redstone_id = "viking1"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "aIx" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/closet/crate/roguecloset,
@@ -2009,12 +2031,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"aJC" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aJR" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -2022,14 +2038,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
-"aKc" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "aKd" = (
 /obj/structure/winch{
 	dir = 4;
@@ -2142,10 +2150,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"aNU" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+"aNR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aNW" = (
 /obj/structure/table/wood,
 /obj/item/chair/rogue,
@@ -2195,16 +2213,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"aPE" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aPF" = (
 /obj/structure/flora/roguetree/stump/burnt,
 /turf/open/floor/rogue/dirt/road{
@@ -2212,8 +2220,11 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2224,13 +2235,6 @@
 /mob/living/carbon/human/species/halforc/orc_raider/savage_orc/ambush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"aQx" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "aQA" = (
 /obj/structure/stairs{
 	dir = 1
@@ -2295,12 +2299,11 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/bench/church/smallbench{
@@ -2432,13 +2435,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"aXs" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "aXx" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/spacevine,
@@ -2478,14 +2474,6 @@
 "aYm" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"aYP" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "aZj" = (
 /obj/structure/table/vtable,
@@ -2625,12 +2613,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"bfD" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "bfK" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2676,6 +2658,10 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
+"bhw" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "bhy" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -2704,16 +2690,22 @@
 /obj/structure/fluff/walldeco/wantedposter/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"biC" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "biG" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"biQ" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "bjd" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -2722,6 +2714,15 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"bjp" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "bjx" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/ruinedwood{
@@ -2739,15 +2740,6 @@
 /obj/item/rogueweapon/tongs,
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
-"bjN" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/closed,
 /area/rogue/indoors/town)
 "bjO" = (
 /obj/structure/lever/wall{
@@ -2838,6 +2830,18 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"bmx" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "bmG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood{
@@ -2845,16 +2849,8 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"bmM" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2872,6 +2868,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"bnK" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bnO" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road{
@@ -2923,6 +2925,10 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
+"bop" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "bow" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -2963,6 +2969,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"bpp" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "bpx" = (
 /obj/structure/table/vtable/v2,
 /obj/item/reagent_containers/glass/mortar,
@@ -3035,10 +3045,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"bqL" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "bqP" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/bath)
@@ -3100,10 +3106,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"bsB" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "bsC" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/churchmarble,
@@ -3113,12 +3115,31 @@
 /obj/effect/landmark/start/mason,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"bsL" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "bsO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"bsV" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3136,13 +3157,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
 "bty" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "btA" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -3158,22 +3180,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"btY" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "buc" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/cobble/mossy,
@@ -3248,6 +3254,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
+"bvy" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "bvH" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -3298,15 +3308,6 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
 	},
-/area/rogue/outdoors/town)
-"bwO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "bwS" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -3362,13 +3363,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"byw" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "byB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -3402,13 +3396,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3473,20 +3463,18 @@
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"bBR" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bCb" = (
-/obj/structure/table/wood{
+/obj/effect/decal/cobbleedge{
 	dir = 1;
-	icon_state = "tablewood1"
+	icon_state = "borderfall"
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3585,12 +3573,6 @@
 "bFU" = (
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"bGe" = (
-/mob/living/simple_animal/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "bGg" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
@@ -3632,12 +3614,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3649,6 +3631,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"bIe" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bIh" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
@@ -3668,18 +3657,18 @@
 "bIu" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"bIE" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "bIJ" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"bIP" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/garrison)
 "bIZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -3741,16 +3730,21 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"bLu" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "bLD" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"bLL" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "bMh" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/dirt,
@@ -3832,25 +3826,24 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"bPk" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "bPv" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"bPz" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/water/cleanshallow,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"bPF" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+"bPz" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3879,6 +3872,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"bQz" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "bQA" = (
 /mob/living/simple_animal/pet/cat/black{
 	name = "Morticia"
@@ -3920,6 +3921,10 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"bRV" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "bSm" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -3968,20 +3973,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"bTg" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "bTy" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/vikingarea)
@@ -3997,12 +3988,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"bUc" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
 "bUf" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -4011,15 +3996,16 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
-"bVa" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
 	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bVa" = (
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4036,18 +4022,13 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"bVT" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
+"bWg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
-"bVV" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "bWj" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/church,
@@ -4119,6 +4100,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"bYy" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bYA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4161,10 +4149,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"bZw" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "bZB" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/grass,
@@ -4172,9 +4156,21 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
-"cag" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
+"bZW" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"car" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
@@ -4264,8 +4260,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4298,6 +4294,13 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ceX" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "cfw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4318,6 +4321,14 @@
 "cfY" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
+"cgc" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cgq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -4377,16 +4388,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"chw" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "chN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -4436,6 +4437,13 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"ciQ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ciX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -4451,13 +4459,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"cjf" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "cjm" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/beastmonger,
@@ -4471,19 +4472,19 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cjJ" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+"cjB" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"cjZ" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"cjJ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4507,12 +4508,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/garrison)
-"ckv" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "ckw" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -4541,10 +4536,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/roguewindow,
+/turf/closed,
 /area/rogue/outdoors/mountains)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -4737,6 +4730,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"csg" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "csi" = (
 /obj/structure/bars,
 /obj/structure/spider/stickyweb,
@@ -4757,16 +4763,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
-"csH" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
-"csJ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4844,8 +4840,7 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "cwh" = (
@@ -5030,9 +5025,8 @@
 /obj/structure/chair/bench/church{
 	dir = 1
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -5097,9 +5091,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/tribalfort)
@@ -5116,6 +5117,13 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"cCG" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cCQ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5135,8 +5143,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5164,6 +5173,17 @@
 "cDM" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/bog)
+"cDZ" = (
+/obj/structure/mineral_door/wood{
+	dir = 4;
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "cEk" = (
 /obj/structure/bookcase/random{
 	pixel_y = 20
@@ -5180,12 +5200,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"cEJ" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "cEK" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -5243,12 +5257,36 @@
 	icon_state = "glyph1"
 	},
 /area/rogue/indoors/town/vault)
+"cGA" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
+"cGC" = (
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "cGD" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"cGR" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "cGX" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -5260,14 +5298,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"cHt" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cHy" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/blocks,
@@ -5295,6 +5325,13 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"cHU" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cIa" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/shop)
@@ -5317,6 +5354,14 @@
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"cIz" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "cIC" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/herringbone,
@@ -5342,25 +5387,18 @@
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/dwarfin)
+"cJU" = (
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "cKj" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
 /area/rogue/indoors)
-"cKp" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "cKr" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/leather,
@@ -5388,14 +5426,6 @@
 	dir = 4
 	},
 /area/rogue/indoors)
-"cKL" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "cLm" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5416,11 +5446,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5437,16 +5467,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"cMj" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
 "cMs" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5470,10 +5497,6 @@
 "cNg" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
-"cNj" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
 "cNk" = (
 /obj/effect/landmark/start/nightmaiden{
@@ -5517,6 +5540,15 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"cOS" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -5546,11 +5578,6 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"cPx" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/hexstone,
@@ -5583,12 +5610,24 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"cQP" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "cQY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors)
+"cRc" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "cRl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -5598,6 +5637,15 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
+"cRE" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "cRM" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5607,12 +5655,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2"
+/obj/structure/chair/bench/church/r{
+	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5651,6 +5698,10 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"cSB" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cSF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/bed/rogue,
@@ -5676,6 +5727,11 @@
 "cTA" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
+"cTF" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cTG" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress,
@@ -5719,13 +5775,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cUS" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "cUW" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5802,19 +5851,9 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"cWM" = (
-/obj/structure/roguewindow/stained/silver,
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "cWT" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/rtfield)
-"cXg" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "cXk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -5832,17 +5871,6 @@
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"cXK" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "cXU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -5924,14 +5952,6 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"cZz" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -5972,15 +5992,21 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
-"dbH" = (
-/turf/open/floor/carpet/inn,
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"dbN" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+"dbH" = (
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -5994,6 +6020,22 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"dbZ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dcf" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -6164,6 +6206,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"dgU" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "dhg" = (
 /obj/structure/roguewindow/stained/yellow,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -6211,10 +6260,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"diq" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "diA" = (
 /mob/living/simple_animal/hostile/mushroom{
 	faction = list("undead")
@@ -6231,14 +6276,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"diR" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "diU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shovel,
@@ -6323,6 +6360,18 @@
 /obj/item/clothing/under/roguetown/chainlegs,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"dlw" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dlx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -6358,13 +6407,16 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"dmf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+"dmj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "dmw" = (
 /obj/structure/fluff/walldeco/painting/queen{
 	pixel_y = 32
@@ -6416,15 +6468,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter)
-"doi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "doK" = (
 /obj/structure/bars,
 /obj/machinery/light/rogue/torchholder{
@@ -6450,6 +6493,13 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"dpd" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dpi" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
@@ -6556,13 +6606,6 @@
 "dsB" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
-"dsP" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "dsW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -6584,6 +6627,10 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"duh" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "duu" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -6657,11 +6704,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6694,12 +6745,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"dyt" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dyD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/red,
@@ -6739,8 +6784,11 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6748,6 +6796,12 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"dAq" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "dAy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -6776,14 +6830,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"dCr" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+"dBX" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6830,26 +6880,12 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dEf" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH"
+"dEo" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"dEk" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "dEA" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet,
@@ -6863,10 +6899,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"dEW" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+"dEF" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -6896,11 +6936,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"dFV" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -6959,11 +6994,6 @@
 	max_integrity = 99999
 	},
 /area/rogue/indoors/town/shop)
-"dIP" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "dIU" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/item/grown/log/tree/small,
@@ -7003,10 +7033,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"dKU" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "dKV" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/herringbone,
@@ -7083,37 +7109,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"dNo" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dNu" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dNI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "dNL" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7136,6 +7141,15 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"dOw" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "dOx" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -7159,6 +7173,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"dOL" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "dPb" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7166,6 +7184,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"dPe" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "dPp" = (
 /obj/structure/table/wood,
 /obj/item/candle/yellow,
@@ -7243,6 +7265,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"dQw" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "dQJ" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
@@ -7293,6 +7322,11 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"dSK" = (
+/obj/structure/roguewindow/stained/silver,
+/obj/structure/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "dSL" = (
 /turf/open/water/river{
 	dir = 4;
@@ -7329,17 +7363,10 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
-"dSY" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "dTa" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7398,12 +7425,25 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dUF" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/magician)
+"dVb" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "dVf" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -7456,6 +7496,30 @@
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
+"dXn" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "dXw" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -7504,6 +7568,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"dZK" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "dZZ" = (
 /obj/structure/statue/saints/knight_l,
 /turf/open/floor/rogue/blocks,
@@ -7548,12 +7616,15 @@
 /area/rogue/indoors/town/manor)
 "ebb" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "ebe" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7648,13 +7719,6 @@
 /obj/item/ingot/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"edb" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "edc" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
@@ -7691,10 +7755,6 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
-"edP" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "edW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -7747,6 +7807,10 @@
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
 "eeR" = (
@@ -7815,6 +7879,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"egC" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "egU" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
@@ -7869,18 +7939,22 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"eiG" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eiQ" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/powder,
 /obj/item/roguekey/merchant,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"eiT" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eiV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
@@ -7915,6 +7989,10 @@
 /obj/effect/landmark/start/gravedigger,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"ejO" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ejV" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7923,6 +8001,14 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
+"ekv" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ekI" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/shop)
@@ -8073,15 +8159,22 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"eoB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "epp" = (
 /obj/structure/fluff/walldeco/innsign{
 	alpha = 200;
@@ -8093,6 +8186,10 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"epN" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "epQ" = (
 /obj/structure/mineral_door/wood{
 	desc = "I shouldn't go in here...";
@@ -8110,6 +8207,15 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"eqr" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "eqt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -8138,13 +8244,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"eqI" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "eqK" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
 	max_integrity = 99999
@@ -8169,16 +8268,34 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
+"erB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"erD" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "erN" = (
 /obj/structure/table/church{
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves)
-"erP" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "erX" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/structure/gravemarker,
@@ -8201,6 +8318,12 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
+"esu" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "esv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -8220,6 +8343,14 @@
 "esR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"esX" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "ete" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/rogue/firebowl/stump,
@@ -8245,18 +8376,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"etF" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "etS" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -8284,7 +8403,15 @@
 /area/rogue/indoors/shelter/rtfield)
 "euo" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/closed/wall/mineral/rogue/decowood,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "eur" = (
 /obj/structure/roguemachine/scomm,
@@ -8376,10 +8503,17 @@
 /obj/structure/pillory/town_square/reinforced,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"ewS" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+"ewU" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "exG" = (
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
@@ -8403,12 +8537,6 @@
 /obj/item/rogue/instrument/drum,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"exW" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
 "eyq" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = -32
@@ -8427,13 +8555,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"eyN" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
+"eyM" = (
+/obj/machinery/anvil{
+	pixel_x = -1
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "eyR" = (
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/concrete,
@@ -8443,9 +8570,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8460,6 +8589,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
+"eAi" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -8520,6 +8659,16 @@
 "eCn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"eCw" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "eCK" = (
 /obj/structure/flora/rogueshroom2,
 /turf/open/floor/rogue/grass,
@@ -8557,6 +8706,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
+"eDY" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eEy" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -8602,14 +8757,6 @@
 	},
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors)
-"eFt" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eFy" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
@@ -8745,12 +8892,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
-"eJE" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "eJI" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -8759,6 +8900,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/magician)
+"eJL" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "eJN" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
@@ -8791,6 +8940,18 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"eLb" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "eLe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8805,14 +8966,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"eLR" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "eMc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -8826,22 +8979,38 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"eMv" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "eMz" = (
 /obj/structure/flora/rock,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"eMF" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eMI" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"eMZ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "eNa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8972,8 +9141,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8997,19 +9170,6 @@
 "eTw" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"eTL" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "eTM" = (
 /obj/structure/stairs/fancy/c{
 	dir = 1
@@ -9172,6 +9332,9 @@
 	icon_state = "longsleep";
 	name = "mushroom ring - Eora's Sanctuary"
 	},
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "eZc" = (
@@ -9222,6 +9385,19 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"fab" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "faE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -9244,15 +9420,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fbB" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "fbO" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -9321,6 +9488,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
+"fdx" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fdF" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -9330,12 +9505,6 @@
 	dir = 4
 	},
 /area/rogue/indoors)
-"fdG" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "fdM" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
@@ -9406,16 +9575,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"fgh" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fgl" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -9500,14 +9659,6 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
-"fjB" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fjJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -9535,21 +9686,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"fkp" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"fkq" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/magician)
@@ -9611,14 +9747,16 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"fmp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+"fmx" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fmR" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomi{
@@ -9636,10 +9774,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"fnf" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "fnl" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 4
@@ -9676,10 +9810,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fnL" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "foh" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
@@ -9695,6 +9825,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
+"foR" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "foS" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomiv{
@@ -9715,15 +9852,14 @@
 /obj/structure/statue/saints/cephine2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fpz" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
+"fpm" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "fpQ" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/tribalguard,
@@ -9749,11 +9885,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"fqo" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
@@ -9782,10 +9913,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"fsD" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -9817,6 +9944,10 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
+"fth" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "ftw" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -9882,6 +10013,26 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fvB" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"fvH" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "fwp" = (
 /obj/structure/bars,
 /turf/closed/mineral/rogue,
@@ -9924,6 +10075,24 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"fxb" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "fxf" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/cooking/pan,
@@ -9936,11 +10105,9 @@
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"fxX" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
+"fxM" = (
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town)
 "fyb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10024,18 +10191,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fAd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+"fAj" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "fAs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -10097,13 +10256,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"fBK" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "fBL" = (
 /obj/structure/flora/shroomstump,
 /turf/open/floor/rogue/grass,
@@ -10167,31 +10319,8 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"fDF" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -10236,10 +10365,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"fEZ" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+"fFh" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -10315,12 +10447,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "fIs" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "fIw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
@@ -10338,10 +10469,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "fID" = (
 /obj/structure/stairs{
@@ -10354,11 +10486,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"fIG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "fIL" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10430,10 +10557,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
@@ -10461,6 +10590,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"fNp" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "fNw" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
@@ -10470,6 +10603,16 @@
 	dir = 4
 	},
 /area/rogue/indoors)
+"fOI" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "fON" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/indoors/shelter/mountains)
@@ -10551,9 +10694,12 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10599,6 +10745,10 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"fRA" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "fRC" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/landmark/start/prince,
@@ -10632,25 +10782,23 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"fSv" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "fSH" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
-"fSU" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"fSZ" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
 	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"fTd" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "fTe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road{
@@ -10663,13 +10811,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"fTD" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "fTE" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -10681,18 +10822,37 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"fTH" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
+"fTJ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fTL" = (
 /obj/structure/closet/crate/chest/reward,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"fTO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "fUc" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10746,6 +10906,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fVv" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fVE" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -10757,11 +10926,23 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10808,16 +10989,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"fXz" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "fXL" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -10842,6 +11013,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fYy" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "fYH" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/dirt/road{
@@ -10855,6 +11033,13 @@
 "fZe" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
+"fZo" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fZw" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobblerock,
@@ -10862,6 +11047,10 @@
 "fZJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"fZP" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gaq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -10904,12 +11093,15 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "gbN" = (
 /obj/structure/statue/saints/knight2,
 /turf/open/floor/rogue/blocks,
@@ -10920,6 +11112,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"gbR" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gbX" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
@@ -10951,6 +11153,13 @@
 "gdv" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/under/cavewet/bogcaves)
+"gdw" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "gdC" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors)
@@ -11045,6 +11254,23 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"ghb" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"ghT" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/ruinedwood{
@@ -11066,9 +11292,21 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/closet/crate/roguecloset,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
+"gir" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"giI" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -11101,6 +11339,11 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"gjr" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "gjB" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -11110,12 +11353,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"gjV" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "gke" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph3"
@@ -11133,12 +11370,6 @@
 /obj/item/rogueweapon/pick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"gkI" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "gkJ" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
@@ -11193,12 +11424,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"gmg" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "gmh" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/naturalstone,
@@ -11228,14 +11453,19 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"gnv" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
+"gnD" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "gnG" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"gnI" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "gnJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager,
@@ -11262,14 +11492,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "goK" = (
 /obj/effect/decal/cobbleedge{
@@ -11339,6 +11563,13 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"grD" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "grQ" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/ruinedwood{
@@ -11352,6 +11583,9 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gsa" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "gsT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -11433,10 +11667,15 @@
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
+"guU" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gvi" = (
-/obj/structure/bars,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/rtfield)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11470,12 +11709,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
-"gws" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11553,12 +11786,6 @@
 /obj/item/chair/stool/bar/rogue/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"gyH" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "gyP" = (
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/dirt/road{
@@ -11647,31 +11874,11 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"gBO" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
 "gBZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"gCr" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "gCA" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/church,
@@ -11706,6 +11913,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"gDF" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -11720,23 +11937,10 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
-"gEr" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "gEw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -11836,6 +12040,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"gHp" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "gHt" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -11905,6 +12116,13 @@
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"gKb" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gKi" = (
 /obj/structure/mineral_door/wood/donjon{
 	locked = 1;
@@ -11987,13 +12205,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"gMp" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "gMs" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -12002,10 +12213,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"gME" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gMO" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
@@ -12105,17 +12312,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"gQa" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "gQl" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/blocks/paving,
@@ -12124,15 +12320,6 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"gQF" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "gQM" = (
 /obj/structure/fluff/statue/small{
 	desc = "An expertly carved figure of an elven woman baring a warm yet flirtatious smile.";
@@ -12146,8 +12333,15 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
 "gQV" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "gRd" = (
 /mob/living/carbon/human/species/human/northern/searaider/brute,
@@ -12177,18 +12371,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"gRv" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "gRz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -12246,6 +12428,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"gSz" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "gSG" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -12346,17 +12534,6 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"gWc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -12396,10 +12573,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"gXN" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "gXW" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -12416,6 +12589,10 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"gYj" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gYC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -12423,14 +12600,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"gYG" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "gYI" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/c,
@@ -12467,6 +12636,16 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"hai" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "hal" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile{
@@ -12521,11 +12700,13 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12692,7 +12873,7 @@
 	max_integrity = 50000;
 	name = "RPW North"
 	},
-/obj/machinery/light/rogue/smelter/great,
+/obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -12700,10 +12881,6 @@
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"heJ" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -12827,9 +13004,21 @@
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/beach)
-"hhM" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
+"hhK" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "hhR" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -12856,17 +13045,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"hiY" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "hji" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -12890,36 +13068,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"hke" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "hkk" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -12955,15 +13110,6 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"hkW" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "hlo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -13112,6 +13258,16 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"hnX" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "hob" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -13121,13 +13277,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"hor" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "hox" = (
 /obj/structure/fluff/psycross,
 /obj/item/rogueweapon/woodstaff/aries,
@@ -13153,14 +13302,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"hpk" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "hpp" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/bogguardsman{
@@ -13193,6 +13334,18 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
+/area/rogue/indoors/town/dwarfin)
+"hpM" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "hpO" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
@@ -13239,10 +13392,6 @@
 "hqI" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"hqS" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "hqV" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13263,10 +13412,20 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"hrS" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+"hrj" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"hrD" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
@@ -13298,14 +13457,19 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"htv" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "htA" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
@@ -13395,21 +13559,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"hxv" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"hxA" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "hxN" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -13468,6 +13617,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hzR" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13496,6 +13655,16 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"hAr" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"hAA" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hAC" = (
 /obj/structure/bars,
 /turf/open/water/river{
@@ -13561,6 +13730,16 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"hDQ" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hDT" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/clothing/shoes/roguetown/nobleboot,
@@ -13582,13 +13761,6 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"hEw" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "hEG" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -13639,25 +13811,51 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"hFZ" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hGf" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves)
+"hGm" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "hGn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/closed,
 /area/rogue/indoors/town/dwarfin)
 "hGE" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"hGF" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"hGH" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "hGU" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -13673,6 +13871,22 @@
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
+"hHm" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"hHz" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hHF" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -13739,10 +13953,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"hJH" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "hJJ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -13764,6 +13974,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"hJY" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hKq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -13772,6 +13989,14 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hKx" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -13801,19 +14026,12 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"hLy" = (
-/obj/structure/fluff/railing/border{
+"hLC" = (
+/obj/structure/stairs{
 	dir = 1
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"hLz" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/area/rogue/indoors/town)
 "hLK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/rtfield)
@@ -13977,18 +14195,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"hQZ" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "hRc" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -14002,11 +14208,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"hRj" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "hRl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -14031,6 +14232,17 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"hRC" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hRK" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -14039,6 +14251,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"hRM" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "hSf" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile,
@@ -14082,7 +14298,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/machinery/light/rogue/lanternpost,
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
 	},
@@ -14115,6 +14330,14 @@
 /obj/structure/chair/bench/church,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"hVz" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hVJ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchbrick,
@@ -14143,6 +14366,9 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"hXa" = (
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "hXf" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
@@ -14199,6 +14425,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"hZa" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "hZe" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/under/roguetown/trou/leather,
@@ -14215,12 +14447,6 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"hZE" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "hZF" = (
 /obj/structure/mineral_door/wood{
 	dir = 4;
@@ -14279,16 +14505,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"ibL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "ibW" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -14369,25 +14585,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"idW" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "idX" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt/road{
@@ -14438,8 +14635,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "ifq" = (
@@ -14456,6 +14652,9 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"ifB" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "ifM" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -14464,13 +14663,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"ign" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
 "igq" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -14531,6 +14723,10 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iiR" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "ijS" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks,
@@ -14540,11 +14736,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3{
-	pixel_x = -34
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/bog)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -14573,12 +14774,23 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"ila" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ilm" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -14638,6 +14850,13 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"imB" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "imV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -14681,14 +14900,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
-"ipr" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
+"ipw" = (
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "ipQ" = (
 /obj/structure/bars/pipe{
 	dir = 9;
@@ -14700,6 +14919,15 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"iqu" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -14743,12 +14971,6 @@
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"irg" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "iri" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/ruinedwood{
@@ -14788,13 +15010,11 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "itR" = (
 /obj/effect/landmark/start/villager{
@@ -14803,9 +15023,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -14861,6 +15080,10 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ivv" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -14897,6 +15120,13 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iwj" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -15042,10 +15272,6 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"iAK" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "iAR" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -15075,12 +15301,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"iBX" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "iCj" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river{
@@ -15104,12 +15324,6 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"iDd" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "iDg" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/under/roguetown/trou,
@@ -15143,6 +15357,14 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iDQ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -15288,6 +15510,16 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"iIy" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "iIG" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -15311,6 +15543,9 @@
 "iJR" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/rtfield)
+"iKn" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "iKA" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -15418,12 +15653,9 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -15449,6 +15681,13 @@
 /obj/effect/landmark/start/vampthralllate,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"iNo" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "iNu" = (
 /obj/structure/bars/passage/shutter/open,
 /obj/structure/bars/pipe,
@@ -15493,10 +15732,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"iOm" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "iOq" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/rogue/cobble,
@@ -15505,12 +15740,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"iOL" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "iPg" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
@@ -15584,15 +15813,16 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"iQF" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
+"iQs" = (
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iRe" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
@@ -15604,8 +15834,13 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15639,12 +15874,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15687,6 +15921,15 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"iVn" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iVr" = (
 /obj/item/roguemachine/mastermail,
 /obj/structure/closet/crate/drawer{
@@ -15720,12 +15963,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -15760,13 +15999,6 @@
 /obj/item/natural/bundle/cloth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"iXl" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "iXn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
@@ -15777,16 +16009,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"iXM" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "iXT" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -15891,6 +16113,14 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"jaY" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "jbb" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -15959,10 +16189,6 @@
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jcZ" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "jde" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -16053,11 +16279,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"jfS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16091,17 +16312,24 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"jgy" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
-"jgV" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
+"jhx" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
@@ -16160,6 +16388,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"jkm" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "jkv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -16213,11 +16447,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
@@ -16239,10 +16476,6 @@
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
-"jmT" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "jmZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16291,6 +16524,16 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/church/chapel)
+"jph" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jpj" = (
 /obj/structure/rack/rogue,
 /obj/item/reagent_containers/glass/cup/silver,
@@ -16312,15 +16555,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16367,10 +16608,6 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"jrD" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "jrZ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -16384,12 +16621,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"jsF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
 "jsN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -16424,6 +16655,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"jtq" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "jtN" = (
 /obj/item/clothing/gloves/roguetown/plate/blk,
 /obj/item/rogueweapon/sword/rapier,
@@ -16447,14 +16685,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"juR" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -16530,6 +16760,15 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"jxX" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "jyb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/metal/barograte,
@@ -16553,6 +16792,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"jyw" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "jyD" = (
 /obj/machinery/light/rogue/oven/south,
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison{
@@ -16567,6 +16812,14 @@
 "jyI" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement)
+"jyO" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "jyT" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -16620,10 +16873,11 @@
 "jAY" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"jBr" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+"jBk" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jBv" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -16631,32 +16885,23 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jCc" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"jCi" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "jCq" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "jCs" = (
 /obj/structure/fluff/railing/border{
@@ -16747,23 +16992,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"jEc" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
-"jEf" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jEB" = (
+/obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/church/chapel)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -16801,12 +17033,6 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"jGj" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "jGw" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -16848,6 +17074,10 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/shop)
+"jHJ" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jHP" = (
 /obj/effect/landmark/start/vagabondlate,
 /turf/open/floor/rogue/cobblerock,
@@ -16874,18 +17104,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
-"jIR" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "jJf" = (
 /obj/structure/bars,
@@ -16935,6 +17154,10 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"jLL" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jLX" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -16952,13 +17175,10 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -17008,19 +17228,29 @@
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"jNB" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jNC" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17094,6 +17324,12 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"jPD" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "jPM" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -17156,17 +17392,6 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"jRF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "jRP" = (
 /obj/effect/landmark/events/testportal{
 	aportalloc = "woodsman"
@@ -17209,10 +17434,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"jTw" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "jTy" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/bars/pipe{
@@ -17225,6 +17446,12 @@
 "jTP" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"jUh" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "jUk" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -17243,13 +17470,6 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
-"jUP" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -17258,19 +17478,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"jVK" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
-"jVO" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17280,6 +17487,19 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"jWz" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "jWH" = (
 /obj/item/rogueweapon/tongs,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -17317,13 +17537,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"jXx" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "jXy" = (
 /obj/effect/landmark/start/seelie,
 /turf/open/floor/rogue/grass,
@@ -17348,14 +17561,6 @@
 "jYm" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
-"jYu" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "jYE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/tongs,
@@ -17364,6 +17569,15 @@
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"jYO" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "jYR" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -17391,15 +17605,6 @@
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"jZC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "jZJ" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -17412,10 +17617,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"jZM" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -17468,15 +17669,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
-"kbt" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "kbR" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
@@ -17518,6 +17710,20 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"kdz" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kdM" = (
 /obj/structure/mineral_door/wood{
 	dir = 1;
@@ -17545,6 +17751,15 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"keM" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "keO" = (
 /obj/structure/bars/pipe{
 	dir = 9
@@ -17567,13 +17782,6 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
-"kfm" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "kfr" = (
 /obj/structure/rack/rogue,
@@ -17610,6 +17818,10 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"kgb" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "kgj" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
@@ -17635,23 +17847,18 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"kgF" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "kha" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -17693,13 +17900,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"kiX" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "kjb" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -17759,6 +17959,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"klX" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "kms" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper,
@@ -17773,10 +17982,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"kmZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "kns" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/herringbone,
@@ -17801,17 +18006,22 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"kol" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "kov" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"kpg" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+"koJ" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "kpk" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -17851,6 +18061,18 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kqS" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "kqT" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -17866,20 +18088,6 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"kqV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "kra" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/rooftop{
@@ -17923,18 +18131,6 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"ksg" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17973,21 +18169,16 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"ksN" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "ksO" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -18029,6 +18220,27 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"ktG" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"ktR" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ktW" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/boss,
 /turf/open/floor/rogue/blocks,
@@ -18040,12 +18252,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"kuf" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "kup" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/ruinedwood{
@@ -18075,16 +18281,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kuV" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "kvB" = (
 /obj/structure/bookcase/random,
@@ -18125,20 +18337,17 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"kwE" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "kwN" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"kxw" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18185,17 +18394,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/garrison)
-"kys" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "kyX" = (
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobblerock,
@@ -18339,6 +18537,10 @@
 "kDc" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
+"kDh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "kDm" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/red,
@@ -18369,6 +18571,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"kDX" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "kEd" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -18377,10 +18589,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kEk" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "kEn" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
@@ -18411,9 +18619,9 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18460,6 +18668,14 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"kGT" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kGY" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -18495,6 +18711,11 @@
 /area/rogue/indoors/town/garrison)
 "kIf" = (
 /obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "kIu" = (
@@ -18522,21 +18743,6 @@
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kJb" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"kJf" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "kJj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -18567,6 +18773,15 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"kKo" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kKr" = (
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/churchbrick,
@@ -18586,6 +18801,20 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"kKJ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "kKS" = (
 /obj/structure/mineral_door/bars{
 	lockid = "dungeon"
@@ -18610,10 +18839,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"kLE" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -18647,6 +18872,12 @@
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"kMA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "kMG" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -18720,12 +18951,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kOA" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "kOB" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -18830,16 +19055,6 @@
 /obj/structure/chair/bench/couch/r,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"kSe" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "kSh" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -18863,16 +19078,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kSC" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "kSG" = (
 /obj/structure/bed/rogue/shit,
 /mob/living/carbon/human/species/halforc/orc_raider/savage_orc/ambush,
@@ -18910,21 +19115,18 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"kTM" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
 	},
 /area/rogue/indoors/town/garrison)
-"kUA" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "kUB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -18954,6 +19156,18 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
+"kVq" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "kVH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -19033,12 +19247,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement)
-"kYz" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "kYS" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
@@ -19121,15 +19329,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"lbj" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"lbf" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"lbx" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lbB" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/scomstone,
@@ -19175,11 +19385,6 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"ldQ" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "lec" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt,
@@ -19196,6 +19401,11 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"leM" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "leV" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -19209,6 +19419,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"lfn" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "lfz" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical{
 	dir = 4;
@@ -19259,22 +19473,6 @@
 "lgp" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/bog)
-"lgx" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"lgz" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "lgA" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road{
@@ -19305,20 +19503,29 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"lhi" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"lhj" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lhq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
@@ -19344,10 +19551,6 @@
 "lih" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/shop)
-"liq" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lis" = (
 /obj/structure/bed/rogue/shit,
 /obj/item/soap,
@@ -19366,6 +19569,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"liA" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "liE" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -19429,15 +19636,6 @@
 "lkM" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"llg" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lli" = (
 /obj/structure/rogue/trophy/deer,
 /obj/item/natural/rock,
@@ -19538,13 +19736,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -19559,10 +19755,6 @@
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"lpb" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lpe" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -19637,6 +19829,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lsi" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lsD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19645,6 +19846,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"lsW" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lsX" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
@@ -19671,6 +19879,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"ltL" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ltM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter/rtfield)
@@ -19778,15 +19994,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"lyQ" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lzc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
@@ -19910,6 +20117,14 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"lCN" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "lCO" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -20011,20 +20226,11 @@
 "lFV" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"lFX" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lGI" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
@@ -20075,6 +20281,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"lIu" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lIH" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile{
@@ -20093,13 +20303,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"lJh" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "lJp" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/railing/border{
@@ -20146,31 +20349,19 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lKl" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lKn" = (
 /obj/item/clothing/head/peaceflower,
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"lKy" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lKP" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lKR" = (
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -20193,19 +20384,16 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"lLq" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "lLE" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/town/basement)
 "lLK" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
@@ -20216,14 +20404,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"lME" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "lMF" = (
 /obj/structure/spider/stickyweb,
 /turf/open/water/sewer,
@@ -20243,23 +20423,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"lNA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
-"lNU" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lOl" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20270,20 +20433,22 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
+"lOp" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lOz" = (
 /obj/structure/mineral_door/bars{
 	lockid = "graveyard"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"lOG" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "lOH" = (
 /obj/item/rogue/instrument/harp,
 /obj/structure/flora/newleaf,
@@ -20314,12 +20479,13 @@
 "lPu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"lPv" = (
-/obj/structure/chair/wood{
-	dir = 8
+"lPG" = (
+/obj/structure/stairs{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "lPQ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20373,6 +20539,16 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"lSG" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
+"lSO" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "lTj" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp/deep,
@@ -20408,16 +20584,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
-"lUO" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lUQ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/church,
@@ -20448,10 +20614,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors)
-"lVX" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lVZ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/minotaur,
 /turf/open/floor/rogue/dirt/road{
@@ -20463,13 +20625,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"lWz" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
@@ -20509,12 +20664,8 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
 "lYl" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -20545,6 +20696,22 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"lYH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"lYS" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "lYU" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/herringbone,
@@ -20571,13 +20738,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"lZE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "mab" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
@@ -20590,6 +20750,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"mah" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "maw" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -20607,10 +20774,22 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"maZ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "mbm" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mbs" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -20659,6 +20838,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"mdt" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mdw" = (
 /obj/item/ingot/iron,
 /obj/item/ingot/iron,
@@ -20668,15 +20855,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20698,6 +20879,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"mdO" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "mdX" = (
 /obj/structure/stairs{
 	dir = 8
@@ -20758,6 +20948,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
+"mfi" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "mfl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -20771,6 +20965,19 @@
 /obj/item/natural/rock/iron,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/tribalfort)
+"mfo" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mfK" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician)
@@ -20809,14 +21016,18 @@
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"mhE" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "mhJ" = (
 /obj/item/chair/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"mhS" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mic" = (
 /obj/structure/mineral_door/wood/red{
 	lockid = "graveyard"
@@ -20832,6 +21043,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"mis" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "miD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -20864,11 +21083,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "mkb" = (
 /obj/structure/mineral_door/bars{
@@ -20925,17 +21143,16 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"mma" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
+"mlO" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "mmb" = (
 /obj/machinery/anvil,
 /turf/open/floor/rogue/blocks,
@@ -20949,6 +21166,17 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"mmm" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mmt" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -21056,10 +21284,20 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"mqI" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+"mqN" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "mrl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21070,13 +21308,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town)
-"mrw" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "mrE" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -21115,6 +21346,10 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"msL" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "msM" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -21123,6 +21358,16 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"msY" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21132,7 +21377,8 @@
 	name = "Temple of the One"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
+	dir = 1;
+	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
 "mtF" = (
@@ -21153,10 +21399,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"mup" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "mus" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -21192,13 +21434,29 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"mvx" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "mwd" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "mwq" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"mwy" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mwz" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -21235,14 +21493,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"mxm" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
-"mxn" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"mxs" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "mxx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mole,
 /turf/open/floor/rogue/dirt/road{
@@ -21325,16 +21580,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"mBJ" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "mCz" = (
 /obj/effect/landmark/start/guardsman{
 	dir = 1
@@ -21425,13 +21670,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"mFA" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
+"mFp" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mFC" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -21441,6 +21687,23 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"mFE" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"mFF" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "mFJ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -21504,38 +21767,32 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"mHT" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "mIn" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"mIR" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/area/rogue/outdoors/town)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"mJI" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "mJL" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/woodturned,
@@ -21663,7 +21920,6 @@
 /area/rogue/indoors/town/manor)
 "mOT" = (
 /obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
 "mOW" = (
@@ -21678,6 +21934,14 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mPb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mPf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -21719,16 +21983,19 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "mQA" = (
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
@@ -21765,6 +22032,10 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"mSy" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mSD" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
@@ -21793,13 +22064,6 @@
 	dir = 6
 	},
 /area/rogue/outdoors/bog)
-"mTP" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "mTT" = (
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/churchmarble,
@@ -21850,11 +22114,11 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/woodturned/nosmooth,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "mVN" = (
 /obj/item/flint,
@@ -21911,16 +22175,16 @@
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"mXh" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "mXi" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"mXk" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "mXn" = (
 /obj/structure/mineral_door/bars,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21955,20 +22219,30 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"mYD" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"mYI" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "mYJ" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"mYM" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mZo" = (
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
@@ -22053,6 +22327,16 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"nbK" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22093,18 +22377,6 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors/town/tavern)
-"ndA" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ndD" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora2";
@@ -22130,13 +22402,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"ndQ" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "ndT" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -22163,20 +22428,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"neE" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"neN" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "neP" = (
 /turf/open/water/river{
 	dir = 4;
@@ -22194,27 +22445,18 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"nfi" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+"nff" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"nfz" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"nga" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22238,9 +22480,8 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22280,15 +22521,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"nju" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "njv" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt/road,
@@ -22300,13 +22532,21 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"nkq" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+"njN" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"nke" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22381,11 +22621,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"nnh" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "nnk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
@@ -22430,17 +22665,6 @@
 	},
 /turf/closed,
 /area/rogue/indoors/town/manor)
-"npv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "npJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -22533,6 +22757,16 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
+"nsu" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nsE" = (
 /obj/structure/roguetent,
 /obj/effect/decal/cleanable/dirt,
@@ -22591,15 +22825,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -22619,6 +22847,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"nvP" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "nvS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -22634,6 +22868,10 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"nwj" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nwo" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/rogue/cobble,
@@ -22702,10 +22940,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"nxD" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "nxF" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -22762,6 +22996,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
+"nyu" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "nyz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -22828,8 +23069,17 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/basement)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -22859,26 +23109,27 @@
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"nCd" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"nCB" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
+"nCo" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"nCG" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nCN" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22990,6 +23241,16 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"nGY" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "nHb" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23035,12 +23296,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"nIw" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "nIy" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -23068,23 +23323,24 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"nIX" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "nJy" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"nJR" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "nJX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -23158,23 +23414,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"nMg" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "nMj" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/indoors)
-"nMl" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "nMz" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/twig,
@@ -23228,6 +23473,10 @@
 /obj/structure/fluff/littlebanners/bluewhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"nOR" = (
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "nOX" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23245,14 +23494,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23301,15 +23545,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"nQP" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "nQU" = (
 /obj/structure/chair/wood,
 /turf/open/floor/rogue/woodturned,
@@ -23340,12 +23575,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"nRw" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nRx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -23359,6 +23588,10 @@
 /obj/structure/statue/saints/magelady3_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"nRU" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "nRW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/feather,
@@ -23372,10 +23605,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nSr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
@@ -23385,6 +23618,14 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"nSF" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "nSS" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -23415,10 +23656,13 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23479,12 +23723,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"nVP" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "nVU" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -23492,18 +23730,33 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"nWe" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "nWj" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"nWm" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
+"nWq" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"nWr" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "nWB" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -23599,6 +23852,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"nYl" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "nYp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -23671,8 +23928,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "obq" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23687,6 +23947,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town/roofs)
+"obJ" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "obL" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -23739,14 +24006,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"odd" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "odi" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
@@ -23848,10 +24107,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -23865,13 +24128,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
-"ohr" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ohs" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -23933,9 +24189,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -23943,6 +24205,15 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"oiW" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ojc" = (
 /obj/structure/fluff/railing/wood,
 /obj/machinery/light/rogue/torchholder/r,
@@ -23961,6 +24232,12 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"ojS" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23993,6 +24270,13 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"oll" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "olD" = (
 /turf/open/floor/grass/snow{
 	icon_state = "ice"
@@ -24026,12 +24310,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
-"omi" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "oml" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 10
@@ -24048,11 +24326,11 @@
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
-"omQ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
+"omP" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "one" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -24068,6 +24346,13 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
+"onB" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "onM" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
@@ -24251,23 +24536,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"oul" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
-"oun" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "ous" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -24280,17 +24548,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"ovd" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "ovj" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -24330,18 +24591,6 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
-"owa" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24366,6 +24615,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"oxf" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "oxk" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -24441,6 +24696,20 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"oza" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "oze" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/grass,
@@ -24468,12 +24737,6 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"ozP" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "oAf" = (
 /obj/structure/bars/cemetery,
 /obj/effect/decal/cobbleedge,
@@ -24514,6 +24777,11 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"oAH" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "oAZ" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -24546,13 +24814,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"oBO" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
+"oBD" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -24560,6 +24829,13 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"oBZ" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oCf" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/shelter)
@@ -24583,6 +24859,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"oCS" = (
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oCW" = (
 /obj/structure/composter/full,
 /turf/open/floor/rogue/dirt/road,
@@ -24635,11 +24916,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"oEy" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/loom,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "oEL" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/tile{
@@ -24684,10 +24960,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"oFV" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "oGv" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/effect/landmark/start/tribalcook,
@@ -24760,13 +25032,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"oIG" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
+"oIC" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "oIY" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -24795,7 +25066,12 @@
 /area/rogue/outdoors/town)
 "oJO" = (
 /obj/effect/decal/cobbleedge{
-	dir = 8
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -24820,6 +25096,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"oKT" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "oLb" = (
 /obj/structure/stairs{
 	dir = 1
@@ -24840,20 +25121,10 @@
 	icon_state = "roofg"
 	},
 /area/rogue/indoors/town)
-"oLS" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "oMa" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -24943,6 +25214,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"oOS" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oOU" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -24951,11 +25226,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"oOW" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "oPi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
@@ -25023,13 +25293,11 @@
 /obj/structure/fermenting_barrel/random,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"oRi" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "oRp" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -25103,6 +25371,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"oTK" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oUc" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -25126,6 +25398,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"oUR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "oUS" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -25164,12 +25444,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"oVC" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "oVD" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/twig,
@@ -25185,6 +25459,12 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"oVO" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "oVT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -25258,13 +25538,6 @@
 /obj/item/clothing/neck/roguetown/psicross/necra,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"oXz" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "oXE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -25433,10 +25706,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"pcs" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "pct" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -25474,15 +25743,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -25496,8 +25759,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -25551,13 +25815,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"pfi" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "pfp" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -25586,6 +25843,17 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"pfG" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "pfN" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
@@ -25651,16 +25919,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"piN" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "piV" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
@@ -25690,10 +25948,9 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "pjB" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pjC" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -25716,6 +25973,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
+"pka" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pkj" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
@@ -25741,10 +26002,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"pkX" = (
-/obj/structure/closet/crate/chest/reward,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "plb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/fluff/railing/wood{
@@ -25755,38 +26012,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"pmd" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"pmt" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "pmF" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/mince,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"pmK" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "pnl" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/bog,
@@ -25832,6 +26067,21 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"pnL" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "pog" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
@@ -25900,16 +26150,6 @@
 /obj/structure/fluff/walldeco/rpainting/forest,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
-"pqp" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "pqr" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -26021,15 +26261,6 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors)
-"ptP" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "ptT" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -26061,6 +26292,13 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"puv" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -26111,6 +26349,11 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pwH" = (
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "pwQ" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/dirt,
@@ -26120,6 +26363,13 @@
 /obj/effect/landmark/start/tribalvillager,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"pwX" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "pxi" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/wood,
@@ -26172,6 +26422,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"pyz" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "pyB" = (
 /obj/item/shard,
 /turf/open/floor/rogue/cobble,
@@ -26239,6 +26497,14 @@
 "pAa" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
+"pAd" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "pAg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -26329,6 +26595,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"pDt" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "pDy" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -26386,6 +26658,14 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"pEp" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "pEC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -26393,11 +26673,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"pFt" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26408,10 +26683,6 @@
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"pGo" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "pGz" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26424,13 +26695,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
-"pGM" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "pHa" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -26470,10 +26734,6 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"pIn" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "pIq" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -26494,6 +26754,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"pIO" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "pJa" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -26530,10 +26797,16 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"pKN" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "pKQ" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -26565,10 +26838,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"pLq" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "pLs" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -26579,6 +26848,10 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"pLU" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "pMi" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
@@ -26592,14 +26865,11 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
+/obj/structure/stairs{
+	dir = 1
 	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -26617,6 +26887,15 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pML" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "pNd" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/rooftop{
@@ -26667,10 +26946,6 @@
 "pOf" = (
 /turf/open/water/river,
 /area/rogue/under/town/sewer)
-"pOq" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "pOs" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -26689,6 +26964,22 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"pOH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"pOL" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "pOO" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood,
@@ -26696,14 +26987,19 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"pOT" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1"
+"pOS" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"pPj" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "pPq" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "nobleguest"
@@ -26720,14 +27016,6 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"pPt" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "pPy" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road{
@@ -26813,6 +27101,14 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"pSO" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "pSS" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/machinery/light/rogue/firebowl{
@@ -26897,6 +27193,10 @@
 /obj/item/quiver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"pUH" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pVg" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -26916,6 +27216,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"pWl" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -26941,6 +27247,10 @@
 	muddy = true
 	},
 /area/rogue/under/cave)
+"pWL" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "pWP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -27000,12 +27310,33 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"pYt" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "pYO" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"pYW" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pZq" = (
 /obj/machinery/light/roguestreet/midlamp{
 	pixel_y = 10
@@ -27103,22 +27434,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"qcb" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"qcc" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "qcm" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -27176,6 +27491,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"qdC" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "qdG" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -27184,16 +27506,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"qdN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "qee" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -27213,12 +27525,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -27254,6 +27571,14 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"qfJ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qfL" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/grass,
@@ -27272,11 +27597,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "qgY" = (
-/obj/structure/stairs{
-	dir = 4
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/closed,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "qhg" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -27384,13 +27709,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qjY" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "qkl" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27465,14 +27783,27 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"qmo" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qmx" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qmA" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qne" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/naturalstone,
@@ -27545,12 +27876,9 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"qoR" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
+"qoJ" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
@@ -27584,6 +27912,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qpS" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qpT" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -27598,24 +27930,11 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"qpY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -27636,12 +27955,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"qqq" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "qqA" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -27693,18 +28006,18 @@
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
+"qrm" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qrn" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1;
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors)
-"qrv" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "qrA" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -27770,6 +28083,11 @@
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"qtL" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "qtT" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -27783,10 +28101,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qua" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "qub" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile{
@@ -27797,12 +28111,6 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"quv" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -27817,11 +28125,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -27864,13 +28170,6 @@
 "qvB" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/manor)
-"qvL" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "qvR" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
@@ -27885,21 +28184,22 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"qwC" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qwD" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/rogue/naturalstone,
@@ -27939,6 +28239,29 @@
 	icon_state = "endwooddark"
 	},
 /area/rogue/indoors/town/garrison)
+"qye" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"qyk" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"qyo" = (
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qyz" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road{
@@ -27968,13 +28291,9 @@
 	},
 /area/rogue/outdoors/bog)
 "qzy" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
@@ -27983,8 +28302,13 @@
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
 	},
+/obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qzN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -28011,12 +28335,7 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"qAB" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
+"qAq" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "qBk" = (
@@ -28059,22 +28378,26 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
+"qCY" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"qDq" = (
-/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "qDx" = (
@@ -28099,10 +28422,23 @@
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"qEM" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qEY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
+"qFo" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "qFu" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -28125,9 +28461,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"qGj" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -28164,6 +28508,15 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"qHy" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qHC" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks,
@@ -28199,10 +28552,6 @@
 /obj/item/soap,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"qJh" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qJp" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -28229,9 +28578,12 @@
 /obj/structure/mineral_door/wood,
 /turf/open/water/swamp,
 /area/rogue/indoors)
-"qKg" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
+"qKm" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qKo" = (
 /obj/structure/closet/crate/roguecloset,
@@ -28247,8 +28599,17 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"qKY" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28302,23 +28663,9 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"qMk" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"qNU" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -28361,6 +28708,11 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"qPE" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qPH" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
@@ -28385,6 +28737,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"qPO" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qQd" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -28394,13 +28753,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"qQD" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+"qQu" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "qQV" = (
 /obj/structure/fluff/railing/border{
@@ -28421,15 +28777,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "qRp" = (
-/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -28482,6 +28834,15 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"qTo" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town/roofs)
 "qTL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "archive"
@@ -28492,6 +28853,21 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"qUs" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"qUD" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qUE" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -28515,10 +28891,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"qVq" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "qVD" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -28597,12 +28969,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -28626,6 +28994,13 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"qZr" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "qZw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -28641,16 +29016,13 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"rac" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
+"raJ" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "raL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -28713,6 +29085,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"rck" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -28720,8 +29096,12 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -28832,8 +29212,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -28863,8 +29248,12 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -28894,6 +29283,13 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"rhG" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rhJ" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/tile{
@@ -28931,24 +29327,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
 "riW" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
-"rja" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rjg" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -28964,7 +29345,7 @@
 /area/rogue/under/town/basement)
 "rkf" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/water/cleanshallow,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "rkp" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -28999,12 +29380,6 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"rlo" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29079,20 +29454,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"rnn" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "rns" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/globe,
@@ -29164,6 +29525,22 @@
 "rqd" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"rqg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "rqh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -29173,14 +29550,16 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"rqj" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rqm" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"rqu" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "rqP" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29241,6 +29620,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rrX" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rsb" = (
 /obj/structure/glowshroom,
 /turf/open/water/sewer,
@@ -29286,6 +29673,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"rtw" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rtB" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -29323,6 +29717,11 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"rvA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29381,6 +29780,13 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"rwX" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rwY" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -29446,6 +29852,12 @@
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
+"rzh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rzq" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -29476,6 +29888,10 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"rAj" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "rAz" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
@@ -29519,6 +29935,19 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"rCp" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "rCL" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -29633,14 +30062,25 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"rGp" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
+"rGv" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"rGG" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "rGQ" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -29650,75 +30090,46 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"rHa" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
+"rHr" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"rHO" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "rHW" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"rIc" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "rIl" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 8
 	},
 /area/rogue/indoors/town)
-"rIp" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "rIP" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -29759,10 +30170,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
-"rJI" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "rJX" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road{
@@ -29790,16 +30197,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"rKD" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "rKQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -29854,15 +30251,9 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
-"rMX" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+"rMO" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "rNg" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -29914,6 +30305,11 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"rOz" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rOF" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/bog)
@@ -29923,12 +30319,14 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church/chapel)
-"rPa" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
+"rPu" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "rPE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -29946,11 +30344,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"rPO" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "rPR" = (
 /obj/structure/crabnest,
 /turf/open/water/sewer,
@@ -29985,12 +30378,6 @@
 "rQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
-"rQT" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "rRb" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/sewer)
@@ -30006,9 +30393,12 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30022,21 +30412,17 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
+/area/rogue/outdoors/mountains)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church/r{
+/obj/structure/chair/bench/church{
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -30053,6 +30439,17 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"rSH" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "rSK" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -30089,12 +30486,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
-"rTo" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "rTv" = (
 /obj/structure/fluff/traveltile/vampire{
@@ -30133,29 +30524,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"rTT" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"rTZ" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/obj/effect/decal/cobbleedge,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
@@ -30206,10 +30580,6 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"rWd" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rWj" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -30239,6 +30609,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"rXe" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "rXl" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -30314,14 +30690,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"rZg" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "rZk" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30375,6 +30743,12 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"saz" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "saS" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -30394,11 +30768,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30509,10 +30884,10 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "seR" = (
 /obj/structure/crabnest,
@@ -30537,6 +30912,21 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"sfZ" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"sge" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sgi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -30552,10 +30942,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"sgt" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "sgx" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -30647,26 +31033,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"siT" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"siV" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "sjc" = (
 /obj/structure/bars/tough,
 /turf/open/water/cleanshallow,
@@ -30710,15 +31076,19 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"skh" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "skn" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"skp" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
 "skx" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/grass/snow,
@@ -30734,12 +31104,34 @@
 	},
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"slh" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sls" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"slt" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"slz" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "slS" = (
 /obj/item/clothing/shoes/roguetown/boots/armoriron,
 /turf/open/floor/rogue/dirt/road{
@@ -30920,6 +31312,12 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"sqi" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sqm" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/grass,
@@ -30973,6 +31371,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"ssk" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ssz" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
@@ -30985,16 +31389,6 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"ssP" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "ssY" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -31005,10 +31399,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/outdoors/beach)
-"stj" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "stv" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31051,9 +31441,11 @@
 	},
 /area/rogue/outdoors/beach)
 "suN" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "suY" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -31093,6 +31485,12 @@
 "swm" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"swn" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "swu" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
@@ -31112,13 +31510,19 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"sxm" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "sxp" = (
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "sxR" = (
 /obj/structure/table/wood,
@@ -31167,16 +31571,19 @@
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"szi" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "szp" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"szF" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "szM" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
@@ -31188,6 +31595,12 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
+"szQ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "szV" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks,
@@ -31197,6 +31610,15 @@
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"sAp" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sAy" = (
 /obj/structure/bars/cemetery,
 /obj/structure/bars/cemetery,
@@ -31258,27 +31680,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town)
 "sDa" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -31301,6 +31707,13 @@
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"sEX" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "sFe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger/steel,
@@ -31420,13 +31833,6 @@
 "sIl" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"sIx" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "sIy" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
@@ -31435,9 +31841,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -31489,6 +31895,12 @@
 /obj/item/roguekey/walls,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"sKY" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sLb" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig,
@@ -31522,15 +31934,11 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"sNm" = (
-/obj/structure/fluff/walldeco/church/line{
+"sNn" = (
+/obj/machinery/light/rogue/torchholder/r{
 	dir = 4
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "sNp" = (
 /obj/structure/table/wood{
@@ -31583,12 +31991,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"sPK" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "sPP" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/naturalstone,
@@ -31607,36 +32009,21 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"sQo" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
-"sRe" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "sRD" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -31644,13 +32031,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sRO" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"sRT" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -31715,9 +32095,6 @@
 "sTr" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter)
-"sTG" = (
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/town)
 "sTW" = (
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt/road{
@@ -31775,10 +32152,6 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
-"sVh" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "sVB" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -31884,8 +32257,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -31893,6 +32266,10 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"tar" = (
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "tat" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -31906,12 +32283,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"taz" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "taK" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -32003,6 +32374,15 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"tdl" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "tdz" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -32037,10 +32417,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"tex" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "teE" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -32071,9 +32447,9 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -32096,18 +32472,15 @@
 "tgZ" = (
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"thr" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+"tha" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "thM" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -32136,6 +32509,15 @@
 	dir = 10
 	},
 /area/rogue/outdoors/town/roofs)
+"tiv" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "tiB" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -32144,10 +32526,8 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -32182,6 +32562,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"tjt" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "tjU" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/flail/sflail,
@@ -32249,10 +32639,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
-"tlG" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -32260,20 +32646,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5"
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
-"tlS" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32284,10 +32661,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"tmu" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "tmE" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -32368,13 +32741,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"tpY" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "tqq" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -32411,6 +32777,14 @@
 /obj/structure/roguemachine/money/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"trg" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "trv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "royal";
@@ -32669,6 +33043,13 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tzn" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "tzy" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -32810,9 +33191,8 @@
 	},
 /area/rogue/outdoors/beach)
 "tCz" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
@@ -32903,22 +33283,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"tFA" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
+"tFq" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "tFH" = (
 /obj/item/dice,
@@ -32936,6 +33305,10 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"tFU" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tGd" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -33016,13 +33389,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors)
-"tJl" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "tJp" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -33041,13 +33407,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -33066,6 +33427,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tKP" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tKW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -33090,6 +33457,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"tMh" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "tMk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -33119,11 +33490,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"tNe" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "tNj" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -33189,15 +33555,21 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"tOv" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
-"tOB" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+"tOG" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tOM" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -33227,14 +33599,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"tQT" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
 "tRf" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33255,6 +33619,12 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"tSr" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "tSx" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/dirt/road{
@@ -33274,16 +33644,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"tTv" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"tTl" = (
+/obj/structure/bookcase/random{
+	desc = s
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "tTF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -33317,23 +33683,31 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"tUB" = (
+/obj/structure/chair/bench/church/mid{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "tUO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -33351,12 +33725,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"tVo" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "tVp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -33415,32 +33783,18 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"tXh" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "tXC" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"tXF" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
-"tYB" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "tYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -33465,17 +33819,6 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"tZx" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "tZJ" = (
 /obj/structure/fluff/walldeco/bigpainting/lake,
 /turf/open/floor/carpet/royalblack,
@@ -33506,34 +33849,16 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "uaj" = (
-/obj/machinery/light/rogue/forge{
-	pixel_x = -1
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"uaQ" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uaX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -33547,13 +33872,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"ubr" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+"ubc" = (
+/obj/structure/stairs{
+	dir = 4
 	},
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "ubv" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -33588,6 +33912,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"udB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "udC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -33673,6 +34004,11 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"ugc" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ugm" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/woodturned,
@@ -33810,6 +34146,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ulg" = (
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"ulj" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ulu" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -33898,21 +34242,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
-"upu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "upx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -33920,17 +34249,14 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"upC" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+"upK" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
 	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"upI" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "upU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/asteroid/elite/broodmother,
 /turf/open/floor/rogue/blocks,
@@ -33979,9 +34305,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34058,6 +34384,12 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/garrison)
+"utA" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "utB" = (
 /obj/structure/table/wood,
@@ -34136,8 +34468,11 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "uvu" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34153,14 +34488,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
 "uwa" = (
-/turf/open/floor/rogue/churchbrick,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
+"uwd" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
-"uwf" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34187,13 +34520,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"uwX" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "uxf" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/structure/fluff/railing/border{
@@ -34204,6 +34530,11 @@
 "uxg" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
+"uxo" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uxL" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -34216,20 +34547,19 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -34248,6 +34578,12 @@
 /obj/item/roguekey/church,
 /obj/item/paper/confession,
 /obj/item/roguekey/priest,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "uyw" = (
@@ -34258,14 +34594,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"uyO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "uyU" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/transparent/openspace,
@@ -34286,12 +34614,20 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34410,12 +34746,7 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains)
 "uDv" = (
 /obj/structure/bookcase/random,
@@ -34451,20 +34782,21 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
 	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "uFE" = (
@@ -34476,15 +34808,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uFY" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "uGc" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -34496,10 +34819,6 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "uGo" = (
@@ -34511,6 +34830,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"uGq" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uGt" = (
 /obj/structure/mineral_door/bars{
 	lockid = "manor"
@@ -34521,14 +34848,6 @@
 /obj/structure/closet/crate/drawer/inn,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"uGE" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "uGI" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/tile,
@@ -34565,12 +34884,28 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
+/obj/effect/landmark/start/templar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
+"uHm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -34591,6 +34926,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"uJC" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
@@ -34662,6 +35004,13 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"uLQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uLS" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/church,
@@ -34720,12 +35069,6 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"uNH" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -34734,6 +35077,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/magician)
+"uOF" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "uOL" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
@@ -34761,10 +35110,6 @@
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
-"uPi" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -34776,6 +35121,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"uPA" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uPB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34800,6 +35152,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"uPY" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "uQp" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -34838,6 +35199,10 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"uRv" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -34852,12 +35217,16 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/rtfield)
 "uSx" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
+/area/rogue/indoors/town/church/chapel)
+"uSR" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "uSS" = (
 /obj/structure/bars,
@@ -34937,6 +35306,10 @@
 "uVq" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/church/chapel)
+"uVy" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uVz" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble,
@@ -34957,10 +35330,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"uVS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "uVU" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
@@ -35043,6 +35412,12 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"uYr" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uYx" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "garrison"
@@ -35082,12 +35457,7 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
@@ -35102,10 +35472,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"uZN" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "uZY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -35186,16 +35552,17 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
-"vdd" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
+"vde" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "vdg" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -35209,6 +35576,13 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town)
+"vdx" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "vdX" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -35223,13 +35597,6 @@
 "veg" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/mountains)
-"veu" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "vey" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/oat,
@@ -35270,6 +35637,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"veT" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "veV" = (
 /obj/structure/roguerock{
 	desc = "A rock protuding from the ground. This one bares the sign of Dendor."
@@ -35277,9 +35650,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35293,6 +35665,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"vfw" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "vfH" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -35312,24 +35691,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vgh" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
-"vgv" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "vgz" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -35343,6 +35704,7 @@
 	dir = 1;
 	icon_state = "border"
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "vgZ" = (
@@ -35409,14 +35771,12 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"vjb" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vjs" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "vjx" = (
@@ -35438,19 +35798,6 @@
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"vjL" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "vka" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/tavern)
@@ -35458,16 +35805,6 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vkk" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/rtfield)
 "vkI" = (
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35478,6 +35815,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"vkW" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "vkY" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -35546,22 +35892,9 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"vnw" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
-"vnG" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
 "vnK" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/grown/log/tree/stick,
@@ -35602,11 +35935,10 @@
 /area/rogue/outdoors/mountains)
 "vox" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -35686,13 +36018,21 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"vrS" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
+"vrP" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
+"vsb" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vse" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/iron/messer,
@@ -35711,9 +36051,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35828,6 +36172,36 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"vvk" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
+"vvB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "vvJ" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/dirt,
@@ -35881,6 +36255,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/indoors/town/church/chapel)
+"vxl" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "vxA" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood,
@@ -35905,12 +36284,6 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
-"vyS" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -35968,15 +36341,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"vzO" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "vzR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36037,13 +36401,18 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"vBy" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
+"vBo" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
 	},
-/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
+"vBG" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
@@ -36082,6 +36451,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vCy" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vCD" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1;
@@ -36098,6 +36475,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"vCY" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "vDa" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/woodturned,
@@ -36109,6 +36492,10 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"vDn" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "vDp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -36123,13 +36510,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"vDr" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "vDz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36150,10 +36530,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"vDQ" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "vDS" = (
 /obj/structure/bars/pipe,
 /obj/item/roguegem/random,
@@ -36183,6 +36559,10 @@
 /obj/structure/statue/saints/magelady2_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"vEP" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "vEQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -36214,17 +36594,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -36243,18 +36614,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "vGQ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "vGT" = (
@@ -36267,13 +36633,18 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"vHJ" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "vIa" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
@@ -36335,12 +36706,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -36376,24 +36744,15 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"vMj" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "vMQ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "vMT" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -36457,14 +36816,12 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/fluff/railing/wood{
+/obj/structure/fluff/railing/fence{
 	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	icon_state = "fence"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -36521,6 +36878,10 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"vRB" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "vRF" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
@@ -36589,6 +36950,16 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
+"vTj" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vTm" = (
 /obj/structure/fluff/statue/knight/r{
 	desc = "The statue seems out of place and in mid-charge as if it were a true warrior and frozen in place.";
@@ -36610,10 +36981,11 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -36641,6 +37013,12 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vVR" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "vWa" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -36667,6 +37045,13 @@
 /obj/structure/mineral_door/secret/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vWm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vWn" = (
 /obj/structure/plasticflaps,
 /turf/closed/mineral/rogue,
@@ -36689,13 +37074,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -36734,6 +37114,15 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"vYx" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vYF" = (
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36791,16 +37180,14 @@
 "wan" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
-"waB" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "waE" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"waG" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "waI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -36856,6 +37243,9 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"wcu" = (
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "wcx" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -36864,10 +37254,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"wdv" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "wdJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
@@ -36937,6 +37323,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"wfK" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wfY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper/scroll,
@@ -36944,10 +37334,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "wgn" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36993,17 +37387,6 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
-"wjl" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -37027,10 +37410,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
-"wke" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "wkg" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
@@ -37074,10 +37453,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"wmH" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "wmK" = (
 /obj/structure/stairs{
 	dir = 1
@@ -37126,16 +37501,25 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"wou" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"wos" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
 	},
-/area/rogue/indoors/town)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"wou" = (
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors/town/garrison)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37163,14 +37547,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -37198,14 +37577,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wqv" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "wqE" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "boat1";
@@ -37227,42 +37598,17 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"wqV" = (
+"wra" = (
 /obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4"
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
-"wra" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
-"wsg" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
@@ -37297,10 +37643,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"wtx" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "wty" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -37339,14 +37681,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"wvp" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "wvy" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -37389,6 +37723,25 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"wwz" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -37422,9 +37775,11 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -37460,14 +37815,6 @@
 /area/rogue/indoors)
 "wAm" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
-/area/rogue/indoors/town/church/chapel)
-"wAp" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "wAr" = (
 /obj/item/bait,
@@ -37595,19 +37942,20 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/chair/bench/church{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37648,19 +37996,12 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"wFn" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "wFp" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -37715,6 +38056,14 @@
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
+"wHL" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -37772,6 +38121,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wKf" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wKh" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -37824,6 +38183,13 @@
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
+"wLB" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "wLL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -37876,6 +38242,11 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"wMv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "wNb" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bog)
@@ -37901,20 +38272,6 @@
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
-"wOr" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
@@ -37972,6 +38329,11 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"wPz" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wPC" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -38058,14 +38420,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -38081,19 +38440,10 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"wSY" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wTs" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
-/area/rogue/indoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -38116,11 +38466,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town/garrison)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38129,15 +38479,19 @@
 /obj/structure/crabnest,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"wUA" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wUP" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/acolyte_alt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"wVi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wVs" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/churchrough,
@@ -38147,6 +38501,10 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
+"wVx" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
 "wVy" = (
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
@@ -38154,6 +38512,13 @@
 "wVI" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wVL" = (
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "wWC" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -38178,12 +38543,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"wXp" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "wXz" = (
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -38207,15 +38566,17 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wYa" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "wYk" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"wYp" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "wYt" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -38225,13 +38586,8 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38270,15 +38626,12 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/under/cave)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38319,18 +38672,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38339,6 +38686,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"xcg" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xck" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -38379,12 +38733,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38518,16 +38869,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"xhZ" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "xif" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -38623,15 +38964,15 @@
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -38643,6 +38984,12 @@
 "xkK" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"xkR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xkS" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -38673,12 +39020,13 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"xlY" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
+"xlI" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "xmn" = (
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/wood,
@@ -38712,11 +39060,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"xng" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
-	},
-/area/rogue/under/cave)
 "xnp" = (
 /obj/structure/stairs,
 /obj/structure/stairs{
@@ -38833,12 +39176,11 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
 	},
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -38892,10 +39234,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"xrs" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "xrH" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
@@ -38905,23 +39243,6 @@
 "xrI" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/shop)
-"xrO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"xrW" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "xse" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -38958,6 +39279,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"xto" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "xtq" = (
 /obj/structure/stairs{
 	dir = 8
@@ -38968,6 +39293,10 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
+"xtu" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "xtw" = (
 /obj/structure/stairs{
 	dir = 4
@@ -38991,16 +39320,6 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"xtW" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"xud" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "xuh" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -39082,8 +39401,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39188,14 +39511,11 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"xyU" = (
-/obj/structure/chair/wood/rogue/chair3{
+"xyM" = (
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "xzi" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -39223,11 +39543,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -39238,18 +39559,6 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town)
-"xAw" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
-"xAz" = (
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "xAL" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border{
@@ -39387,6 +39696,11 @@
 "xDn" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
+"xDC" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xDJ" = (
 /obj/structure/closet/crate/drawer{
 	pixel_y = 16
@@ -39423,24 +39737,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xEI" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
+"xEP" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
-"xEK" = (
-/obj/structure/fluff/wallclock/l,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
-"xET" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
+"xET" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -39481,15 +39787,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"xGq" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "xGz" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/dirt/road{
@@ -39520,7 +39817,6 @@
 	},
 /area/rogue/indoors/town/shop)
 "xGM" = (
-/obj/machinery/light/rogue/lanternpost,
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
 	},
@@ -39531,12 +39827,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xHe" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39574,14 +39870,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"xIg" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "xIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -39600,21 +39888,18 @@
 /obj/effect/landmark/start/guardsman,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"xIQ" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"xIT" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/rtfield)
 "xJe" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "xJr" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -39713,27 +39998,6 @@
 "xMr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
-"xMP" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"xMR" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "xMZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -39747,10 +40011,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town/roofs)
-"xNf" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "xNo" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -39769,10 +40029,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"xOd" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "xOt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -39855,13 +40111,6 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/garrison)
-"xQc" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "xQK" = (
 /obj/structure/bed/rogue/shit,
@@ -40014,6 +40263,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"xUO" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xUQ" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -40142,16 +40395,6 @@
 "xYz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"xYB" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xYM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -40164,16 +40407,6 @@
 /obj/item/natural/poo/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"xZg" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xZs" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -40257,11 +40490,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"ybB" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "ybH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/border{
@@ -40289,16 +40517,15 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/town)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -40323,10 +40550,6 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
-"yeq" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "yer" = (
 /obj/structure/bars/passage/shutter,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -40378,14 +40601,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"yff" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "yfj" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -40422,34 +40637,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"yfN" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
-"yfQ" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "yfY" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "ygF" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"ygS" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ygW" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
@@ -40474,12 +40667,6 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/rogue/indoors/town/church/chapel)
-"yhL" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "yhO" = (
 /obj/structure/spider/stickyweb,
@@ -40515,8 +40702,15 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -40543,12 +40737,24 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -40596,6 +40802,32 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"ykZ" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"ylg" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ylk" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -183390,18 +183622,18 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
 bpD
 bpD
 bpD
@@ -183792,18 +184024,18 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+lGI
+lGI
 bpD
 bpD
 bpD
@@ -184194,21 +184426,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+sYw
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+sYw
+lGI
+lGI
+lGI
+lGI
+lGI
 bpD
 bpD
 bpD
@@ -184596,21 +184828,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-pkX
-tUp
-tUp
-xlY
-pkX
-dbt
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+sYw
+pKQ
+adK
+bVa
+bVa
+aPR
+adK
+pKQ
+sYw
+sYw
+sYw
+sYw
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -184998,21 +185230,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-tUp
-tUp
-xlY
-tUp
-pLq
-dbt
-dbt
-dbt
-dbt
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+bVa
+bVa
+aPR
+bVa
+ebe
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -185400,21 +185632,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-lZE
+lGI
+sYw
+pKQ
+uLQ
+xHe
+bVa
+bVa
+bVa
+bVa
+bVa
 adK
-tUp
-tUp
-tUp
-tUp
-tUp
-uPi
-dbt
-dbt
-bpD
-bpD
+pKQ
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -185802,21 +186034,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-xng
-xng
-xrO
-pmd
-rRA
-tUp
-xlY
-uPi
-dbt
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+lGI
+lGI
+fvH
+aAh
+dBX
+bVa
+aPR
+adK
+pKQ
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -186204,21 +186436,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-nRw
-xng
-xng
-yff
-jrD
-tUp
-tUp
-tUp
-rIc
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+egC
+lGI
+lGI
+rrX
+hjD
+bVa
+lYS
+bVa
+wyA
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -186606,21 +186838,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-dbt
-wFn
-xng
-xng
-dNo
-jrD
-tUp
-tUp
-tUp
-rIc
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+lSO
+lGI
+lGI
+ekv
+hjD
+eMF
+bVa
+bVa
+wyA
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -187008,21 +187240,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-dbt
-xng
-xng
-nCG
-tUp
-rRA
-tUp
-xlY
-uPi
-dbt
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+lGI
+lGI
+gDF
+bVa
+dBX
+bVa
+aPR
+adK
+pKQ
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -187410,21 +187642,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-dbt
-eoz
-lJh
-tUp
-tUp
-tUp
-tUp
-tUp
-uPi
-dbt
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+ksK
+rtw
+bVa
+bVa
+bVa
+bVa
+bVa
+adK
+pKQ
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -187812,21 +188044,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-dbt
-tUp
-tUp
-tUp
-tUp
-pLq
-dbt
-dbt
-dbt
-dbt
-dbt
-bpD
-bpD
+lGI
+sYw
+pKQ
+bVa
+bVa
+bVa
+bVa
+ebe
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -188214,21 +188446,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-dbt
-pkX
-tUp
-xlY
-xlY
-pkX
-dbt
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+sYw
+pKQ
+adK
+bUi
+aPR
+aPR
+adK
+pKQ
+sYw
+sYw
+sYw
+sYw
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -188616,21 +188848,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-dbt
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+sYw
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+pKQ
+sYw
+lGI
+lGI
+lGI
+lGI
+lGI
 bpD
 bpD
 bpD
@@ -189018,17 +189250,17 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+lGI
 bpD
 bpD
 bpD
@@ -189420,17 +189652,17 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
+lGI
 bpD
 bpD
 bpD
@@ -202656,15 +202888,15 @@ vRu
 vRu
 vRu
 fjw
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
-nBf
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
+nhR
 vup
 iTw
 iTw
@@ -203058,7 +203290,7 @@ vRu
 vRu
 fjw
 fjw
-nBf
+nhR
 txa
 txa
 txa
@@ -206675,8 +206907,8 @@ sYw
 sYw
 sYw
 sYw
-nBf
-nBf
+nhR
+nhR
 txa
 cFQ
 cBf
@@ -227583,7 +227815,7 @@ acD
 acD
 fhw
 acD
-ibL
+dmj
 acD
 acD
 acD
@@ -227986,8 +228218,8 @@ acD
 acD
 acD
 vuH
-mIR
-xpM
+xaD
+ikM
 acD
 azH
 azH
@@ -228385,7 +228617,7 @@ vRu
 vRu
 acD
 qgC
-xpM
+ikM
 qgC
 vuH
 qgC
@@ -228786,12 +229018,12 @@ vRu
 vRu
 vRu
 acD
-xpM
+ikM
 qgC
-mIR
+xaD
 vuH
-mIR
-xpM
+xaD
+ikM
 acD
 qgC
 qgC
@@ -229189,11 +229421,11 @@ vRu
 vRu
 acD
 qgC
-xpM
+ikM
 qgC
 vuH
-mIR
-xpM
+xaD
+ikM
 acD
 qgC
 qgC
@@ -229590,12 +229822,12 @@ vRu
 vRu
 vRu
 acD
-xpM
+ikM
 qgC
 qgC
 vuH
-mIR
-xpM
+xaD
+ikM
 acD
 qgC
 qgC
@@ -229994,9 +230226,9 @@ vRu
 acD
 qgC
 qgC
-kFh
+lfn
 vuH
-mIR
+xaD
 qgC
 acD
 vRu
@@ -230397,7 +230629,7 @@ acD
 acD
 acD
 acD
-xGq
+klX
 acD
 acD
 acD
@@ -231198,12 +231430,12 @@ vRu
 vRu
 acD
 qgC
-xpM
-gWc
+ikM
+uHm
 vuH
 ffw
 qgC
-xpM
+ikM
 acD
 vRu
 vRu
@@ -231601,7 +231833,7 @@ vRu
 acD
 qgC
 qgC
-gWc
+uHm
 qgC
 vuH
 vuH
@@ -232002,9 +232234,9 @@ vRu
 vRu
 acD
 qgC
-xpM
+ikM
 qgC
-gWc
+uHm
 vuH
 vuH
 qgC
@@ -232806,9 +233038,9 @@ vRu
 vRu
 acD
 qgC
-gBO
+cQP
 qgC
-gBO
+cQP
 ffw
 vuH
 qgC
@@ -233209,11 +233441,11 @@ vRu
 acD
 qgC
 vRu
-gWc
+uHm
 vuH
 vuH
 vuH
-xpM
+ikM
 acD
 vRu
 vRu
@@ -233613,8 +233845,8 @@ acD
 acD
 acD
 acD
-rPO
-jVK
+vxl
+xdw
 acD
 acD
 vRu
@@ -280682,12 +280914,12 @@ hcW
 hcW
 hcW
 cWT
-rfO
-rfO
-rfO
-rfO
-rfO
-rfO
+tJC
+tJC
+tJC
+tJC
+tJC
+tJC
 uSw
 uSw
 uSw
@@ -280707,35 +280939,35 @@ uSw
 uSw
 uSw
 uSw
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 cWT
 hcW
 hcW
@@ -281083,12 +281315,12 @@ uaL
 uaL
 uaL
 uaL
-dAf
-eSt
-wdv
-mwq
-mwq
-neE
+uwa
+tiH
+bzl
+qRp
+qRp
+nsu
 nrw
 nrw
 nrw
@@ -281118,26 +281350,26 @@ ykt
 ykt
 ykt
 ykt
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
+uwa
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 cWT
 hcW
 hcW
@@ -281485,61 +281717,61 @@ wSn
 wSn
 uaL
 uaL
-dAf
-eSt
-aem
-mwq
-mwq
-mwq
-nrw
-nrw
-aPE
-oRp
-oRp
-pKQ
-pKQ
-nnh
-nrw
-kzQ
-obq
-obq
-obq
-kzQ
-kys
-ogC
-ogC
-nju
-gQa
-nrw
-mwq
-mwq
+uwa
+tiH
+tfp
 qRp
+qRp
+qRp
+nrw
+nrw
+nbK
+vsb
+veW
+oMa
+oMa
+cTF
+nrw
+bHX
+wYv
+wYv
+szQ
+kzQ
+mdO
+dbH
+dbH
+vMQ
+cGR
+nrw
+qRp
+qRp
+abZ
 uaL
-bGe
+uaL
 paf
 qvR
 qvR
-auL
+dTa
 uaL
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
-dAf
-kVc
-kVc
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 cWT
 hcW
 hcW
@@ -281887,62 +282119,62 @@ wSn
 wSn
 tzK
 uaL
-dAf
-eSt
-dIP
-mwq
-mwq
-qJh
-nrw
-nrw
-qDn
-oRp
-iOm
-pGo
-pGo
-pGo
-nrw
-jlO
-obq
-uzT
-obq
-jlO
-kys
-ogC
-ogC
-kSe
-pcQ
-nrw
-mwq
-mwq
+uwa
+tiH
+pwH
 qRp
+xto
+vLA
+nrw
+nrw
+wUA
+veW
+veW
+wfK
+wfK
+wfK
+nrw
+jlO
+wYv
+grD
+wYv
+jlO
+mdO
+dbH
+dbH
+jgy
+nGY
+nrw
+qRp
+qRp
+abZ
+pDt
 uaL
-bGe
 paf
 qvR
 qvR
-auL
+dTa
 uaL
 uaL
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 cWT
 cWT
 cWT
@@ -282289,65 +282521,65 @@ wSn
 uaL
 uaL
 uaL
-dAf
-eSt
-mqI
-mwq
-mwq
-qJh
+uwa
+tiH
+iiR
+qRp
+qRp
+vLA
 nrw
 nrw
-mFA
-oRp
-oRp
-oRp
-oRp
-oRp
-qMk
+cjB
+veW
+veW
+vsb
+veW
+veW
+iIy
 jlO
-obq
-rZg
-edP
+wYv
+hGH
+wYv
 jlO
 evo
-tJC
-ogC
-wSl
-ogC
+pAd
+dbH
+cGA
+dbH
 nrw
-mwq
-mwq
 qRp
-uaL
+qRp
+abZ
+ojS
 uaL
 paf
 qvR
 qvR
-auL
+dTa
 fxx
 aJj
 wSn
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 cWT
 hcW
 hcW
@@ -282691,66 +282923,66 @@ wSn
 uaL
 uaL
 uaL
-dAf
-eSt
-eSt
-uvu
-uvu
-dEW
-eSt
+uwa
+tiH
+tiH
+gvi
+gvi
+apx
+tiH
 nrw
-rTT
-sbF
-iOm
-oRp
-iOm
-oRp
-qMk
+bnK
+esu
+veW
+veW
+veW
+veW
+iIy
 jlO
-obq
-pMn
-obq
+wYv
+erD
+wYv
 jlO
 nrw
-gCr
-ogC
-ogC
-ogC
-dsP
-mwq
-mwq
+rqg
+dbH
+dbH
+dbH
+onB
 qRp
+qRp
+abZ
 uaL
 uaL
-iBX
+cLL
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 wSn
 wSn
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -283093,68 +283325,68 @@ wSn
 wSn
 uaL
 uaL
-dAf
-eSt
-mqI
-uvu
-uvu
-dEW
-eSt
+uwa
+tiH
+iiR
+gvi
+gvi
+apx
+tiH
 nrw
-pfi
-oRp
-oRp
-liq
-liq
-liq
+lbx
+vsb
+veW
+pka
+pka
+pka
 nrw
-jlO
-obq
-etF
-obq
-jlO
+eza
+wYv
+nBf
+wYv
+eza
 nrw
-wXp
-ogC
-oRi
-mwq
-dsP
-mwq
-mwq
+oVO
+dbH
 qRp
+qRp
+onB
+qRp
+qRp
+abZ
 ykt
 ykt
 ykt
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 wSn
 aJj
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 hcW
 hcW
 uaL
@@ -283456,7 +283688,7 @@ cWT
 hcW
 hcW
 hcW
-gRv
+kqS
 wSn
 wSn
 wSn
@@ -283495,69 +283727,69 @@ uaL
 uaL
 uaL
 uaL
-dAf
-eSt
-wdv
-uvu
-uvu
-uvu
-vkk
-oRp
-oRp
-iOm
-gME
-pGo
-pGo
-tNe
+uwa
+tiH
+bzl
+gvi
+wTs
+gvi
+hnX
+veW
+veW
+veW
+aDb
+wfK
+wfK
+omP
 nrw
-pOT
-obq
-obq
-obq
-nfi
+eqr
+wYv
+wYv
+wYv
+jlO
 nrw
-tJC
-ogC
-oRi
-mwq
-dsP
-qDq
-mwq
+pAd
+dbH
 qRp
+qRp
+onB
+wpm
+qRp
+abZ
 uaL
 uaL
-iBX
+cLL
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 wSn
 uaL
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 uaL
 uaL
 wSn
@@ -283897,68 +284129,68 @@ hcW
 hcW
 uaL
 uaL
-dAf
-eSt
-aem
-uvu
-uvu
-uvu
-eSt
+uwa
+tiH
+tfp
+gvi
+gvi
+gvi
+tiH
 nrw
-qMk
-nrw
-nrw
+iIy
 nrw
 nrw
 nrw
 nrw
 nrw
-nfi
-uVS
+nrw
+nrw
 jlO
+sIE
+eza
 jlO
 nrw
-ozP
-ogC
-mwq
-veu
-nrw
-jmT
-mwq
+dEo
+dbH
 qRp
-tVo
+obJ
+nrw
+aev
+qRp
+abZ
+uOF
 uaL
 paf
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
 wSn
 uaL
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 wSn
@@ -284299,67 +284531,67 @@ hcW
 hcW
 uaL
 uaL
-dAf
-eSt
-dIP
-fSv
-uvu
-uvu
-fdG
-mwq
-mwq
-xEK
-mwq
-mwq
-mwq
-mwq
-mwq
-nrw
-kUA
-nrw
-jlO
-jlO
-nrw
-ptP
-wou
-mwq
-dmf
-nrw
-qDq
-mwq
+uwa
+tiH
+pwH
+pOL
+gvi
+gvi
+jUh
 qRp
-rIp
+qRp
+jBk
+qRp
+kgb
+kgb
+qRp
+mwq
+nrw
+yiI
+nrw
+jlO
+jlO
+nrw
+vBo
+ceX
+qRp
+gHp
+nrw
+wpm
+qRp
+abZ
+xIT
 uaL
 paf
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
 uaL
 wSn
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 qvR
@@ -284701,65 +284933,65 @@ hcW
 hcW
 hcW
 uaL
-dAf
-eSt
-eSt
-eSt
-eSt
+uwa
+tiH
+tiH
+tiH
+tiH
 nrw
 nrw
-mwq
-mwq
-mwq
-mwq
-oRi
-mwq
-mwq
-mwq
-mwq
-mwq
-nrw
-kwN
-nrw
-nrw
-nrw
-nrw
-wTs
-nrw
-nrw
-mwq
 mwq
 qRp
+xto
+qRp
+xto
+qRp
+qRp
+qRp
+qRp
+qRp
+nrw
+eSt
+nrw
+nrw
+nrw
+nrw
+dgU
+nrw
+nrw
+qRp
+qRp
+abZ
 lsD
 lsD
-fbB
+vrP
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
 fxx
 wSn
-dAf
+uwa
 kVc
-dAf
-kVc
-kVc
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
@@ -285103,65 +285335,65 @@ hcW
 hcW
 uaL
 uaL
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
 evo
 nrw
 nrw
-qgY
-qgY
-eMZ
-mXk
-qeY
-qeY
-qeY
-nMl
-mwq
-nrw
-oRp
-oVC
-aJC
-ubr
-xtW
-qDq
-jmT
-qDq
-mwq
-mwq
+vUf
+vUf
+fQq
+qAq
+aem
+aem
+aem
+qAq
 qRp
+nrw
+veW
+eDY
+uvu
+nrw
+bhw
+wpm
+aev
+wpm
+qRp
+qRp
+abZ
 rhD
 rhD
 rhD
 rhD
 rhD
-auL
-fxx
+dTa
+rZt
 fxx
 fxx
 fxx
 uaL
-dAf
+uwa
 kVc
-dAf
-kVc
-kVc
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 uaL
@@ -285509,31 +285741,31 @@ uaL
 uaL
 qvR
 qvR
-dAf
+uwa
 evo
-gXN
-jmT
+vDn
+aev
 cbG
 cbG
-idW
-nMl
-lME
-fBK
-qAB
-nMl
-oRi
+yjP
+qAq
+tOv
+car
+esX
+nuH
+qRp
 nrw
-oRp
-bVV
-oRp
-kwN
-mwq
-mwq
-qDq
-mwq
-mwq
-mwq
-dwO
+veW
+guU
+veW
+uPA
+qRp
+qRp
+wpm
+qRp
+qRp
+qRp
+jhx
 fxx
 fxx
 fxx
@@ -285546,24 +285778,24 @@ fxx
 fxx
 aJj
 wSn
-dAf
-dAf
+uwa
+uwa
 kVc
 kVc
-dAf
+uwa
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 uaL
@@ -285911,34 +286143,34 @@ uaL
 uaL
 qvR
 qvR
-cdn
+fDB
 evo
-upI
-jmT
+vGN
+aev
 cbG
 cbG
-eMZ
-nMl
-lOG
-hxA
-kwE
-nMl
-mwq
+oUR
+qAq
+hKx
+qGh
+rRA
+qAq
+qRp
+sge
+veW
 vjs
-oRp
-iOm
-oRp
-kwN
-mwq
-mwq
-mwq
-mwq
-mwq
-mwq
-dwO
+veW
+eSt
+qRp
+qRp
+qRp
+qRp
+qRp
+qRp
+jhx
 fxx
 fxx
-cMs
+fTH
 fxx
 fxx
 fxx
@@ -285948,24 +286180,24 @@ fxx
 fxx
 uaL
 wSn
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 wSn
@@ -286313,31 +286545,31 @@ uaL
 uaL
 qvR
 qvR
-cdn
+fDB
 evo
-qNU
-jmT
+fxM
+aev
 cbG
 cbG
-eMZ
-nMl
-ksN
-jXx
-tJl
-nMl
-mwq
+fQq
+qAq
+jaY
+hJY
+wDZ
+qAq
+qRp
 nrw
-nVP
-aFJ
-oRp
-kwN
-mwq
-mwq
-mwq
-mwq
-mwq
-mwq
-dwO
+rqj
+rqj
+vjs
+eSt
+qRp
+qRp
+qRp
+qRp
+qRp
+qRp
+jhx
 fxx
 fxx
 fxx
@@ -286351,23 +286583,23 @@ fxx
 uaL
 uaL
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 uaL
@@ -286679,7 +286911,7 @@ uaL
 uaL
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -286715,61 +286947,61 @@ uaL
 uaL
 qvR
 qvR
-cdn
+fDB
 evo
 nrw
 nrw
-bUc
-bUc
-eMZ
-nMl
-fIs
-fIs
-fIs
-nMl
-oRi
-nrw
-iOL
-ohr
-oRp
-ubr
-mwq
-mwq
-qDq
-mwq
-mwq
-mwq
+iSJ
+iSJ
+fQq
+nuH
+cMs
+cMs
+cMs
+qAq
 qRp
+nrw
+hLC
+gKb
+veW
+uPA
+qRp
+qRp
+wpm
+qRp
+qRp
+qRp
+abZ
 rhD
 rhD
 rhD
 rhD
 rhD
-auL
-fxx
+dTa
+rZt
 fxx
 fxx
 fxx
 fxx
 aJj
 kVc
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 uaL
@@ -287117,37 +287349,37 @@ uaL
 uaL
 qvR
 qvR
-dAf
+uwa
 evo
 nrw
 mwq
-mwq
-mwq
-mwq
-oRi
-mwq
-mwq
-mwq
-mwq
-mwq
-nrw
-nrw
-nrw
-bty
-nrw
-xtW
-qDq
-jmT
-qDq
-mwq
-mwq
 qRp
-bHX
+qRp
+qRp
+qRp
+qRp
+qRp
+qRp
+xto
+qRp
+nrw
+nrw
+nrw
+gbR
+nrw
+bhw
+wpm
+aev
+wpm
+qRp
+qRp
+abZ
+fYy
 qvR
 qvR
 qvR
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -287155,23 +287387,23 @@ fxx
 fxx
 uaL
 aJj
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
-dAf
+uwa
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
-dAf
+uwa
 kVc
 qvR
 qvR
@@ -287519,37 +287751,37 @@ uaL
 uaL
 uaL
 qvR
-dAf
+uwa
 evo
 nrw
-cRP
-mwq
-xAz
-mwq
-mwq
-mwq
-mwq
-mwq
-nrw
-nrw
-nrw
-nrw
-uxV
-oRp
-nrw
-nrw
-fxX
-nrw
-nrw
-qDq
-mwq
+awV
+qDn
+qwp
 qRp
+qDn
+qDn
+qRp
+mwq
+nrw
+nrw
+nrw
+nrw
+lIu
+veW
+nrw
+nrw
+nWm
+nrw
+nrw
+wpm
+qRp
+abZ
 uaL
 uaL
 uaL
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -287557,23 +287789,23 @@ fxx
 fxx
 wSn
 aJj
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 uaL
 wSn
@@ -287890,7 +288122,7 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -287919,9 +288151,9 @@ uaL
 uaL
 uaL
 hcW
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
 evo
 nrw
 nrw
@@ -287933,25 +288165,25 @@ nrw
 nrw
 nrw
 nrw
-khc
-khc
+vvk
+vvk
 nrw
-uxV
-oRp
-uxV
-cag
-qmA
-pKQ
+lIu
+veW
+lIu
+rck
+jLL
+oMa
 nrw
-jmT
-mwq
+aev
 qRp
+abZ
 uaL
 uaL
 uaL
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -287960,20 +288192,20 @@ fxx
 wSn
 aJj
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dbN
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+bvy
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
@@ -288323,37 +288555,37 @@ hcW
 hcW
 hcW
 cWT
-rfO
-rfO
-rfO
-rfO
-uxV
-uxV
-uxV
-khc
-khc
-uxV
-uxV
-uxV
-oRp
-wVi
+tJC
+tJC
+tJC
+tJC
+lIu
+lIu
+lIu
+vvk
+vvk
+lIu
+lIu
+lIu
+veW
+qzN
 nrw
-wSY
-oRp
-iOm
-oRp
-bVV
-oRp
-oIG
-qDq
-mwq
+xkR
+veW
+vjs
+veW
+guU
+veW
+qyk
+wpm
 qRp
+abZ
 qvR
 qvR
 qvR
 qvR
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -288362,20 +288594,20 @@ fxx
 wSn
 wSn
 kVc
-dAf
+uwa
 kVc
-dAf
+uwa
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 kVc
@@ -288722,40 +288954,40 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 cWT
-rfO
+tJC
 iJR
-cMj
-rRD
-oRp
-fIG
-wVi
-wVi
-fIG
-fIG
-wVi
-fIG
-fIG
-oRp
-upI
-qmA
-oRp
-oRp
-oRp
-iOm
-oRp
-ubr
-mwq
-mwq
+qKY
+dwO
+veW
+rvA
+qzN
+lLK
+rvA
+rvA
+qzN
+rvA
+rzh
+veW
+vGN
+jLL
+veW
+veW
+veW
+vjs
+veW
+uPA
 qRp
+qRp
+abZ
 uaL
 uaL
 uaL
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -288770,15 +289002,15 @@ kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 lyL
@@ -289088,25 +289320,22 @@ uaL
 uaL
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
-pdm
-hcW
-hcW
-hcW
-hcW
-pdm
+vFz
 hcW
 hcW
 hcW
+hcW
+vFz
 hcW
 hcW
 hcW
@@ -289115,11 +289344,14 @@ hcW
 hcW
 hcW
 hcW
-pdm
 hcW
 hcW
 hcW
-pdm
+vFz
+hcW
+hcW
+hcW
+vFz
 hcW
 hcW
 hcW
@@ -289127,37 +289359,37 @@ hcW
 hcW
 hcW
 cWT
-rfO
+tJC
 iJR
-nxD
-rRD
-oRp
-fIG
-rGY
-fVM
-fIG
-wVi
-rGY
-wVi
-wVi
-iOm
+dOL
+dwO
+veW
+rvA
+qzN
+vWm
+rvA
+qzN
+lLK
+qzN
+qzN
+veW
 nrw
-oRp
-oRp
-liq
-liq
-oRp
-oRp
-ubr
-mwq
-mwq
+veW
+veW
+pka
+pka
+veW
+veW
+uPA
 qRp
+qRp
+abZ
 uaL
 uaL
 uaL
 uaL
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -289165,22 +289397,22 @@ fxx
 fxx
 uaL
 wSn
-dAf
+uwa
 kVc
 kVc
 kVc
-dAf
+uwa
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 qvR
@@ -289524,42 +289756,42 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 cWT
-rfO
-rfO
-rfO
-rfO
-uxV
-uxV
-uxV
-tYB
-tYB
-uxV
-uxV
-uxV
-wVi
-oRp
-bjN
-oRp
-oRp
-jYu
-rJI
-pcs
-uxV
+tJC
+tJC
+tJC
+tJC
+lIu
+lIu
+lIu
+kol
+kol
+lIu
+lIu
+lIu
+lLK
+veW
+lsi
+veW
+veW
+jNB
+vjb
+bPz
+lIu
 nrw
-mwq
-mwq
 qRp
-jgV
+qRp
+abZ
+cRE
 qvR
 qvR
 qvR
 qvR
-auL
+dTa
 fxx
 fxx
 fxx
@@ -289567,22 +289799,22 @@ fxx
 fxx
 fxx
 wSn
-dAf
+uwa
 kVc
-dAf
-kVc
-kVc
+uwa
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+kVc
+kVc
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 qvR
@@ -289919,7 +290151,7 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -289934,7 +290166,7 @@ cWT
 cWT
 cWT
 cWT
-rfO
+tJC
 nrw
 nrw
 nrw
@@ -289971,20 +290203,20 @@ fxx
 uaL
 kVc
 kVc
-dAf
+uwa
 kVc
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 uaL
@@ -290303,7 +290535,7 @@ qvR
 uaL
 uaL
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -290321,14 +290553,14 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -290337,10 +290569,10 @@ hcW
 hcW
 hcW
 cWT
-cdn
-cdn
-sTG
-sTG
+fDB
+fDB
+tUp
+tUp
 evo
 ykt
 ykt
@@ -290375,17 +290607,17 @@ aJj
 kVc
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 kVc
 qvR
@@ -290706,7 +290938,7 @@ qvR
 qvR
 hcW
 hcW
-pdm
+vFz
 hcW
 kYc
 kYS
@@ -290715,7 +290947,7 @@ mzx
 kYc
 mzx
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -290739,8 +290971,8 @@ hcW
 hcW
 hcW
 hcW
-sTG
-cdn
+tUp
+fDB
 evo
 evo
 evo
@@ -290775,19 +291007,19 @@ fxx
 uaL
 uaL
 uaL
-dAf
+uwa
 uaL
 kVc
 kVc
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
-dAf
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
+uwa
 kVc
 qvR
 qvR
@@ -291120,16 +291352,16 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -291172,10 +291404,10 @@ fxx
 fxx
 fxx
 fxx
-rZt
 fxx
 fxx
-uaL
+fxx
+fTe
 uaL
 aJj
 uaL
@@ -291520,18 +291752,18 @@ msk
 ntQ
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -291584,13 +291816,13 @@ uaL
 uaL
 fxx
 fxx
-qvL
-oJO
-oJO
-oJO
-oJO
-oJO
-qvL
+wVL
+tUR
+tUR
+tUR
+tUR
+tUR
+wVL
 wSn
 uaL
 uaL
@@ -291911,7 +292143,7 @@ sJZ
 sJZ
 qvR
 hcW
-pdm
+vFz
 hcW
 hcW
 ldI
@@ -291986,13 +292218,13 @@ fxx
 fxx
 fxx
 fxx
-hLz
+vdg
 peN
 peN
 peN
 peN
 peN
-aQx
+rwX
 fxx
 fxx
 fxx
@@ -292301,7 +292533,7 @@ uaL
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 qvR
@@ -292333,13 +292565,13 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -292388,13 +292620,13 @@ fxx
 fxx
 fxx
 fxx
-oJO
+tUR
 peN
 peN
 peN
-bZw
+nfz
 peN
-oJO
+tUR
 fxx
 fxx
 fxx
@@ -292738,10 +292970,10 @@ hcW
 hcW
 hcW
 hcW
-pdm
-pdm
+vFz
+vFz
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -292762,14 +292994,14 @@ wSn
 wSn
 wSn
 xKz
-fmp
-nPQ
+rPu
+fVv
 lLa
 xKz
 xKz
-dNI
-qzy
-hkW
+mmm
+hrj
+bjp
 xKz
 jeb
 jeb
@@ -293135,8 +293367,8 @@ hcW
 hcW
 hcW
 hcW
-pdm
-pdm
+vFz
+vFz
 hcW
 hcW
 hcW
@@ -293164,18 +293396,18 @@ wSn
 wSn
 wSn
 xKz
-wke
+msL
 iYQ
 fVQ
-edb
+cCG
 qpt
-wgn
+sDa
 peN
-kIf
-xZg
-edb
+rUr
+wgn
+cCG
 fVQ
-ycz
+cBG
 xKz
 qvR
 qvR
@@ -293192,13 +293424,13 @@ wSn
 uaL
 fTe
 wSn
-iWj
-qYw
-jlY
-jlY
-jlY
-qYw
-iWj
+fIB
+ebb
+wSl
+wSl
+wSl
+ebb
+fIB
 uaL
 uaL
 uaL
@@ -293539,7 +293771,7 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -293566,18 +293798,18 @@ wSn
 wSn
 wSn
 xKz
-ybB
-nPQ
+mxs
+fVv
 fVQ
 lLa
 qpt
-wgn
+sDa
 peN
-kIf
-xZg
+rUr
+wgn
 lLa
 fVQ
-aok
+qEM
 xKz
 qvR
 qvR
@@ -293597,7 +293829,7 @@ uaL
 xKz
 bOK
 jeb
-cjJ
+cRc
 jeb
 bOK
 xKz
@@ -293934,14 +294166,14 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -293968,18 +294200,18 @@ wSn
 wSn
 wSn
 xKz
-wke
+msL
 iYQ
 fVQ
-uaQ
+fVM
 qpt
-wgn
+sDa
 peN
-kIf
-xZg
+rUr
+wgn
 hmU
 fVQ
-aok
+qEM
 xKz
 qvR
 qvR
@@ -293999,7 +294231,7 @@ uaL
 bOK
 tYP
 tYP
-lPv
+utA
 tYP
 tYP
 xKz
@@ -294312,7 +294544,7 @@ uaL
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 qvR
 qvR
@@ -294334,7 +294566,7 @@ ndD
 kYc
 msk
 nxV
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -294370,18 +294602,18 @@ wSn
 wSn
 wSn
 xKz
-ybB
-nPQ
+mxs
+fVv
 fVQ
 jeb
 jeb
-wgn
+sDa
 peN
-kIf
+rUr
 jeb
 jeb
 fVQ
-aok
+iNo
 xKz
 qvR
 qvR
@@ -294398,11 +294630,11 @@ uaL
 qvR
 qvR
 uaL
-eyN
+dVb
 tYP
-kvj
+jCc
 tYP
-uwX
+fSZ
 tYP
 xKz
 qvR
@@ -294772,18 +295004,18 @@ wSn
 wSn
 wSn
 xKz
-kfm
+udB
 iYQ
 fVQ
 fVQ
 jeb
-pGM
+xcg
 peN
-kIf
+rUr
 jeb
 fVQ
 tYP
-doi
+jxX
 xKz
 qvR
 qvR
@@ -294801,7 +295033,7 @@ qvR
 uaL
 wSn
 xKz
-kpg
+puv
 tYP
 tYP
 tYP
@@ -295126,7 +295358,7 @@ uaL
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -295174,18 +295406,18 @@ wSn
 wSn
 wSn
 xKz
-fSU
+obq
 lLa
 fVQ
 fVQ
-hZF
-wgn
+cDZ
+sDa
 peN
-kIf
-hZF
+rUr
+cDZ
 fVQ
 sCg
-jfS
+ugc
 xKz
 qvR
 uaL
@@ -295204,10 +295436,10 @@ uaL
 wSn
 bOK
 tYP
-erP
+ulj
 tYP
 sCg
-heJ
+ejO
 xKz
 qvR
 qvR
@@ -295535,7 +295767,7 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -295576,18 +295808,18 @@ xKz
 xKz
 xKz
 xKz
-fSU
+obq
 lLa
 kMi
-hEw
+qPO
 jeb
-pGM
+xcg
 peN
-kIf
+rUr
 jeb
 fVQ
 sCg
-jfS
+ugc
 xKz
 qvR
 uaL
@@ -295607,9 +295839,9 @@ wSn
 xKz
 xKz
 xKz
-eza
+aym
 sCg
-jfS
+ugc
 xKz
 qvR
 qvR
@@ -295981,15 +296213,15 @@ fVQ
 fVQ
 fVQ
 kMi
-kfm
+udB
 jeb
-wgn
+sDa
 peN
-kIf
+rUr
 jeb
 fVQ
 tYP
-jfS
+ugc
 xKz
 qvR
 qvR
@@ -296011,7 +296243,7 @@ xKz
 xKz
 tYP
 sCg
-jfS
+ugc
 xKz
 qvR
 qvR
@@ -296321,7 +296553,7 @@ hcW
 wSn
 uaL
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -296381,17 +296613,17 @@ xKz
 mDY
 fVQ
 fVQ
-fIB
+lhd
 fVQ
 fVQ
 qpt
-wgn
+sDa
 peN
-kIf
-xZg
+rUr
+wgn
 lLa
 fVQ
-waB
+qwC
 xKz
 qvR
 uaL
@@ -296411,9 +296643,9 @@ wSn
 xKz
 xKz
 xKz
-eza
+aym
 sCg
-heJ
+ejO
 xKz
 qvR
 uaL
@@ -296723,7 +296955,7 @@ wSn
 wSn
 uaL
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
@@ -296732,7 +296964,7 @@ hcW
 hcW
 hcW
 hcW
-pdm
+vFz
 wSn
 wSn
 qvR
@@ -296779,7 +297011,7 @@ xqL
 wSn
 wSn
 xKz
-hEw
+qPO
 gqa
 fVQ
 fVQ
@@ -296787,13 +297019,13 @@ fVQ
 fVQ
 fVQ
 qpt
-wgn
+sDa
 peN
-kIf
-xZg
+rUr
+wgn
 lLa
 fVQ
-uxZ
+cHU
 xKz
 qvR
 qvR
@@ -296813,7 +297045,7 @@ uaL
 xKz
 xKz
 xKz
-kSC
+mYM
 xKz
 xKz
 xKz
@@ -297122,19 +297354,19 @@ fyc
 cWT
 cWT
 wSn
-pdm
-pdm
-pdm
-pdm
+vFz
+vFz
+vFz
+vFz
 hcW
-pdm
+vFz
 hcW
 hcW
 hcW
-pdm
-pdm
-pdm
-pdm
+vFz
+vFz
+vFz
+vFz
 wSn
 wSn
 qvR
@@ -297181,21 +297413,21 @@ aJj
 uaL
 qvR
 xKz
-wke
+msL
 iYQ
 lLa
 fVQ
-fIB
+lhd
 fVQ
 fVQ
 qpt
-wgn
+sDa
 peN
-kIf
-xZg
-rHj
+rUr
+wgn
+fTJ
 fVQ
-xJe
+kTM
 xKz
 uaL
 uaL
@@ -297524,9 +297756,9 @@ fyc
 cWT
 cWT
 uaL
-pdm
-pdm
-pdm
+vFz
+vFz
+vFz
 hcW
 hcW
 hcW
@@ -297583,18 +297815,18 @@ evo
 evo
 evo
 xKz
-kfm
-nPQ
+udB
+fVv
 kds
-aSD
+szF
 xKz
-uaQ
+fVM
 fVQ
 xKz
-npv
-dCr
-gQF
-bIP
+oJO
+upK
+kIf
+hZa
 xKz
 xKz
 xKz
@@ -297994,29 +298226,29 @@ xKz
 xKz
 xKz
 uWL
-mJI
-mJI
+ubc
+ubc
 xKz
 xKz
-csH
-csH
-rUr
-rUr
-rUr
-rUr
-rUr
-rUr
-ikM
-ikM
-rUr
-rUr
-csH
-csH
-csH
-csH
-rUr
-rUr
-rUr
+wcu
+wcu
+wou
+wou
+wou
+wou
+wou
+wou
+rMO
+rMO
+wou
+wou
+wcu
+wcu
+wcu
+wcu
+wou
+wou
+wou
 axq
 dnx
 axl
@@ -300855,7 +301087,7 @@ trG
 ryI
 ryI
 fxx
-oiE
+qvR
 qvR
 qvR
 fxx
@@ -305231,7 +305463,7 @@ xKz
 wVI
 wbg
 wbg
-bqL
+bPv
 wbg
 wbg
 wbg
@@ -305587,7 +305819,7 @@ mcK
 nBW
 mOY
 nBW
-tlG
+vRB
 nBW
 wtF
 wbg
@@ -307201,7 +307433,7 @@ wtF
 wbg
 wbg
 wbg
-bqL
+bPv
 wbg
 wbg
 wbg
@@ -308553,7 +308785,7 @@ wGD
 iae
 wGD
 sYx
-ijU
+odi
 odi
 wGD
 wGD
@@ -309324,9 +309556,9 @@ bwS
 lVe
 bwS
 lVe
-kuf
+jyw
 goK
-veW
+wVx
 sux
 pYf
 pYf
@@ -310460,14 +310692,14 @@ wbg
 wbg
 wbg
 wVI
-wVI
-fnL
+hrD
+uxZ
 nHz
 wVI
 wVI
 wVI
-rKD
-wVI
+mlO
+hrD
 wVI
 tUw
 wVI
@@ -310503,7 +310735,7 @@ fxx
 fxx
 fxx
 fxx
-oMa
+bpp
 fxx
 boU
 fxx
@@ -310521,13 +310753,13 @@ qvR
 wSn
 cyr
 hHF
-wsg
+bWg
 wlD
 sIG
 wlD
 wlD
 wlD
-veW
+wVx
 wlD
 sIG
 wlD
@@ -310828,7 +311060,7 @@ wbg
 xXq
 yhZ
 yhZ
-yfN
+bRV
 yhZ
 yhZ
 xXq
@@ -311241,13 +311473,13 @@ xez
 wbg
 wbg
 wbg
-bqL
+bPv
 wbg
 wbg
 wbg
 wbg
 wbg
-bqL
+bPv
 wbg
 wbg
 wbg
@@ -311295,7 +311527,7 @@ fxx
 fxx
 fxx
 fxx
-oMa
+bpp
 fxx
 fxx
 fxx
@@ -311663,7 +311895,7 @@ wbg
 wbg
 wbg
 wbg
-bqL
+bPv
 wbg
 wbg
 wbg
@@ -311671,7 +311903,7 @@ wbg
 wbg
 wbg
 wbg
-bqL
+bPv
 wbg
 wbg
 wbg
@@ -311709,7 +311941,7 @@ fxx
 fxx
 fxx
 wxd
-tCz
+iDD
 wmj
 cyr
 cyr
@@ -312877,7 +313109,7 @@ qzH
 wbg
 wbg
 wbg
-qzH
+xGM
 xGM
 qzH
 wsR
@@ -312921,7 +313153,7 @@ trG
 ryI
 fZw
 fxx
-oMa
+bpp
 rhD
 qvR
 qvR
@@ -313279,9 +313511,9 @@ wew
 wxZ
 nRo
 bQf
-nuH
+eCw
 iPY
-bPz
+nvP
 wsR
 ukb
 wvE
@@ -313636,7 +313868,7 @@ aOn
 aOn
 lpa
 nCh
-bqL
+bPv
 wbg
 wbg
 hOh
@@ -313669,21 +313901,21 @@ pUl
 rJX
 tCr
 guP
-xhZ
-guP
-csJ
+vYx
+quL
+fFh
 wbg
 qtV
 iPY
 iPY
 iPY
-quL
+cjJ
 wVI
 weX
 wVI
-bwO
+sQo
 hRv
-bPz
+nvP
 wsR
 xMr
 yho
@@ -314071,21 +314303,21 @@ rJX
 eai
 tCr
 guP
-ams
-guP
+hpM
+xlI
 iGf
 viq
 qtV
 iPY
-iPY
-iPY
-quL
+aOn
+aOn
+oll
 wxZ
 wVI
 bQf
-vjL
+mfo
 nXd
-lhd
+tjt
 wsR
 dHZ
 xww
@@ -314470,18 +314702,18 @@ wbg
 ufu
 pUl
 pUl
-pUl
+hGr
 fQm
 guP
 guP
 guP
-kLE
+quL
 uTQ
 qtV
 nXd
-hor
-hor
-vMQ
+sbF
+sbF
+oiE
 wVI
 wVI
 wVI
@@ -314545,7 +314777,7 @@ lVe
 uxL
 sZI
 xlx
-skp
+lSG
 iTv
 cXU
 iTv
@@ -314823,7 +315055,7 @@ uOL
 jxy
 vbO
 oif
-bmM
+mfi
 oif
 uJk
 tOz
@@ -314880,16 +315112,16 @@ sxR
 sxR
 abh
 wbg
-qRm
-qRm
+cJU
+cJU
 aSH
-qRm
+cJU
 wVI
 wVI
 wVI
 wVI
 wVI
-sPK
+slt
 oUn
 xMr
 vwQ
@@ -314932,7 +315164,7 @@ hLK
 nht
 fxx
 fxx
-aIp
+avX
 wxd
 wSn
 wSn
@@ -315271,7 +315503,7 @@ tYm
 oAn
 wbg
 wbg
-oul
+bQz
 dTB
 tVP
 tVP
@@ -315280,7 +315512,7 @@ tCG
 tVP
 tVP
 tCG
-jVO
+uPY
 wbg
 wVI
 wVI
@@ -315682,9 +315914,9 @@ tVP
 tVP
 tVP
 tVP
-iQF
+tha
 qtV
-mrw
+foR
 rZY
 wVI
 wxZ
@@ -316072,21 +316304,21 @@ pAS
 sZN
 sZN
 xdq
-iDd
+qpX
 wbg
 wbg
-oul
+bQz
 rJC
 tVP
-qrv
-oOW
+hGm
+sxm
 tVP
 tZZ
 tVP
 tVP
-iQF
+tha
 qtV
-mrw
+foR
 rZY
 wVI
 wxZ
@@ -316096,7 +316328,7 @@ wVI
 bQf
 wVI
 rZY
-vrS
+nWq
 kjH
 kjH
 kjH
@@ -316126,7 +316358,7 @@ vLS
 uaL
 sjP
 wSn
-oMa
+bpp
 fxx
 lcg
 fQg
@@ -316474,23 +316706,23 @@ sZN
 sZN
 sZN
 xdq
-quL
+cjJ
 wbg
 wbg
 wKT
 kFS
 tVP
-ovd
-mBJ
-sDa
-ldQ
+raJ
+fOI
+vvB
+oKT
 tVP
 tCG
-iQF
+tha
 wbg
 wbg
 wVI
-woq
+lKl
 wVI
 wVI
 wVI
@@ -316826,7 +317058,7 @@ oif
 oif
 oif
 oif
-qVq
+waG
 eUJ
 eUJ
 jxy
@@ -316876,7 +317108,7 @@ sZN
 sZN
 lzC
 xdq
-iDd
+qpX
 wbg
 wbg
 wKT
@@ -316884,8 +317116,8 @@ eWj
 yfY
 ijS
 mmb
-wmH
-uaj
+uRv
+vGQ
 yfY
 yfY
 wKT
@@ -316894,8 +317126,8 @@ qEa
 vXm
 vXm
 vXm
-kqV
-ssP
+aNR
+eAi
 wVI
 wVI
 wVI
@@ -317296,12 +317528,12 @@ wbg
 uqe
 ewM
 uqe
-hke
-quL
+wwz
+cjJ
 wVI
 wVI
 rZY
-bTg
+mqN
 rZY
 jXw
 xgi
@@ -317680,7 +317912,7 @@ pDy
 sZN
 sZN
 xdq
-iDd
+qpX
 wbg
 wbg
 cCQ
@@ -317692,18 +317924,18 @@ yfY
 yfY
 yfY
 yfY
-hGr
+rGG
 wbg
-vDQ
+koJ
 uqe
 uqe
 uqe
-xHe
+qFo
 wew
 weX
 wVI
 rZY
-fDF
+bsV
 rZY
 jXw
 xgi
@@ -317745,7 +317977,7 @@ gkv
 hLK
 njv
 fxx
-oMa
+bpp
 wxd
 wxd
 wSn
@@ -318051,7 +318283,7 @@ wrj
 jDm
 jDm
 mwE
-nIX
+dZK
 mwE
 wbg
 wbg
@@ -318082,25 +318314,25 @@ pAS
 sZN
 sZN
 xdq
-quL
+cjJ
 wbg
 wbg
 cJz
 yfY
-fQq
+epN
 ijS
-dNL
-uaj
-wmH
-kfr
+eyM
 vGQ
+uRv
+kfr
+hHm
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-xHe
+qFo
 wew
 wVI
 wVI
@@ -318484,7 +318716,7 @@ ygF
 ygF
 uDv
 xdq
-iDd
+qpX
 wbg
 wbg
 wKT
@@ -318502,8 +318734,8 @@ qEa
 gGZ
 gGZ
 gGZ
-sRe
-xaD
+dXn
+mIn
 wqq
 wqq
 wqq
@@ -318890,13 +319122,13 @@ qls
 wbg
 wbg
 wKT
-qqq
-biQ
-ksK
+tSr
+rXe
+urF
 vQV
-ksK
+urF
 vQV
-ksK
+urF
 vQV
 wKT
 wbg
@@ -319690,7 +319922,7 @@ pMj
 pPI
 xdq
 xdq
-iDd
+qpX
 wbg
 wbg
 wKT
@@ -319708,13 +319940,13 @@ wbg
 usR
 ncb
 ncb
-uyO
+vgA
 wbg
 wVI
 wVI
 wVI
 wVI
-iAK
+giI
 wVI
 wVI
 wbg
@@ -320092,25 +320324,25 @@ pOs
 pRW
 xdq
 qls
-gjV
+vox
 wbg
 wbg
 wKT
 wKT
 jCs
-ksK
-wFp
-ksK
-wFp
-ksK
-wFp
+urF
+xwi
+urF
+xwi
+urF
+xwi
 wKT
 wbg
 wbg
 usR
 xAt
 xAt
-vgA
+pEp
 wbg
 kjH
 xxF
@@ -320493,7 +320725,7 @@ xdq
 xdq
 xdq
 xdq
-kiX
+xAh
 wbg
 wbg
 wbg
@@ -320511,7 +320743,7 @@ wbg
 wbg
 vAB
 bnQ
-eLR
+cgc
 nWM
 wbg
 kjH
@@ -320895,7 +321127,7 @@ xMr
 xMr
 xMr
 xMr
-quL
+cjJ
 wbg
 wbg
 wbg
@@ -321297,7 +321529,7 @@ dCV
 csA
 dCV
 hXf
-iDd
+qpX
 wbg
 wbg
 wbg
@@ -321699,7 +321931,7 @@ dCV
 dCV
 dCV
 qee
-gjV
+vox
 wbg
 wbg
 wbg
@@ -322505,11 +322737,11 @@ xMr
 xMr
 gGZ
 qCy
-gEr
+iRN
 wVI
 weX
 wVI
-mdB
+iQs
 wbg
 ekQ
 qDx
@@ -322906,7 +323138,7 @@ bmi
 mgx
 xMr
 xAt
-chw
+nWr
 wbg
 wVI
 wVI
@@ -323309,11 +323541,11 @@ oVp
 xMr
 qnO
 oZC
-xAw
+fdx
 wVI
 xbo
 wVI
-mdB
+iQs
 wbg
 hOh
 qDx
@@ -323711,11 +323943,11 @@ nTe
 qhC
 wbg
 wbg
-xAw
+fdx
 wVI
 wVI
 wVI
-mdB
+iQs
 wbg
 hOh
 qDx
@@ -324111,7 +324343,7 @@ oXn
 oXn
 oXn
 xMr
-tXh
+ycz
 wbg
 wbg
 wVI
@@ -324513,13 +324745,13 @@ paz
 bmi
 bmi
 xMr
-kiX
+xAh
 wbg
-gEr
+iRN
 wVI
 weX
 wVI
-mdB
+iQs
 wbg
 lHf
 rfx
@@ -324915,7 +325147,7 @@ gVS
 gVS
 bmi
 xMr
-iDd
+qpX
 wbg
 wbg
 wbg
@@ -324940,7 +325172,7 @@ wbg
 ltk
 rSS
 lpq
-mwE
+nCh
 xEB
 axk
 wbg
@@ -325317,7 +325549,7 @@ poR
 pPs
 bmi
 qhR
-kiX
+xAh
 wbg
 wbg
 wbg
@@ -325743,7 +325975,7 @@ bJG
 wbg
 jpZ
 aOv
-cOV
+wMv
 aOv
 aOv
 aOv
@@ -326121,7 +326353,7 @@ orY
 orY
 bmi
 xMr
-iDd
+qpX
 wbg
 wbg
 wbg
@@ -326144,7 +326376,7 @@ ewt
 cEF
 wbg
 xll
-nTR
+oAH
 aOn
 jHc
 mwE
@@ -326523,7 +326755,7 @@ bmi
 mou
 bmi
 xMr
-iDd
+qpX
 wbg
 wbg
 wbg
@@ -326925,7 +327157,7 @@ xMr
 xMr
 xMr
 xMr
-quL
+cjJ
 wbg
 wbg
 wbg
@@ -328211,7 +328443,7 @@ kVc
 kVc
 hcW
 cWT
-dAf
+uwa
 hcW
 hcW
 hcW
@@ -328612,8 +328844,8 @@ kVc
 kVc
 kVc
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -329014,8 +329246,8 @@ wxd
 kVc
 kVc
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -329416,8 +329648,8 @@ wxd
 kVc
 kVc
 kVc
-dAf
-dAf
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -329730,9 +329962,9 @@ xKF
 xKF
 xKF
 xKF
-vLA
-oFV
-hhM
+pKN
+jCr
+fTd
 xKF
 xKF
 xKF
@@ -329818,8 +330050,8 @@ xqL
 kVc
 kVc
 kVc
-dAf
-dAf
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -330126,10 +330358,10 @@ uaL
 xAt
 xAt
 xKF
-diR
-dTa
-dTa
-qKg
+ltL
+gsa
+gsa
+vWY
 xKF
 xKF
 eBN
@@ -330137,10 +330369,10 @@ eBN
 eBN
 mGn
 mGn
-bVT
+bIE
 trI
-wDz
-wDz
+cdn
+cdn
 hcp
 tkZ
 xKF
@@ -330220,8 +330452,8 @@ wxd
 kVc
 kVc
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -330528,10 +330760,10 @@ paf
 xAt
 xAt
 xKF
-bPF
-dTa
-dTa
-qKg
+cCS
+gsa
+gsa
+vWY
 xKF
 xKF
 ejY
@@ -330541,9 +330773,9 @@ mGn
 mGn
 ejY
 trI
-wDz
+cdn
 rTm
-wDz
+cdn
 obL
 xKF
 vtw
@@ -330622,8 +330854,8 @@ sJZ
 wxd
 wxd
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -330930,10 +331162,10 @@ afX
 xAt
 xAt
 xKF
-szi
-dTa
-dTa
-qKg
+uYr
+gsa
+gsa
+vWY
 xKF
 xKF
 xKF
@@ -330943,9 +331175,9 @@ xKF
 xKF
 xKF
 xKF
-wDz
-wDz
-wDz
+cdn
+cdn
+cdn
 oiC
 xKF
 vtw
@@ -331024,8 +331256,8 @@ sJZ
 sJZ
 feP
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -331332,22 +331564,22 @@ paf
 xAt
 xAt
 xKF
-bLu
-dTa
-dTa
-rTo
+pWL
+gsa
+gsa
+vHJ
 xKF
+ofq
+ofq
 xKF
-xKF
-xKF
-exW
+xJe
 ofq
 eBN
-wDz
-suN
-wDz
+cdn
+uHj
+cdn
 bok
-wDz
+cdn
 tkZ
 xKF
 vtw
@@ -331426,8 +331658,8 @@ sJZ
 sJZ
 wxd
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -331734,20 +331966,20 @@ paf
 xAt
 xAt
 xKF
-aky
-dTa
-dTa
-hQZ
+vde
+gsa
+gsa
+bmx
 xKF
-xKF
-iuo
+ofq
+ofq
 wVy
 ofq
 ofq
 eBN
 bok
-suN
-wDz
+uHj
+cdn
 nrx
 idG
 obL
@@ -331756,9 +331988,9 @@ vtw
 wOR
 wOR
 vtw
-ofq
+eEC
 iPY
-hRv
+aOv
 aOv
 xEB
 rfx
@@ -331828,8 +332060,8 @@ qet
 sJZ
 wxd
 kVc
-dAf
-dAf
+uwa
+uwa
 kVc
 hcW
 hcW
@@ -332136,20 +332368,20 @@ paf
 xAt
 xAt
 xKF
-kmZ
-dTa
-cEJ
-bfD
+fRA
+gsa
+mbs
+uxV
 xKF
-xKF
-iuo
+ofq
+ofq
 wVy
 ofq
 ofq
 eBN
-wDz
-suN
-wDz
+cdn
+uHj
+cdn
 iIl
 xKF
 xKF
@@ -332230,8 +332462,8 @@ qet
 qet
 wxd
 kVc
-dAf
-dAf
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -332538,10 +332770,10 @@ paf
 xAt
 xAt
 xKF
-byw
-iME
+rgO
+rgO
 xKF
-yhL
+saz
 xKF
 xKF
 xKF
@@ -332550,8 +332782,8 @@ xKF
 ofq
 eBN
 bok
-suN
-wDz
+uHj
+cdn
 tkZ
 xKF
 vtw
@@ -332562,7 +332794,7 @@ gLx
 vtw
 rkf
 mOT
-iPY
+aOv
 kJX
 jHc
 jHc
@@ -332632,8 +332864,8 @@ qet
 qet
 wxd
 kVc
-dAf
-dAf
+uwa
+uwa
 hcW
 hcW
 hcW
@@ -332939,21 +333171,21 @@ uaL
 afX
 xAt
 xAt
-jTw
+qzy
 fCM
 fCM
 cNo
 twX
 cNo
-jCi
+rHr
 eeO
-bPv
-xKF
+sKd
+hRC
 eBN
 eBN
-wDz
-suN
-wDz
+cdn
+uHj
+cdn
 vCr
 xKF
 vtw
@@ -333341,20 +333573,20 @@ uaL
 paf
 xAt
 xAt
-jTw
+qzy
 fCM
 fCM
 fCM
 fCM
-stj
-xrW
+dPe
+mah
 dsW
 sKd
 xgL
-wDz
-wDz
-wDz
-wDz
+cdn
+cdn
+cdn
+cdn
 nrx
 obL
 xKF
@@ -333744,21 +333976,21 @@ uaL
 xAt
 xAt
 xKF
-wYa
+pLU
 iuo
 iuo
 iuo
-stj
+dPe
 wPC
 dsW
 sKd
 xgL
-jBr
-wDz
-wDz
-wDz
-wDz
-wDz
+mXh
+cdn
+cdn
+cdn
+cdn
+cdn
 xKF
 vtw
 vWe
@@ -334146,21 +334378,21 @@ paf
 xAt
 xAt
 xKF
-xAh
-xAh
-xAh
+qCT
+qCT
+qCT
 iuo
 fCM
 sKd
 sKd
 vSM
-mma
-wDz
-wDz
+rSH
+cdn
+cdn
 wIl
 dXw
 uHg
-wDz
+cdn
 xKF
 vtw
 vWe
@@ -334171,7 +334403,7 @@ vtw
 qZh
 ltk
 mwE
-nIX
+dZK
 mwE
 mwE
 aOv
@@ -334548,9 +334780,9 @@ paf
 xAt
 xAt
 xKF
-cUS
-tZx
-jUP
+pIO
+gQV
+pwX
 iuo
 oIv
 sKd
@@ -334562,7 +334794,7 @@ lma
 xKF
 xKF
 xKF
-jMf
+hnd
 xKF
 vtw
 vtw
@@ -334949,7 +335181,6 @@ uaL
 pOO
 xAt
 xAt
-vtw
 xKF
 xKF
 xKF
@@ -334958,7 +335189,8 @@ xKF
 xKF
 xKF
 xKF
-juR
+xKF
+qKU
 eCn
 eCn
 xKF
@@ -336170,14 +336402,14 @@ eCn
 xKF
 xKF
 xKF
-jNF
+hnd
 xKF
 kPZ
 xKF
 xKF
-jMf
+hnd
 ofb
-vtw
+xKF
 vtw
 oAn
 wbg
@@ -336570,16 +336802,16 @@ eCn
 eCn
 eCn
 euo
-oOU
+smO
 oOU
 smO
 buj
 smO
-uGE
+hnd
 kSh
 sKd
 uHb
-vtw
+xKF
 vtw
 oAn
 swu
@@ -336974,14 +337206,14 @@ eCn
 mty
 smO
 smO
-smO
 nXv
+smO
 smO
 hnd
 sKd
 sKd
 sKd
-vtw
+xKF
 vtw
 oAn
 nvS
@@ -337371,19 +337603,19 @@ xKF
 xKF
 xKF
 xKF
-jMf
-vtw
-vtw
+hnd
+xKF
+xKF
 wnv
-vtw
-vtw
-jMf
-jMf
-vtw
+xKF
+xKF
+hnd
+hnd
+xKF
 bJs
 sKd
 aqj
-vtw
+xKF
 vtw
 oAn
 xgy
@@ -337774,18 +338006,18 @@ oSY
 szN
 szN
 sKd
-vtw
+xKF
 iuo
 iuo
 fXv
-vtw
+xKF
 wOR
 wOR
-vtw
+xKF
 alk
 alk
-vtw
-vtw
+xKF
+xKF
 vtw
 oAn
 vzm
@@ -338176,18 +338408,18 @@ bau
 sKd
 sKd
 sKd
-clr
+hnd
 iuo
 aFS
 iuo
-clr
+hnd
 wOR
 wOR
 rKn
 sKd
 tkq
-vtw
-lAs
+xKF
+xKF
 vtw
 rfx
 pwQ
@@ -338578,17 +338810,17 @@ lel
 szN
 szN
 sKd
-vtw
+xKF
 bEo
 iuo
 iuo
-vtw
+xKF
 wOR
 wOR
 rKn
 sKd
 sKd
-vtw
+xKF
 vtw
 vtw
 rfx
@@ -338980,17 +339212,17 @@ iuo
 iuo
 iuo
 sKd
-vtw
-vtw
-clr
-vtw
-vtw
+xKF
+xKF
+hnd
+xKF
+xKF
 wOR
 wOR
-vtw
+xKF
 mfd
 sKd
-vtw
+xKF
 lAs
 lAs
 pQd
@@ -339383,7 +339615,7 @@ oHg
 iuo
 sKd
 wPC
-vtw
+xKF
 wOR
 azQ
 qHe
@@ -339391,8 +339623,8 @@ wOR
 wOR
 hnd
 sKd
-vtw
-vtw
+xKF
+xKF
 lAs
 lAs
 pQd
@@ -339785,15 +340017,15 @@ bXB
 iuo
 sKd
 sKd
-vtw
+xKF
 wOR
 wOR
 wOR
 wOR
 lds
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -340187,14 +340419,14 @@ pDa
 iuo
 krp
 sBX
-jMf
+hnd
 wlI
 pHa
 odo
 oBB
 aTg
-vtw
-lAs
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -340586,17 +340818,17 @@ xKF
 xKF
 xKF
 xKF
-hjD
+clr
 xKF
 xKF
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-lAs
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -383595,31 +383827,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-uHk
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
+uGf
+uGf
+uGf
+uGf
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 erZ
 erZ
 erZ
@@ -383997,31 +384229,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-uHk
-yiI
-rST
-dyt
-jEB
-jEB
-yiI
-jEB
-jEB
-yiI
-cwd
-uHk
-lNU
-uHk
-ygS
-uHk
-uHk
-aev
-uHk
-uHk
-yeq
-xET
+uGf
+uGf
+uGf
+uGf
+aac
+pMn
+pWl
+jIP
+tlQ
+aac
+jIP
+jIP
+aac
+qQu
+uGf
+gnD
+uGf
+jph
+gnD
+gnD
+rcr
+uGf
+uGf
+gnD
+dAf
 erZ
 erZ
 erZ
@@ -384399,31 +384631,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-uHk
-yiI
-rST
-tQT
-jEB
-jEB
-yiI
-jEB
-jEB
-yiI
-qpX
-uHk
-uHk
-qpX
-yiI
-uHk
-uHk
-yiI
-rHO
-uHk
-vHd
-xET
+uGf
+uGf
+uGf
+uGf
+aac
+pMn
+nTR
+jIP
+tlQ
+aac
+jIP
+jIP
+aac
+gYj
+seC
+seC
+gYj
+aac
+mVz
+qrm
+aac
+oOS
+uGf
+hHz
+dAf
 erZ
 erZ
 erZ
@@ -384801,31 +385033,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-uHk
-yiI
-yiI
-yiI
-mup
-jEB
-yiI
-jEB
-jEB
-yiI
-jpw
-iXl
-uHk
-cKp
-yiI
-sIE
-uHk
-yiI
-oXz
 uGf
-wtx
-xET
+uGf
+uGf
+uGf
+aac
+aac
+aac
+ulg
+jIP
+aac
+jIP
+jIP
+aac
+mvx
+mQA
+uGf
+jWz
+aac
+vVR
+vVR
+aac
+ciQ
+bIe
+oTK
+dAf
 erZ
 erZ
 erZ
@@ -385203,31 +385435,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-uHk
-yiI
-yiI
-yiI
-mup
-jEB
-yiI
-jEB
-jEB
-yiI
-htf
-uHk
-uHk
-ebe
-yiI
-uHk
-uHk
-yiI
-yiI
-yiI
-yiI
-yiI
+uGf
+uGf
+uGf
+uGf
+aac
+aac
+aac
+ulg
+tlQ
+aac
+jIP
+jIP
+aac
+tKP
+uGf
+uGf
+cSB
+aac
+uaj
+uaj
+aac
+aac
+aac
+aac
+aac
 erZ
 erZ
 erZ
@@ -385605,31 +385837,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-uHk
-yiI
-yiI
-yiI
-cPx
-jEB
-yiI
-jEB
-jEB
-yiI
-htf
-uHk
-sIE
-ebe
-yiI
-uHk
-sIE
-yiI
-yiI
-yiI
-yiI
-yiI
+uGf
+uGf
+uGf
+uGf
+aac
+aac
+aac
+sxM
+jIP
+aac
+jIP
+jIP
+aac
+kwN
+uGf
+uGf
+cSB
+aac
+liA
+uGf
+aac
+aac
+aac
+aac
+aac
 erZ
 erZ
 erZ
@@ -386007,31 +386239,31 @@ erZ
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-yiI
-yiI
-yiI
-yiI
-yiI
-piN
-yiI
-yiI
-yiI
-yiI
-goz
-hLy
-uHk
-mIn
-yiI
-uHk
-sIE
-aev
-uHk
-vHd
-yeq
-xET
+uGf
+uGf
+uGf
+aac
+aac
+aac
+aac
+aac
+mHT
+aac
+aac
+aac
+aac
+nJy
+mQA
+uGf
+csg
+aac
+seC
+seC
+rcr
+uGf
+hHz
+gnD
+dAf
 erZ
 erZ
 erZ
@@ -386409,31 +386641,31 @@ vIa
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-yiI
-vDr
-jEB
-jEB
-jEB
-jEB
-cBG
-yiI
-xMR
-uHk
-uHk
-sIE
-uHk
-qpX
-yiI
-uHk
-uHk
-yiI
-uHk
-uHk
-uHk
-xET
+uGf
+uGf
+uGf
+aac
+bYy
+jIP
+kFh
+jIP
+jIP
+mSy
+aac
+gip
+uGf
+uGf
+uGf
+seC
+gYj
+aac
+uGf
+uGf
+aac
+uGf
+uGf
+uGf
+dAf
 erZ
 erZ
 erZ
@@ -386811,31 +387043,31 @@ vIa
 erZ
 erZ
 erZ
-uHk
-uHk
-uHk
-yiI
-lgx
-jEB
-jEB
-jEB
-jEB
-rWd
-yiI
-xMR
-uHk
-wqV
-uHk
-lpb
-qpX
-yiI
-uHk
-uHk
-yiI
-pFt
-pmt
-wtx
-xET
+uGf
+uGf
+uGf
+aac
+gir
+jIP
+jIP
+jIP
+tlQ
+fZP
+aac
+gip
+uGf
+uFp
+uGf
+pUH
+gYj
+aac
+liA
+uGf
+aac
+uxo
+khc
+oTK
+dAf
 erZ
 erZ
 erZ
@@ -387213,31 +387445,31 @@ vIa
 vIa
 erZ
 erZ
-uHk
-uHk
-uHk
-yiI
-gnv
-jEB
-jEB
-jEB
-jEB
-rWd
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-qwp
-qwp
-yiI
-yiI
-yiI
-yiI
-yiI
+uGf
+uGf
+uGf
+aac
+fNp
+jIP
+jIP
+tlQ
+jIP
+fZP
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+slh
+slh
+aac
+aac
+aac
+aac
+aac
 erZ
 erZ
 erZ
@@ -387618,24 +387850,24 @@ erZ
 erZ
 erZ
 erZ
-yiI
-sgt
-jEB
-jEB
-jEB
-jEB
-cBG
-yiI
-jcZ
-fqo
-uZN
-asr
-uZN
-fqo
-fLK
-jEB
-jEB
-gvi
+aac
+nRU
+jIP
+jIP
+jIP
+jIP
+mSy
+aac
+pjB
+mwy
+nwj
+kFh
+nwj
+mwy
+suN
+jIP
+slz
+xUO
 erZ
 erZ
 erZ
@@ -388020,24 +388252,24 @@ erZ
 erZ
 erZ
 erZ
-yiI
-fkp
-jEB
-jEB
-jEB
-jEB
-pIn
-yiI
-jEB
-rlo
-rlo
-jEB
-bmL
-bmL
-jEB
-vdg
-jEB
-gvi
+aac
+nyu
+tlQ
+jIP
+tFU
+jIP
+goz
+aac
+jIP
+xEP
+xEP
+jIP
+rhG
+rhG
+jIP
+tlQ
+jIP
+xUO
 erZ
 erZ
 erZ
@@ -388422,24 +388654,24 @@ erZ
 erZ
 erZ
 erZ
-yiI
-kgF
-jEB
-jEB
-jEB
-jEB
-uwa
-fkq
-jEB
-jEB
-jEB
-vdg
-jEB
-jEB
-vdg
-jEB
-jEB
-gvi
+aac
+xDC
+jIP
+pjB
+sfZ
+jIP
+aHC
+fvB
+jIP
+tlQ
+jIP
+tlQ
+jIP
+jIP
+jIP
+jIP
+jIP
+xUO
 erZ
 erZ
 erZ
@@ -388824,24 +389056,24 @@ erZ
 erZ
 erZ
 erZ
-yiI
-jZM
-jEB
-jEB
-jEB
-jEB
-pIn
-yiI
-jEB
-cld
-cld
-jEB
-jEB
-rQT
-rQT
-vdg
-jEB
-gvi
+aac
+qpS
+jIP
+pjB
+qyo
+jIP
+goz
+aac
+jIP
+veT
+veT
+jIP
+jIP
+sqi
+sqi
+jIP
+tlQ
+xUO
 erZ
 erZ
 erZ
@@ -389226,24 +389458,24 @@ erZ
 erZ
 erZ
 erZ
-yiI
-jIR
-jEB
-jEB
-jEB
-jEB
-dKU
-yiI
-jcZ
-uZN
-uZN
-fLK
-jEB
-jEB
-dyt
-taz
-jEB
-gvi
+aac
+hGF
+jIP
+jIP
+jIP
+jIP
+mdB
+aac
+pjB
+nwj
+nwj
+suN
+slz
+jIP
+pWl
+sKY
+jIP
+xUO
 erZ
 erZ
 erZ
@@ -389628,24 +389860,24 @@ erZ
 erZ
 erZ
 erZ
-yiI
-sRO
-jEB
-jEB
-jEB
-jEB
-dKU
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-siV
-siV
-yiI
+aac
+gEw
+jIP
+pjB
+sfZ
+jIP
+mdB
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+hFZ
+hFZ
+aac
 erZ
 erZ
 erZ
@@ -390030,28 +390262,28 @@ erZ
 erZ
 erZ
 erZ
-yiI
-jZM
-jEB
-jEB
-jEB
-jEB
-hRj
-yiI
-oun
-rMX
-tUR
-xkF
-tUR
-rMX
-xkF
-taz
-jEB
-yiI
-yiI
-yiI
-yiI
-yiI
+aac
+qpS
+jIP
+pjB
+qyo
+jIP
+qPE
+aac
+jlY
+jYO
+rfO
+eoB
+rfO
+jYO
+eoB
+sKY
+jIP
+aac
+aac
+aac
+aac
+aac
 erZ
 erZ
 erZ
@@ -390431,29 +390663,29 @@ erZ
 erZ
 aUc
 erZ
-yiI
-yiI
-mup
-jEB
-jEB
-jEB
-jEB
-mxn
-yiI
-jEB
-vdg
-jEB
-jEB
-jEB
-jEB
-vdg
-jEB
-jEB
-aev
-uHk
-uHk
-yeq
-xET
+aac
+aac
+ulg
+jIP
+jIP
+kuV
+jIP
+tOG
+aac
+jIP
+jIP
+jIP
+jIP
+jIP
+jIP
+jIP
+rGY
+jIP
+rcr
+uGf
+uGf
+gnD
+dAf
 erZ
 erZ
 erZ
@@ -390833,29 +391065,29 @@ vIa
 vIa
 aUc
 aUc
-yiI
-yiI
-mup
-jEB
-jEB
-jEB
-jEB
-uwa
-yiI
-mhE
-jEB
-jEB
-vdg
-vdg
-jEB
-jEB
-jEB
-jEB
-yiI
-gkI
-uHk
-uHk
-xET
+aac
+aac
+ulg
+tlQ
+jIP
+jIP
+jIP
+aHC
+aac
+duh
+jIP
+jIP
+lhi
+jIP
+rGY
+jIP
+jIP
+jIP
+aac
+xyM
+uGf
+uGf
+dAf
 erZ
 erZ
 erZ
@@ -391235,29 +391467,29 @@ vIa
 vIa
 aUc
 aUc
-rcr
-rcr
-mup
-ahX
-uwa
-jEB
-jEB
-jEB
-vnw
-jEB
-jEB
-jEB
-vdg
-vdg
-jEB
-jEB
-jEB
-jEB
-yiI
-rHO
-uHk
-uHk
-xET
+ifB
+ifB
+ulg
+wHL
+aHC
+jIP
+tlQ
+jIP
+fmx
+jIP
+rGY
+jIP
+jIP
+jIP
+jIP
+jIP
+jIP
+jIP
+aac
+oOS
+uGf
+uGf
+dAf
 erZ
 erZ
 erZ
@@ -391638,28 +391870,28 @@ vIa
 vIa
 vIa
 aUc
-rcr
-rcr
-rcr
-uwa
-uwa
-jEB
-jEB
-dSY
-tlQ
-vdg
-jEB
-jEB
-jEB
-jEB
-vdg
-jEB
-jEB
-yiI
-lVX
-uHk
-uHk
-xET
+ifB
+ifB
+ifB
+aHC
+aHC
+jIP
+jIP
+kDX
+cIz
+jIP
+jIP
+jIP
+jIP
+jIP
+jIP
+rGY
+jIP
+aac
+liA
+uGf
+uGf
+dAf
 erZ
 erZ
 erZ
@@ -392042,26 +392274,26 @@ vIa
 vIa
 aUc
 aUc
-rcr
-rcr
-uwa
-uwa
-uwa
-yiI
-yiI
-lgz
-lgz
-nQP
-lgz
-taz
-jEB
-jEB
-jEB
-yiI
-gip
-wtx
-ifg
-xET
+ifB
+ifB
+qoJ
+aHC
+aHC
+aac
+aac
+dOw
+dOw
+vkW
+dOw
+sKY
+jIP
+jIP
+jIP
+aac
+uwd
+oTK
+wPz
+dAf
 erZ
 erZ
 erZ
@@ -392445,25 +392677,25 @@ vIa
 vIa
 aUc
 aUc
-rcr
-rcr
-rcr
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-sxM
-sxM
-sxM
-sxM
-yiI
-yiI
-yiI
-yiI
-yiI
+ifB
+ifB
+ifB
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+nff
+nff
+nff
+nff
+aac
+aac
+aac
+aac
+aac
 erZ
 erZ
 erZ
@@ -394095,13 +394327,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-lLK
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+nPQ
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -394497,13 +394729,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-mVz
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+wLB
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -394875,12 +395107,12 @@ xKz
 xKz
 xKz
 xKz
-kJb
-tlS
-siT
-xYB
-xIQ
-nWe
+uJC
+oBD
+wKf
+eiT
+uGq
+iDQ
 xKz
 erZ
 erZ
@@ -394899,13 +395131,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-lLK
-iRN
-lLK
-cNj
-iRN
-gbA
+pdm
+nPQ
+wDz
+nPQ
+fth
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -395272,10 +395504,10 @@ erZ
 fVQ
 fVQ
 xKz
-bCb
-llg
-llg
-nga
+ylg
+ogC
+ogC
+nCd
 xKz
 fVQ
 fVQ
@@ -395301,13 +395533,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-iRN
-iRN
-mVz
-lLK
-iRN
-gbA
+pdm
+wDz
+wDz
+wLB
+nPQ
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -395682,14 +395914,14 @@ xKz
 fVQ
 fVQ
 jeb
-lFX
+dEF
 fVQ
-fjB
+mFp
 xKz
 fVQ
 bvN
 tYP
-hJH
+iME
 jeb
 erZ
 erZ
@@ -395703,13 +395935,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-iRN
-iRN
-lLK
-cNj
-iRN
-gbA
+pdm
+wDz
+wDz
+nPQ
+fth
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -396080,18 +396312,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-lKP
+bZW
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-lKP
+bZW
 fVQ
 bvN
 tYP
-iSJ
+pOS
 jeb
 erZ
 erZ
@@ -396105,13 +396337,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-lLK
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+nPQ
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -396476,24 +396708,24 @@ erZ
 erZ
 erZ
 xKz
-rTZ
-uNH
+ktR
+wUw
 fVQ
 fVQ
 lLa
-ndA
+dlw
 jeb
-lbj
-mYD
-jZC
-gEw
+keM
+msY
+iqu
+iVn
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-aym
+woq
 jeb
 erZ
 erZ
@@ -396507,13 +396739,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-mVz
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+wLB
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -396878,12 +397110,12 @@ erZ
 erZ
 erZ
 xKz
-xQc
-uNH
+rHj
+wUw
 fVQ
 fVQ
 lLa
-ndA
+dlw
 jeb
 xKz
 xKz
@@ -396895,7 +397127,7 @@ xKz
 fVQ
 tYP
 tYP
-odd
+vsg
 jeb
 erZ
 erZ
@@ -396909,13 +397141,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-lLK
-iRN
-lLK
-cNj
-iRN
-gbA
+pdm
+nPQ
+wDz
+nPQ
+fth
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -397280,24 +397512,24 @@ erZ
 erZ
 erZ
 xKz
-vyS
-uNH
+swn
+wUw
 fVQ
 fVQ
 fVQ
 fVQ
-lKP
+bZW
 fVQ
-cKL
-jEf
-wYv
+pSO
+vTj
+ovj
 fVQ
-cHt
+alz
 xKz
 fVQ
 bvN
 tYP
-hJH
+iME
 jeb
 erZ
 erZ
@@ -397311,13 +397543,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-iRN
-iRN
-mVz
-lLK
-iRN
-gbA
+pdm
+wDz
+wDz
+wLB
+nPQ
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -397682,24 +397914,24 @@ erZ
 erZ
 erZ
 xKz
-pmK
-uNH
+fpm
+wUw
 fVQ
-nIw
+hAA
 fVQ
 fVQ
 jeb
-rGp
+mhS
 fVQ
 fVQ
 fVQ
 fVQ
-gws
+kvj
 xKz
 fVQ
 bvN
 tYP
-iSJ
+pOS
 jeb
 erZ
 erZ
@@ -397713,13 +397945,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-lLK
-iRN
-lLK
-cNj
-iRN
-gbA
+pdm
+nPQ
+wDz
+nPQ
+fth
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -398088,20 +398320,20 @@ xKz
 xKz
 xKz
 xKz
-ovj
+ktG
 xKz
 xKz
-eiG
+pPj
 fVQ
 jeb
-lFX
+dEF
 fVQ
-lyQ
+qCY
 xKz
 fVQ
 tYP
 tYP
-aym
+woq
 jeb
 erZ
 erZ
@@ -398115,13 +398347,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-mVz
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+wLB
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -398493,7 +398725,7 @@ fVQ
 fVQ
 fVQ
 xKz
-eFt
+kGT
 fVQ
 fVQ
 fVQ
@@ -398503,7 +398735,7 @@ xKz
 fVQ
 tYP
 tYP
-odd
+vsg
 jeb
 erZ
 erZ
@@ -398517,13 +398749,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-lLK
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+nPQ
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -398895,17 +399127,17 @@ vZP
 lLa
 fVQ
 xKz
-pqp
-tTv
-owa
-xMP
+hDQ
+rGv
+biC
+ykZ
 fVQ
-rHa
+jNF
 xKz
 fVQ
-fIB
+lhd
 tYP
-hJH
+iME
 jeb
 erZ
 erZ
@@ -398919,13 +399151,13 @@ erZ
 erZ
 erZ
 erZ
-iug
-iRN
-iRN
-iRN
-iRN
-iRN
-gbA
+pdm
+wDz
+wDz
+wDz
+wDz
+wDz
+vPA
 erZ
 erZ
 erZ
@@ -399295,7 +399527,7 @@ fVQ
 lLa
 noC
 lLa
-fjB
+mFp
 xKz
 xKz
 xKz
@@ -399305,7 +399537,7 @@ xKz
 xKz
 xKz
 fVQ
-fIB
+lhd
 fVQ
 fVQ
 jeb
@@ -399321,10 +399553,10 @@ erZ
 erZ
 erZ
 erZ
-iug
-iRN
+pdm
+wDz
 xKz
-fgh
+xkF
 bOK
 jeb
 xKz
@@ -399706,7 +399938,7 @@ fVQ
 fVQ
 xKz
 xKz
-ovj
+ktG
 xKz
 xKz
 xKz
@@ -399723,8 +399955,8 @@ erZ
 erZ
 erZ
 erZ
-iug
-iRN
+pdm
+wDz
 jeb
 fVQ
 ugK
@@ -418979,7 +419211,7 @@ ygF
 ygF
 ygF
 ygF
-tmu
+riW
 jYR
 lHe
 lHe
@@ -432238,12 +432470,12 @@ teW
 kwf
 nRx
 rwH
-uSx
+ipw
 teW
 kqc
-vFz
+kVq
 jjS
-abZ
+dbZ
 wte
 vsf
 rwH
@@ -432251,8 +432483,8 @@ nKu
 jiv
 rwH
 teW
-fDB
-rja
+dbt
+eMv
 wte
 enq
 fZJ
@@ -432640,10 +432872,10 @@ teW
 dvD
 jiv
 jiv
-vgv
+uSx
 teW
-sIx
-jRF
+nSr
+ijU
 jiv
 jiv
 jiv
@@ -432654,7 +432886,7 @@ jiv
 jjS
 teW
 hqI
-aPR
+bmL
 hqI
 enq
 fZJ
@@ -433045,7 +433277,7 @@ jiv
 teW
 teW
 wte
-jRF
+ijU
 jiv
 jiv
 jiv
@@ -433056,11 +433288,11 @@ jiv
 vIX
 teW
 hqI
-aPR
+bmL
 hqI
-wUw
-wUw
-bzl
+maZ
+atl
+jyO
 fZJ
 fZJ
 fZJ
@@ -433451,18 +433683,18 @@ jiv
 jiv
 jiv
 qfh
-nSr
+itC
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-aPR
+bmL
 hqI
 jFM
 jFM
-oEy
+akm
 fZJ
 fZJ
 fZJ
@@ -433848,23 +434080,23 @@ jiv
 jiv
 hcx
 cfw
-jiv
 xSI
 jiv
 jiv
-vPA
-lLq
+jiv
+mQr
+uVy
 htU
 teW
 ael
 hqI
 hqI
 hqI
-aPR
+bmL
 hqI
 jFM
 jFM
-jIP
+qTo
 fZJ
 fZJ
 fZJ
@@ -434251,8 +434483,8 @@ xSI
 tML
 tML
 tML
-vWY
-vWY
+tdl
+tdl
 tML
 aGb
 tML
@@ -434262,11 +434494,11 @@ pDA
 hqI
 hqI
 hqI
-aPR
+bmL
 hqI
 jFM
 jFM
-jIP
+qTo
 fZJ
 fZJ
 fZJ
@@ -434655,20 +434887,20 @@ tML
 teW
 nyc
 ntK
-ntK
+gbA
 cAe
-wpm
-wDZ
+cAe
+rSg
 teW
 ulu
 hqI
 fVE
-aPR
+bmL
 uPa
 hqI
-fTO
-fTO
-lNA
+gSz
+gSz
+qeY
 fZJ
 fZJ
 fZJ
@@ -435057,16 +435289,16 @@ lPt
 swm
 nyc
 ntK
-ntK
-tak
-lGI
-lGI
+tUB
+lYl
+lYl
+lYl
 teW
 uNz
 hqI
 hqI
-aPR
-btY
+bmL
+hhK
 ojc
 enq
 fZJ
@@ -435450,7 +435682,7 @@ erZ
 erZ
 fZJ
 fZJ
-cWM
+dSK
 gys
 tsB
 aur
@@ -435459,10 +435691,10 @@ pLs
 swm
 nyc
 ntK
-ntK
-iXM
-rSg
-rSg
+pYt
+cRP
+cRP
+cRP
 teW
 ajj
 uPa
@@ -435861,8 +436093,8 @@ vrG
 wtl
 ntK
 ntK
-ntK
-lYl
+hai
+xrf
 xrf
 xrf
 ohA
@@ -435870,7 +436102,7 @@ bcN
 bcN
 bcN
 vWe
-ffv
+sNn
 ffv
 fZJ
 fZJ
@@ -436261,10 +436493,10 @@ oBU
 sUQ
 xXs
 ntK
-ntK
-ntK
+dNL
 ntK
 uTT
+swm
 swm
 swm
 wQn
@@ -436662,11 +436894,11 @@ uKB
 aur
 uZa
 cPw
-tOB
+jkm
 ntK
 ntK
-ntK
-vgh
+tak
+ybm
 ybm
 ybm
 ohA
@@ -436674,7 +436906,7 @@ bcN
 bcN
 bcN
 vWe
-ffv
+nJR
 ffv
 fZJ
 fZJ
@@ -437058,7 +437290,7 @@ erZ
 erZ
 fZJ
 fZJ
-cWM
+dSK
 pfp
 sUb
 aur
@@ -437067,16 +437299,16 @@ pLs
 swm
 nyc
 ntK
-ntK
-cAe
-wDZ
-wDZ
+gbA
+rSg
+rSg
+rSg
 teW
 eYI
-vGN
-vGN
-tML
-tML
+uZC
+uZC
+wAm
+wAm
 ffv
 fZJ
 fZJ
@@ -437469,15 +437701,15 @@ oyP
 swm
 nyc
 ntK
-ntK
-tak
-lGI
-lGI
+tUB
+lYl
+lYl
+lYl
 tML
-wjl
-wjl
-wjl
-wAm
+pfG
+pfG
+pfG
+tML
 tML
 tML
 fZJ
@@ -437871,20 +438103,20 @@ tML
 aXE
 nyc
 ntK
-ntK
-eTL
-sNm
-fXz
+rCp
+bPk
+bPk
+mFE
 tML
-ewS
-ewS
-ewS
+rAj
+rAj
+rAj
 wAm
-hKU
-hKU
-lug
-tML
-teW
+wAm
+wAm
+wAm
+wAm
+wAm
 squ
 squ
 squ
@@ -437895,7 +438127,7 @@ squ
 squ
 squ
 rTC
-vnG
+vHd
 squ
 squ
 squ
@@ -438271,7 +438503,7 @@ tML
 teW
 tML
 tML
-aKc
+uHk
 fnF
 tML
 aGb
@@ -438285,7 +438517,7 @@ wpe
 fQd
 eCn
 sNY
-lWz
+vfw
 teW
 teW
 teW
@@ -438297,7 +438529,7 @@ squ
 squ
 squ
 rTC
-vnG
+vHd
 rTC
 rTC
 rTC
@@ -438691,7 +438923,7 @@ eCn
 teW
 aor
 xfh
-ksg
+eLb
 teW
 squ
 squ
@@ -439087,8 +439319,8 @@ cfY
 cfY
 teW
 aTF
-cXK
-nkq
+qye
+vdx
 eCn
 mYi
 gbX
@@ -439489,8 +439721,8 @@ uZy
 cfY
 alk
 eCn
-nMg
-fTD
+nSF
+lsW
 eCn
 mYi
 gbX
@@ -439873,14 +440105,14 @@ erZ
 fZJ
 fZJ
 rxp
-vdd
+auL
 uKB
 uBv
 tML
 tML
 tML
 xnv
-pPt
+hbc
 tML
 rMM
 cfY
@@ -439895,9 +440127,9 @@ eCn
 eCn
 eCn
 teW
-wra
-kbt
-nJy
+fxb
+tiv
+cOS
 teW
 squ
 squ
@@ -440679,8 +440911,8 @@ fZJ
 rxp
 uKB
 uKB
-fsD
-xOd
+vBG
+qUs
 uKB
 nIr
 swm
@@ -441478,14 +441710,14 @@ vIa
 vIa
 aUc
 teW
-vBy
+lCN
 teW
 uKB
 uKB
-gQV
-tfp
-rqu
-qua
+hRM
+cGC
+lbf
+nCo
 tML
 swm
 swm
@@ -441880,10 +442112,10 @@ vIa
 vIa
 aUc
 teW
-hrS
+tXF
 teW
-aYP
-cZz
+mis
+eJL
 tML
 tML
 ydR
@@ -441899,10 +442131,10 @@ idu
 sct
 sNp
 cfY
-wvp
-gMp
-uZC
-jCr
+jpw
+dQw
+pOH
+wos
 eCn
 teW
 lMZ
@@ -442290,21 +442522,21 @@ cgD
 tML
 hqI
 tML
-pjB
+kKo
 swm
 swm
 tML
-irg
+tTl
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-wvp
-hqS
-cjZ
-qjY
+jpw
+xtu
+qtL
+imB
 eCn
 teW
 lMZ
@@ -442698,15 +442930,15 @@ swm
 tML
 rMM
 eVa
-loE
+bLL
 tcW
 tcW
 tcW
 eVa
-yfQ
-aXs
-gYG
-xEI
+pyz
+gdw
+skh
+ghb
 eCn
 teW
 lMZ
@@ -443086,7 +443318,7 @@ vIa
 vIa
 aUc
 teW
-sVh
+nYl
 nMd
 uKB
 uKB
@@ -443095,7 +443327,7 @@ tML
 tML
 tML
 wAm
-pPt
+hbc
 wAm
 wAm
 teW
@@ -443490,14 +443722,14 @@ aUc
 teW
 teW
 teW
-xOd
+qUs
 uKB
 uKB
-lKy
+fZo
 iYx
-omi
-xwi
-xwi
+uEX
+iug
+iug
 teW
 iYx
 iYx
@@ -443892,18 +444124,18 @@ aUc
 lMZ
 lMZ
 teW
-xOd
+qUs
 uKB
 uKB
-tpY
+qKm
 iYx
 vaa
-xwi
-quv
+iug
+dAq
 teW
-itC
-aac
-uHj
+bty
+lhj
+bop
 iYx
 lMZ
 lMZ
@@ -444294,18 +444526,18 @@ vIa
 lAs
 lMZ
 teW
-xOd
+qUs
 uKB
 uKB
-hxv
+mFF
 iYx
-als
-xwi
-xwi
+oxf
+iug
+iug
 teW
-uwf
-xwi
-xwi
+tFq
+iug
+iug
 iYx
 lMZ
 lAs
@@ -444696,18 +444928,18 @@ vIa
 lAs
 lMZ
 teW
-dFV
+aok
 uKB
 uKB
-tFA
+qmo
 iYx
-bUi
-xwi
-xwi
-hpk
-xwi
-xwi
-wAp
+gjr
+iug
+iug
+vCy
+iug
+iug
+hVz
 iYx
 lMZ
 lAs
@@ -445103,13 +445335,13 @@ teW
 teW
 teW
 iYx
-omQ
-xwi
-vsg
+gnI
+iug
+qGj
 iYx
-cXg
-aNU
-tiH
+rOz
+bsL
+oRp
 iYx
 lMZ
 lAs
@@ -445505,9 +445737,9 @@ iYx
 iYx
 iYx
 iYx
-omi
-xwi
-nCB
+uEX
+iug
+qgY
 iYx
 iYx
 iYx
@@ -445904,16 +446136,16 @@ lAs
 lAs
 lMZ
 iYx
-nCB
-oBO
+qgY
+loE
 iYx
 iYx
-xwi
-vsg
+iug
+qGj
 iYx
-itC
-aac
-uHj
+bty
+lhj
+bop
 iYx
 lMZ
 lAs
@@ -446306,16 +446538,16 @@ lAs
 lAs
 lMZ
 iYx
-uwf
-xwi
-aKc
-xwi
-xwi
-xwi
+tFq
+iug
+uHk
+iug
+iug
+iug
 iYx
-uwf
-xwi
-xwi
+tFq
+iug
+iug
 iYx
 lMZ
 lAs
@@ -446708,16 +446940,16 @@ lAs
 lAs
 lMZ
 iYx
-xwi
-xwi
+iug
+iug
 iYx
-xwi
-xwi
-xwi
-hpk
-xwi
-xwi
-wAp
+iug
+iug
+iug
+vCy
+iug
+iug
+hVz
 iYx
 lMZ
 lAs
@@ -447110,16 +447342,16 @@ lAs
 lAs
 lMZ
 iYx
-neN
-tiH
+uSR
+oRp
 iYx
-xwi
-mQr
-wOr
+iug
+jHJ
+kKJ
 iYx
-cXg
-aNU
-tiH
+rOz
+bsL
+oRp
 iYx
 lMZ
 lAs
@@ -447511,18 +447743,18 @@ vIa
 vIa
 vIa
 aUc
-qCT
+iKn
 iYx
 iYx
 iYx
-uEX
+mdt
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-qCT
+iKn
 aUc
 vIa
 vIa
@@ -447916,7 +448148,7 @@ aUc
 aUc
 iYx
 iYx
-mxm
+fAj
 tWY
 tWY
 iyd
@@ -448317,8 +448549,8 @@ vIa
 vIa
 aUc
 iYx
-xNf
-dbH
+tMh
+hXa
 tWY
 tWY
 iyd
@@ -448719,8 +448951,8 @@ vIa
 vIa
 aUc
 iYx
-jEc
-dbH
+ivv
+hXa
 tWY
 tWY
 iyd
@@ -449121,11 +449353,11 @@ vIa
 vIa
 aUc
 iYx
-gmg
-xrs
-vGN
-vGN
-vGN
+vCY
+hAr
+uZC
+uZC
+uZC
 iYx
 iYx
 iYx
@@ -449525,9 +449757,9 @@ aUc
 iYx
 iYx
 iYx
-kEk
-kEk
-bsB
+jEB
+jEB
+xET
 iYx
 lMZ
 lMZ
@@ -451523,16 +451755,16 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
 iyK
 iyK
 iyK
@@ -451924,17 +452156,17 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
 iyK
 iyK
 iyK
@@ -452327,16 +452559,16 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
 iyK
 iyK
 iyK
@@ -452729,16 +452961,16 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
+qRm
 iyK
 iyK
 iyK
@@ -486110,27 +486342,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
-nhR
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+tar
 erZ
 erZ
 erZ
@@ -486512,27 +486744,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-uHk
-ckv
-yiI
-yiI
-yiI
-uHk
-uHk
-uHk
-uHk
-uHk
-aev
-uHk
-yiI
-eqI
-wqv
-fpz
-gyH
-bVa
-gyH
-xyU
+aac
+uGf
+axp
+aac
+aac
+aac
+gnD
+uGf
+uGf
+uGf
+gnD
+rcr
+uGf
+aac
+jtq
+qfJ
+qHy
+htf
+jMf
+htf
+oiW
 erZ
 erZ
 erZ
@@ -486914,27 +487146,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-uHk
-jGj
-yiI
-yiI
-yiI
-uHk
-uHk
-qdN
-qoR
-qoR
-yiI
-uHk
-uFY
-bVa
-bVa
-bVa
-bVa
-bVa
-bVa
-lUO
+aac
+uGf
+kMA
+aac
+aac
+aac
+uGf
+uGf
+hzR
+sEX
+sEX
+aac
+uGf
+sAp
+jMf
+aSD
+jMf
+aSD
+jMf
+jMf
+lOp
 erZ
 erZ
 erZ
@@ -487316,27 +487548,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-uHk
-uHk
-ebe
-yiI
-jpw
-upC
-qGh
-qcc
-yiI
-yiI
-yiI
-aev
-yiI
-cLL
-bVa
-bVa
-bVa
-bVa
-bVa
-vzO
+aac
+uGf
+uGf
+cSB
+aac
+mvx
+ila
+pcQ
+mYI
+aac
+aac
+aac
+rcr
+aac
+ssk
+jMf
+jMf
+jMf
+jMf
+jMf
+ghT
 erZ
 erZ
 erZ
@@ -487718,27 +487950,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-uHk
-uHk
-ebe
-yiI
-vUf
-uHk
-uHk
-fnf
-yiI
-lVX
-uHk
-uHk
-yiI
-mQA
-uDi
-qQD
-bVa
-bVa
-bVa
-xyU
+aac
+uGf
+uGf
+cSB
+aac
+oCS
+uGf
+uGf
+cwd
+aac
+liA
+wFp
+uGf
+aac
+fLK
+lYH
+trg
+jMf
+jMf
+jMf
+oiW
 erZ
 erZ
 erZ
@@ -488120,27 +488352,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-aev
-yiI
-yiI
-yiI
-vUf
-uHk
-uHk
-fnf
-yiI
-wyA
-uHk
-uHk
-nhR
-cjf
-xdw
-vMj
-upu
-bVa
-bVa
-lUO
+aac
+rcr
+aac
+aac
+aac
+oCS
+uGf
+uGf
+cwd
+aac
+wFp
+uGf
+uGf
+tar
+lPG
+akZ
+pML
+uzT
+jMf
+aSD
+lOp
 erZ
 erZ
 erZ
@@ -488521,28 +488753,28 @@ bqt
 bqt
 bqt
 bqt
-yiI
-yiI
-urF
-urF
-xIg
-yiI
-jpw
-hLy
-uHk
-cKp
-yiI
-uHk
-qGh
-uHk
-nhR
+aac
+aac
+ifg
+ifg
+njN
+aac
+mvx
+mQA
+uGf
+jWz
+aac
+uGf
+pcQ
+wFp
+tar
 wQI
-hbc
+mjP
 wQI
-qpY
-bVa
-bVa
-vzO
+pnL
+jMf
+jMf
+ghT
 erZ
 erZ
 erZ
@@ -488923,28 +489155,28 @@ bqt
 bqt
 bqt
 bqt
-yiI
-jpw
-hLy
-uHk
-qcc
-yiI
-vUf
-qGh
-qGh
-fnf
-yiI
-uHk
-uHk
-uHk
-nhR
+aac
+mvx
+mQA
+uGf
+mYI
+aac
+oCS
+pcQ
+pcQ
+cwd
+aac
+uGf
+uGf
+uGf
+tar
 wQI
 wQI
-wQI
-xbW
-bVa
-bVa
-xyU
+vEP
+fab
+jMf
+jMf
+oiW
 erZ
 erZ
 erZ
@@ -489325,28 +489557,28 @@ bqt
 bqt
 bqt
 bqt
-yiI
-vUf
-uHk
-uHk
-fnf
-yiI
-vUf
-uHk
-uHk
-fnf
-yiI
-wyA
-uHk
-wyA
-nhR
-tex
+aac
+oCS
+uGf
+uGf
+cwd
+aac
+oCS
+uGf
+uGf
+cwd
+aac
+uGf
+wFp
+uGf
+tar
+kDh
 wQI
-tex
-fAd
-bVa
-bVa
-lUO
+kDh
+bCb
+jMf
+jMf
+lOp
 erZ
 erZ
 erZ
@@ -489727,28 +489959,28 @@ bqt
 bqt
 bqt
 bqt
-yiI
-htf
-uHk
-urF
-ebe
-yiI
-jpw
-hLy
-uHk
-cKp
-yiI
-lVX
-uHk
-qGh
-yiI
-yiI
-yiI
-yiI
-uDi
-uDi
-uDi
-thr
+aac
+kwN
+uGf
+ifg
+cSB
+aac
+mvx
+mQA
+uGf
+jWz
+aac
+liA
+uGf
+pcQ
+aac
+aac
+aac
+aac
+mPb
+mPb
+mPb
+avq
 erZ
 erZ
 erZ
@@ -490129,24 +490361,24 @@ bqt
 bqt
 bqt
 bqt
-yiI
-yjP
-hLy
-uHk
-qdN
-yiI
-htf
-uHk
-uHk
-ebe
-yiI
-uHk
-qGh
-uHk
-eJE
-uHk
-wyA
-bBR
+aac
+qZr
+mQA
+uGf
+hzR
+aac
+kwN
+uGf
+uGf
+cSB
+aac
+uGf
+pcQ
+uGf
+uGf
+uGf
+iwj
+eoz
 erZ
 erZ
 erZ
@@ -490531,24 +490763,24 @@ bqt
 bqt
 bqt
 bqt
-yiI
-vox
-hLy
-uHk
-qcc
-yiI
-vUf
-uHk
-uHk
-fnf
-yiI
-eJE
-uHk
-uHk
-uHk
-oLS
-kYz
-kJf
+aac
+dpd
+mQA
+uGf
+mYI
+aac
+oCS
+uGf
+uGf
+cwd
+aac
+uGf
+uGf
+uGf
+uGf
+qUD
+iWj
+eoz
 erZ
 erZ
 erZ
@@ -490933,24 +491165,24 @@ bqt
 bqt
 bqt
 bqt
-yiI
-htf
-urF
-uHk
-fnf
-yiI
-jpw
-hLy
-uHk
-cKp
-yiI
-wyA
-uHk
-qGh
-uHk
-mTP
-seC
-dEf
+aac
+kwN
+ifg
+uGf
+cwd
+aac
+mvx
+mQA
+uGf
+jWz
+aac
+uGf
+uGf
+pcQ
+uGf
+iwj
+dUF
+kdz
 erZ
 erZ
 erZ
@@ -491335,24 +491567,24 @@ bqt
 bqt
 bqt
 bqt
-yiI
-vUf
-uHk
-uHk
-ebe
-yiI
-ebe
-qGh
-qGh
-fnf
-yiI
-lVX
-eJE
-uHk
-uHk
-mTP
-sRT
-fEZ
+aac
+oCS
+uGf
+uGf
+cSB
+aac
+cSB
+pcQ
+pcQ
+cwd
+aac
+liA
+uGf
+uGf
+uGf
+iwj
+iWj
+eoz
 erZ
 erZ
 erZ
@@ -491737,24 +491969,24 @@ bqt
 bqt
 bqt
 bqt
-yiI
-jpw
-hLy
-uHk
-xud
-xud
-xud
-uHk
-uHk
-xud
-xud
-qGh
-uHk
-eJE
-eJE
-mTP
-sRT
-fEZ
+aac
+mvx
+mQA
+uGf
+xpM
+xpM
+xpM
+uGf
+uGf
+xpM
+xpM
+pcQ
+uGf
+uGf
+kxw
+ewU
+iWj
+eoz
 erZ
 erZ
 erZ
@@ -492139,24 +492371,24 @@ bqt
 bqt
 bqt
 bqt
-yiI
-vUf
-urF
-uHk
-dEk
-yiI
-goz
-hLy
-uHk
-mIn
-yiI
-lVX
-qGh
-uHk
-wyA
-qcb
-qcb
-ipr
+aac
+oCS
+ifg
+uGf
+erB
+aac
+nJy
+mQA
+uGf
+csg
+aac
+liA
+pcQ
+uGf
+uGf
+uGf
+ewU
+eoz
 erZ
 erZ
 erZ
@@ -492541,27 +492773,27 @@ bqt
 bqt
 bqt
 bqt
-yiI
-vUf
-uHk
-urF
-uHk
-aev
-uHk
-uHk
-uHk
-yiI
-yiI
-yiI
-yiI
-yiI
-lVX
-uHk
-uHk
+aac
+oCS
+uGf
+ifg
+uGf
+rcr
+uGf
+uGf
+uGf
+aac
+aac
+aac
+aac
+aac
+oBZ
+uGf
+uGf
 uLh
 uLh
-riW
-pOq
+leM
+cld
 uLh
 erZ
 erZ
@@ -492943,29 +493175,29 @@ bqt
 bqt
 bqt
 bqt
-yiI
-hiY
-hLy
-uHk
-rnn
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
+aac
+pYW
+mQA
+uGf
+oza
+aac
+aac
+aac
+aac
+aac
+aac
 bqt
 bqt
-yiI
-uHk
-uHk
-wyA
+aac
+uGf
+wFp
+wFp
 uLh
-kOA
-rgO
-mjP
+jPD
+tCz
+qdC
 uLh
-diq
+nOR
 erZ
 erZ
 erZ
@@ -493345,12 +493577,12 @@ bqt
 bqt
 bqt
 bqt
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
+aac
+aac
+aac
+aac
+aac
+aac
 bqt
 bqt
 bqt
@@ -493358,17 +493590,17 @@ bqt
 bqt
 bqt
 bqt
-yiI
-wyA
-uHk
-uHk
-ndQ
-rgO
-rgO
-rPa
-pOq
-rgO
-rgO
+aac
+uGf
+uGf
+uGf
+avi
+tCz
+tCz
+fIs
+cld
+tCz
+tCz
 erZ
 erZ
 erZ
@@ -493750,9 +493982,9 @@ bqt
 bqt
 bqt
 bqt
-yiI
-yiI
-yiI
+aac
+aac
+aac
 bqt
 bqt
 bqt
@@ -493760,17 +493992,17 @@ bqt
 bqt
 bqt
 bqt
-yiI
-wyA
-uHk
-uHk
-ndQ
-rgO
-rgO
-rgO
-ndQ
-rgO
-rgO
+aac
+uGf
+uGf
+uGf
+avi
+tCz
+tCz
+tCz
+avi
+tCz
+tCz
 erZ
 erZ
 erZ
@@ -494162,17 +494394,17 @@ bqt
 bqt
 bqt
 bqt
-yiI
-lVX
-uHk
-uHk
-ndQ
-rgO
-rgO
-rgO
-pOq
-rgO
-rgO
+aac
+liA
+wFp
+uGf
+avi
+tCz
+tCz
+tCz
+cld
+tCz
+tCz
 erZ
 erZ
 erZ
@@ -494529,7 +494761,7 @@ vIa
 erZ
 erZ
 erZ
-erZ
+bqt
 lgg
 lgg
 lgg
@@ -494564,16 +494796,16 @@ bqt
 bqt
 bqt
 bqt
-yiI
-rac
-uHk
-uHk
+aac
+wra
+nke
+uGf
 uLh
-ebb
-rgO
-rgO
+htv
+tCz
+tCz
 uLh
-diq
+nOR
 erZ
 erZ
 erZ
@@ -494960,21 +495192,21 @@ vIa
 vIa
 aUc
 bqt
-yiI
-jsF
-jsF
-jsF
-jsF
-jsF
-jsF
-jsF
-uFp
-uFp
+aac
+oIC
+oIC
+oIC
+oIC
+oIC
+oIC
+oIC
+rRD
+rRD
 uLh
 uLh
-hZE
-hZE
-ign
+wYp
+wYp
+tzn
 erZ
 erZ
 erZ
@@ -496983,14 +497215,14 @@ erZ
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -497380,19 +497612,19 @@ erZ
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -497782,24 +498014,24 @@ erZ
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -498184,24 +498416,24 @@ erZ
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -498584,26 +498816,26 @@ sri
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -498986,26 +499218,26 @@ sri
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -499388,26 +499620,26 @@ sri
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -499790,26 +500022,26 @@ erZ
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -500192,26 +500424,26 @@ erZ
 erZ
 erZ
 erZ
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -500594,7 +500826,7 @@ erZ
 erZ
 erZ
 erZ
-qKU
+uDi
 iJC
 bOK
 nEd
@@ -500602,18 +500834,18 @@ nEd
 nEd
 bOK
 iJC
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -500996,7 +501228,7 @@ erZ
 erZ
 erZ
 erZ
-qKU
+uDi
 bOK
 fVQ
 fVQ
@@ -501004,18 +501236,18 @@ bmG
 fVQ
 fVQ
 bOK
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -501398,7 +501630,7 @@ erZ
 erZ
 erZ
 erZ
-qKU
+uDi
 nEd
 fVQ
 lgN
@@ -501406,18 +501638,18 @@ jJC
 lgN
 fVQ
 nEd
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -501800,7 +502032,7 @@ erZ
 erZ
 erZ
 erZ
-qKU
+uDi
 nEd
 fVQ
 qxZ
@@ -501814,12 +502046,12 @@ vxC
 vxC
 vxC
 ppx
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -502202,7 +502434,7 @@ erZ
 erZ
 erZ
 erZ
-qKU
+uDi
 nEd
 fVQ
 fVQ
@@ -502216,12 +502448,12 @@ fZJ
 fZJ
 fZJ
 kZS
-qKU
-qKU
-qKU
-qKU
-qKU
-qKU
+uDi
+uDi
+uDi
+uDi
+uDi
+uDi
 erZ
 erZ
 erZ
@@ -536776,7 +537008,7 @@ eZN
 rFc
 hjt
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -537179,7 +537411,7 @@ pur
 udS
 udS
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -537580,7 +537812,7 @@ miM
 rFc
 hjt
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -542794,11 +543026,11 @@ qzV
 nLH
 pil
 aqS
-qTb
+xbW
 fCM
 fCM
 fCM
-pur
+rgO
 fCM
 nQU
 cGD
@@ -543587,8 +543819,8 @@ vIa
 vIa
 vIa
 vIa
-cCS
-cCS
+qYw
+qYw
 lAs
 woj
 qPA
@@ -543989,8 +544221,8 @@ vIa
 vIa
 vIa
 vIa
-cCS
-cCS
+qYw
+qYw
 lAs
 woj
 qPA
@@ -544391,8 +544623,8 @@ vIa
 vIa
 vIa
 vIa
-cCS
-cCS
+qYw
+qYw
 lAs
 woj
 qPA
@@ -544793,8 +545025,8 @@ vIa
 vIa
 vIa
 vIa
-cCS
-cCS
+qYw
+qYw
 lAs
 eJN
 bHY
@@ -545195,8 +545427,8 @@ vIa
 vIa
 vIa
 vIa
-cCS
-cCS
+qYw
+qYw
 lAs
 lAs
 lAs
@@ -545597,7 +545829,7 @@ vIa
 vIa
 vIa
 vIa
-cCS
+qYw
 vIa
 vIa
 vIa
@@ -545999,7 +546231,7 @@ vIa
 vIa
 vIa
 vIa
-cCS
+qYw
 vIa
 vIa
 vIa
@@ -546401,7 +546633,7 @@ vIa
 vIa
 vIa
 vIa
-cCS
+qYw
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,8 +7,12 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/stairs{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -495,16 +499,19 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/effect/decal/cobbleedge{
+	dir = 10
 	},
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -982,8 +989,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "adK" = (
-/turf/closed/mineral/rogue,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "adL" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt/road{
@@ -1137,35 +1149,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "aev" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"aew" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1250,12 +1240,6 @@
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"aha" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "ahH" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -1276,6 +1260,14 @@
 "ahY" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter/mountains)
+"aiu" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "aiH" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -1285,6 +1277,16 @@
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"aiR" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"aiZ" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "ajj" = (
 /obj/structure/statue/saints/father,
@@ -1336,13 +1338,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"akO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "alk" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -1351,12 +1346,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"alw" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "alL" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt/road{
@@ -1410,16 +1399,16 @@
 /obj/structure/statue/saints/knight_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"anR" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "aok" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1510,13 +1499,6 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"asR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "atx" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/church,
@@ -1527,6 +1509,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"atE" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "atM" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -1568,8 +1554,10 @@
 	})
 "auL" = (
 /obj/structure/fluff/railing/border{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "auQ" = (
@@ -1589,6 +1577,13 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town)
+"avO" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "avQ" = (
 /obj/structure/bars/grille,
@@ -1670,30 +1665,36 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"axV" = (
-/obj/structure/gate/bars{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "axW" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"ayc" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ayi" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1776,23 +1777,16 @@
 "aBh" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
-"aBG" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH6";
-	name = "WH Lever 6"
+"aBW" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"aCa" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aCv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
@@ -1817,6 +1811,17 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"aDD" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1882,14 +1887,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"aFc" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "aFk" = (
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -1907,14 +1904,6 @@
 "aGb" = (
 /obj/structure/bars,
 /turf/closed/wall/mineral/rogue/stone/window,
-/area/rogue/indoors/town/church/chapel)
-"aGc" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/closed,
 /area/rogue/indoors/town/church/chapel)
 "aGO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
@@ -1979,6 +1968,9 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"aIl" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "aIx" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/closet/crate/roguecloset,
@@ -2065,10 +2057,6 @@
 "aKu" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/bath)
-"aKz" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "aKH" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/dirt/road{
@@ -2143,11 +2131,23 @@
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
+"aNu" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "aNE" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
 	},
+/area/rogue/indoors/town)
+"aNG" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "aNN" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -2218,15 +2218,11 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
 	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/area/rogue/outdoors/rtfield)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2300,12 +2296,17 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"aSD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+"aSo" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
-/turf/open/floor/rogue/churchrough,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"aSD" = (
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -2410,23 +2411,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"aWh" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"aWt" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH7";
-	name = "WH Lever 7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "aWO" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -2434,6 +2422,11 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"aWQ" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "aXa" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/cobble,
@@ -2451,6 +2444,16 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
+"aXv" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "aXx" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /obj/structure/spacevine,
@@ -2491,22 +2494,16 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"aYC" = (
-/obj/structure/chair/wood/rogue/chair3{
+"aZg" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
-"aYG" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "aZj" = (
 /obj/structure/table/vtable,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -2535,6 +2532,13 @@
 "bau" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
+"bay" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "baE" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -2555,10 +2559,6 @@
 	dir = 10
 	},
 /area/rogue/indoors/town/manor)
-"bbG" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "bbO" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
@@ -2579,13 +2579,6 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
-"bdw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "bdB" = (
 /obj/structure/statue/saints/knight,
 /turf/open/floor/rogue/blocks,
@@ -2620,15 +2613,6 @@
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"bep" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "beA" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -2673,15 +2657,6 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"bgb" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "bge" = (
 /obj/structure/roguemachine/wizardvend,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2737,16 +2712,6 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"bib" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH5"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2830,12 +2795,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
-"bkL" = (
-/obj/structure/stationary_bell{
-	name = "Bell of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -2865,6 +2824,12 @@
 	icon_state = "roof"
 	},
 /area/rogue/outdoors/mountains)
+"bmc" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bmd" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt/road{
@@ -2876,6 +2841,19 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"bmj" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"bmk" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bmu" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road{
@@ -2889,9 +2867,20 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
+"bmO" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -3054,8 +3043,10 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors/town/garrison)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3087,10 +3078,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"brj" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "brp" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/twig{
@@ -3270,13 +3257,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"bwb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
 "bwc" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/rogue/cobble,
@@ -3315,11 +3295,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town)
-"bwP" = (
-/obj/structure/roguewindow,
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/mountains)
 "bwS" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
@@ -3407,12 +3382,17 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/structure/roguemachine/scomm/l{
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3429,6 +3409,16 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"bzU" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bAi" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell2";
@@ -3462,10 +3452,20 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"bBs" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+"bBc" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
+"bBo" = (
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "bBu" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -3482,8 +3482,14 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
@@ -3536,6 +3542,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"bEJ" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "bEL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -3583,6 +3596,10 @@
 "bFU" = (
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"bFX" = (
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bGg" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
@@ -3624,15 +3641,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/structure/rack/rogue,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3721,17 +3732,16 @@
 /obj/item/roguekey/roomhunt,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
-"bLe" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
+"bKE" = (
+/obj/structure/closet/crate/chest/reward,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bLa" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "bLf" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -3747,12 +3757,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"bMe" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "bMh" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/dirt,
@@ -3835,27 +3839,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bPz" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
-"bPH" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3996,20 +3985,26 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/stairs{
-	dir = 4
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
-"bVa" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"bVa" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
+"bVe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4071,13 +4066,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
-"bXL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "bXS" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -4104,6 +4092,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"bYy" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bYA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4146,15 +4142,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"bZo" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "bZB" = (
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/grass,
@@ -4162,6 +4149,16 @@
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"bZX" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "caS" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/cobble,
@@ -4250,7 +4247,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cdA" = (
 /obj/structure/bars/passage{
@@ -4262,6 +4263,11 @@
 /obj/structure/table/vtable/v2,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
+"cdQ" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cev" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/ruinedwood{
@@ -4284,10 +4290,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"cfb" = (
-/obj/structure/chair/bench/church/smallbench,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "cfw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4444,23 +4446,19 @@
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cjI" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+"cjy" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "cjJ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4512,13 +4510,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4526,13 +4520,6 @@
 	name = "Temple of the One"
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
-"cly" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/church/chapel)
 "clA" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -4563,6 +4550,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"cmQ" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cna" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -4698,15 +4691,6 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"cqJ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "crx" = (
 /obj/structure/statue/saints/noble3_l,
 /turf/open/floor/rogue/grass,
@@ -4734,17 +4718,18 @@
 "csk" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/indoors)
+"csm" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "csr" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"csw" = (
-/obj/structure/table/wood{
-	dir = 2;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "csA" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck{
 	tame = 1
@@ -4788,6 +4773,12 @@
 "cue" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"cuh" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "cur" = (
 /obj/structure/bed/rogue/inn/pileofshit,
 /turf/open/floor/carpet/royalblack,
@@ -4830,15 +4821,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4"
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4942,13 +4931,13 @@
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"cye" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"cyy" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "czb" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
@@ -5092,15 +5081,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/item/storage/backpack/rogue/backpack/surgery,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "cBW" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/tribalfort)
@@ -5136,15 +5118,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "BASEMENT"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5178,12 +5158,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cEr" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "cEv" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/single,
@@ -5257,6 +5231,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"cGQ" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cGX" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -5295,6 +5273,10 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"cHY" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "cIa" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/shop)
@@ -5338,26 +5320,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"cJi" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "cJz" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/dwarfin)
-"cJR" = (
-/obj/structure/chair/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "cKj" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -5411,10 +5377,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5432,7 +5399,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "cMO" = (
@@ -5489,16 +5459,6 @@
 "cNY" = (
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/manor)
-"cOn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "cOz" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -5511,6 +5471,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"cOS" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
@@ -5532,15 +5499,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"cPr" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "cPw" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -5581,6 +5539,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"cQP" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cQY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/dirt/road{
@@ -5605,14 +5567,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1;
@@ -5667,6 +5625,12 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"cSR" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "cTr" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -5686,17 +5650,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors)
-"cTT" = (
-/obj/structure/table/wood,
-/obj/structure/bars/passage/shutter{
-	redstone_id = "feedingline"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "cTY" = (
 /obj/structure/fluff/walldeco/wantedposter/r,
 /turf/open/floor/rogue/cobble,
@@ -5707,6 +5660,15 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"cUj" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "cUu" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -5761,10 +5723,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"cVu" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "cVK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -5810,6 +5768,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"cWS" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "cWT" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/rtfield)
@@ -5911,25 +5873,12 @@
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"cZN" = (
-/obj/item/rogueweapon/mace/goden,
-/obj/item/rogueweapon/mace/goden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"cZx" = (
+/obj/machinery/anvil{
+	pixel_x = -1
 	},
-/area/rogue/indoors/town/garrison)
-"dad" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "dap" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ammo_casing/caseless/rogue/bullet,
@@ -5970,25 +5919,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
-"dbB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "dbH" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -6015,14 +5952,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"dcq" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "dcw" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/churchrough,
@@ -6068,6 +5997,10 @@
 /obj/item/storage/box/matches,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"dcU" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dcV" = (
 /obj/structure/closet/crate/chest,
 /obj/item/ingot/copper,
@@ -6075,10 +6008,6 @@
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"dcZ" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "ddl" = (
 /obj/machinery/light/rogue/torchholder,
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
@@ -6184,16 +6113,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"dgS" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison";
-	name = "Southwest Tower"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "dhg" = (
 /obj/structure/roguewindow/stained/yellow,
 /turf/closed/wall/mineral/rogue/decostone/long{
@@ -6225,16 +6144,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"dhJ" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "dhK" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -6251,6 +6160,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"diu" = (
+/obj/machinery/light/rogue/smelter,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "diA" = (
 /mob/living/simple_animal/hostile/mushroom{
 	faction = list("undead")
@@ -6328,15 +6241,15 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"dkD" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+"dkw" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/item/dice,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "dkI" = (
 /obj/structure/fermenting_barrel,
@@ -6421,21 +6334,6 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
-"dnc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "dnf" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
 /area/rogue/indoors/town/manor)
@@ -6457,13 +6355,16 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter)
-"dof" = (
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/huntingknife,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"dol" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "doK" = (
 /obj/structure/bars,
 /obj/machinery/light/rogue/torchholder{
@@ -6573,6 +6474,13 @@
 /obj/item/clothing/suit/roguetown/shirt/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"dsq" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "dsr" = (
 /obj/structure/statue/saints/cephine{
 	desc = "Her radiant angel that shall serve as our guiding light during end times."
@@ -6602,6 +6510,10 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
+"dtf" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dth" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
@@ -6676,6 +6588,13 @@
 "dwl" = (
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"dwu" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dwK" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -6689,9 +6608,15 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6763,12 +6688,7 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "dAk" = (
 /obj/structure/bars/pipe{
@@ -6790,13 +6710,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"dAG" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "dBk" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/grass,
@@ -6831,17 +6744,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
-"dCX" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"dDc" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "dDf" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -6882,15 +6784,15 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"dFg" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+"dFa" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "dFq" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -6920,11 +6822,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"dFY" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "dGb" = (
 /obj/machinery/light/rogue/lanternpost{
 	pixel_x = 15
@@ -6950,6 +6847,14 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"dGv" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dGG" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6971,25 +6876,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
-"dHx" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "dHC" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "dHZ" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
-"dIj" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "dIo" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
 	dir = 1;
@@ -7024,6 +6916,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
+"dJz" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "dJO" = (
 /turf/open/floor/rogue/twig{
 	dir = 4
@@ -7035,17 +6934,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"dKU" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "dKV" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/herringbone,
@@ -7128,10 +7016,23 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"dNz" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dNL" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
 /area/rogue/outdoors/mountains)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
@@ -7245,6 +7146,14 @@
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"dQi" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dQp" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/clinic,
@@ -7300,25 +7209,17 @@
 /obj/item/rogueweapon/greatsword,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
-"dRp" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
+"dSi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
-"dSd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/area/rogue/under/cave)
 "dSo" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
@@ -7368,19 +7269,10 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"dTy" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH1"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "dTB" = (
 /obj/structure/table/wood,
 /obj/item/ingot/steel,
@@ -7422,13 +7314,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/exposed)
-"dTZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "dUk" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
@@ -7446,6 +7331,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dUD" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "dUY" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood{
@@ -7486,10 +7375,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"dWu" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
 "dWG" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -7599,16 +7484,16 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "ebe" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7618,11 +7503,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/rtfield)
-"ebC" = (
-/obj/structure/table/vtable,
-/obj/item/clothing/mask/cigarette/pipe/westman,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+"ebt" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ebG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -7708,12 +7592,6 @@
 /obj/item/ingot/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"eda" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "edc" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
@@ -7906,6 +7784,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"eil" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "eit" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -8008,17 +7890,6 @@
 "els" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"elx" = (
-/obj/structure/gate/bars{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
-"ema" = (
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "emp" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road{
@@ -8094,6 +7965,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"enF" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "enI" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -8133,8 +8008,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "eoA" = (
 /turf/open/water/swamp/deep,
@@ -8167,10 +8042,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"eqh" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "eqt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -8180,12 +8051,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"eqw" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eqy" = (
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
@@ -8276,18 +8141,6 @@
 "esR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
-"etc" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
-	name = "Daupie"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "ete" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/rogue/firebowl/stump,
@@ -8319,14 +8172,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"etX" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "euc" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples2,
 /turf/open/floor/rogue/dirt,
@@ -8414,6 +8259,12 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ewf" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "ewq" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjailr"
@@ -8424,6 +8275,17 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"ewu" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "ewB" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
@@ -8440,9 +8302,18 @@
 /obj/structure/pillory/town_square/reinforced,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
+"exq" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "exG" = (
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
+"exJ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "exP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -8490,23 +8361,18 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/item/rogue/instrument/drum,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"ezu" = (
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/garrison)
 "ezv" = (
 /obj/machinery/light/rogue/wallfire,
 /turf/closed/wall/mineral/rogue/decowood,
@@ -8515,25 +8381,18 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
-"eAs" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"eAP" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "eAW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8626,6 +8485,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
+"eEp" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "eEy" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
@@ -8638,13 +8503,6 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"eES" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "eEU" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -8683,14 +8541,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
-"eFI" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "eFO" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -8706,6 +8556,12 @@
 /obj/item/signal_horn,
 /obj/item/signal_horn,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"eGy" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "eGD" = (
 /obj/item/natural/stone,
@@ -8759,10 +8615,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"eHF" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+"eHv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eHU" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8791,18 +8653,17 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"eIH" = (
-/obj/structure/fluff/railing/wood{
+"eIr" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"eIC" = (
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "eIK" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -8854,43 +8715,23 @@
 /obj/structure/statue/saints/lady_l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"eJX" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"eJZ" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "eKa" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
+"eKb" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "eKe" = (
 /obj/structure/bars/pipe{
 	dir = 8
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"eKj" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "eKP" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
@@ -8931,25 +8772,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"eMm" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "eMz" = (
 /obj/structure/flora/rock,
 /turf/open/water/river,
 /area/rogue/outdoors/vikingarea)
-"eMC" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "eMI" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
@@ -8992,15 +8818,6 @@
 "eOg" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter)
-"eOt" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "eOR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop/green{
@@ -9013,6 +8830,12 @@
 	lockid = "priest"
 	},
 /turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
+"ePv" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
 /area/rogue/indoors/town/church/chapel)
 "ePQ" = (
 /turf/open/floor/rogue/dirt/road{
@@ -9046,18 +8869,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"eRc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "eRi" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -9087,6 +8898,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"eSj" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "eSl" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -9106,16 +8925,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
@@ -9126,10 +8940,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
-"eSH" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 8
@@ -9144,13 +8954,6 @@
 "eTw" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"eTE" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "eTM" = (
 /obj/structure/stairs/fancy/c{
 	dir = 1
@@ -9169,12 +8972,12 @@
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
-"eUi" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH5";
-	name = "WH Lever 5"
-	},
-/turf/open/floor/rogue/herringbone,
+"eUt" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "eUw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -9251,13 +9054,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/cavewet/bogcaves)
-"eVP" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "eVS" = (
 /obj/structure/fluff/wallclock/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -9291,12 +9087,6 @@
 "eWl" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
-"eWs" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
 "eWM" = (
 /obj/machinery/light/rogue/chand,
 /obj/effect/landmark/start/jester{
@@ -9325,6 +9115,12 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
+"eYG" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eYI" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora1";
@@ -9383,8 +9179,16 @@
 /obj/structure/stationary_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"faD" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+"eZX" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"far" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "faE" = (
@@ -9427,6 +9231,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"fcf" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fco" = (
 /obj/structure/statue/saints/martyr2,
 /turf/open/floor/rogue/blocks,
@@ -9556,6 +9364,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"ffN" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "fgl" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
@@ -9604,6 +9421,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"fhK" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fhN" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
@@ -9739,10 +9568,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"fmV" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "fnc" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -9771,6 +9596,16 @@
 "fnA" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
+"fnD" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "fnF" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -9800,6 +9635,14 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
+"foQ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "foS" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/roomiv{
@@ -9820,17 +9663,6 @@
 /obj/structure/statue/saints/cephine2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"fpk" = (
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "fpQ" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/tribalguard,
@@ -9867,6 +9699,12 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/town/basement)
+"frp" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town)
 "frB" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/exposed)
@@ -9884,10 +9722,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"fsm" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -9927,6 +9761,18 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
+"ftE" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ftF" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks,
@@ -9980,15 +9826,20 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"fvl" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "fvr" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"fvS" = (
-/obj/structure/flora/tree/crystal{
-	name = "Drained Bough"
-	},
-/turf/open/floor/rogue/grass,
+"fvW" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "fwp" = (
 /obj/structure/bars,
@@ -10002,16 +9853,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"fwK" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "fwL" = (
 /obj/item/rogueweapon/hammer{
 	color = gold;
@@ -10029,9 +9870,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"fwP" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "fwR" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/rack/rogue/shelf/big,
@@ -10053,6 +9891,11 @@
 "fxx" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"fxA" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "fxK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
@@ -10092,15 +9935,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"fyv" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fyA" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -10134,6 +9968,12 @@
 "fzQ" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"fzR" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fzS" = (
 /obj/effect/landmark/start/farmer{
 	dir = 8
@@ -10196,18 +10036,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors)
-"fBj" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/obj/item/clothing/suit/roguetown/armor/leather/hide,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fBp" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
@@ -10217,10 +10045,6 @@
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"fBz" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "fBF" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -10288,9 +10112,18 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/obj/structure/roguewindow,
-/turf/closed,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"fDD" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -10299,14 +10132,12 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
-"fDR" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+"fEa" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "fEo" = (
 /obj/item/rogueweapon/woodstaff/wise{
 	color = gold;
@@ -10343,12 +10174,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"fEX" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "fFq" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
@@ -10462,17 +10287,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
-"fIW" = (
-/obj/structure/mineral_door/wood{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fIY" = (
 /obj/item/paper,
 /obj/item/paper,
@@ -10490,6 +10304,12 @@
 /obj/item/rogue/instrument/accord,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fJl" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fJM" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/sewer)
@@ -10512,6 +10332,20 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"fKs" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
+"fKy" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "fKC" = (
 /turf/open/water/river{
 	dir = 1;
@@ -10529,14 +10363,6 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
-"fLr" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "fLt" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -10546,11 +10372,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10581,14 +10407,6 @@
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"fNz" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/mountains)
 "fOo" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -10614,6 +10432,13 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
+"fPi" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "fPm" = (
 /turf/open/floor/rogue/dirt/road{
@@ -10675,11 +10500,16 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10715,33 +10545,20 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"fRl" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable_mid"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "fRo" = (
 /obj/structure/stairs{
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/tribalfort)
-"fRp" = (
-/obj/structure/closet/crate/chest,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
 "fRt" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"fRy" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fRC" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/effect/landmark/start/prince,
@@ -10771,9 +10588,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"fSe" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/indoors/town)
 "fSk" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -10813,13 +10627,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"fTX" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
+"fTV" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
 	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fUc" = (
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10884,19 +10699,32 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"fWa" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fWh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"fWp" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "fWA" = (
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/blocks,
@@ -10945,11 +10773,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"fYb" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "fYj" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -11023,14 +10846,9 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "gbN" = (
 /obj/structure/statue/saints/knight2,
 /turf/open/floor/rogue/blocks,
@@ -11046,6 +10864,13 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/church/chapel)
+"gcf" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "gch" = (
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/town/basement)
@@ -11054,18 +10879,6 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"gcs" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "gcw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/wood,
@@ -11081,6 +10894,10 @@
 "gdc" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/exposed)
+"gds" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gdv" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/under/cavewet/bogcaves)
@@ -11142,6 +10959,16 @@
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves)
+"gff" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gfl" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
@@ -11199,10 +11026,13 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "giR" = (
 /obj/structure/table/wood,
@@ -11308,6 +11138,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"glV" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "gmc" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -11370,49 +11209,23 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
+"gog" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "goK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"goP" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"goR" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"gpb" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "gpe" = (
 /obj/structure/bed/rogue,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -11427,6 +11240,10 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
+"gpA" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "gpP" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -11446,24 +11263,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"gqb" = (
-/obj/structure/gate/bars{
-	gid = "viking1";
-	redstone_id = "viking1"
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "gqc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"gqo" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -11526,6 +11329,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"gtr" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "gtx" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -11584,12 +11394,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "gvi" = (
-/obj/structure/fluff/railing/fence{
-	dir = 1;
-	icon_state = "fence"
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11610,14 +11419,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"gvZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/item/book/granter/trait/war/undying,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "gwd" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -11631,12 +11432,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
-"gww" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "gwC" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -11644,20 +11439,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"gwF" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "gwJ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -11710,23 +11491,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"gxP" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "gye" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -11775,12 +11539,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"gzY" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "gAc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -11839,18 +11597,20 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"gBS" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "gBZ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"gCr" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "gCA" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/church,
@@ -11908,15 +11668,6 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
-"gEF" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "gEI" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -12007,10 +11758,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
-"gHn" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "gHt" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -12231,12 +11978,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"gOu" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "gOv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -12259,11 +12000,6 @@
 "gPy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor)
-"gPF" = (
-/obj/structure/fluff/dryingrack,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "gPI" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -12385,6 +12121,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"gSA" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "gSG" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -12513,10 +12256,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"gXf" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "gXr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -12568,10 +12307,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"gZn" = (
-/obj/structure/handcart,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "gZr" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -12645,8 +12380,16 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
+"hbi" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town)
 "hby" = (
 /obj/structure/stairs{
@@ -12672,14 +12415,6 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"hcc" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "hcg" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/mountains)
@@ -12739,6 +12474,14 @@
 /obj/structure/crabnest,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"hcT" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "hcU" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cobbleedge{
@@ -12802,14 +12545,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"hea" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hec" = (
 /obj/structure/mineral_door/wood{
 	lockid = "roomii";
@@ -12837,12 +12572,6 @@
 /area/rogue/indoors/town/dwarfin)
 "hew" = (
 /turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/rtfield)
-"heM" = (
-/obj/structure/well/fountain{
-	pixel_x = -14
-	},
-/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "heV" = (
 /obj/structure/table/church/m,
@@ -12886,15 +12615,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/basement)
-"hfA" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "hfI" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
@@ -12980,14 +12700,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hhY" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "hiz" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"hiA" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "hiI" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -13023,14 +12743,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/town/roofs)
-"hju" = (
-/obj/structure/chair/bench,
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = 5;
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "hjv" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -13145,14 +12857,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"hmr" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/clothing/neck/roguetown/psicross/silver,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "hmz" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -13233,6 +12937,17 @@
 /obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"hnL" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "hnN" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -13362,6 +13077,13 @@
 /obj/structure/statue/saints/knight,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"hqZ" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hra" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -13370,10 +13092,28 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"hrf" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"hsd" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hsg" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/churchrough,
@@ -13385,14 +13125,22 @@
 "hsn" = (
 /turf/open/water/swamp,
 /area/rogue/indoors)
+"hsp" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "hsw" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"hsF" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hsQ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/dirt/road{
@@ -13405,13 +13153,9 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
@@ -13424,12 +13168,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"htG" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "htU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -13489,12 +13227,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"hvB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "hvH" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/purple,
@@ -13575,14 +13307,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"hzI" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -13611,6 +13335,15 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"hAx" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "hAC" = (
 /obj/structure/bars,
 /turf/open/water/river{
@@ -13666,6 +13399,13 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"hCW" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hDm" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
@@ -13737,6 +13477,19 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hFp" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "hFM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/ravager,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13754,11 +13507,14 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hGE" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13807,6 +13563,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"hIn" = (
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "hIr" = (
 /obj/structure/stairs{
 	dir = 1
@@ -13873,14 +13633,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"hKN" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -13926,10 +13678,10 @@
 /obj/effect/rune,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
-"hMe" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+"hMb" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "hMD" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -13952,10 +13704,6 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
-"hNB" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "hND" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
@@ -13963,6 +13711,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"hNE" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "hNF" = (
 /obj/structure/stairs{
 	dir = 1
@@ -13986,11 +13740,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"hOb" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "hOh" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
@@ -14017,10 +13766,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
-"hON" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "hOP" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /obj/structure/spider/stickyweb,
@@ -14070,6 +13815,21 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"hQz" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
+"hQD" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hQE" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -14103,14 +13863,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
-"hRk" = (
-/obj/item/cooking/pan,
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "hRl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -14152,15 +13904,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town)
-"hSs" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "hSz" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14244,6 +13987,15 @@
 /obj/item/dice,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"hWr" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "hWK" = (
 /obj/structure/fluff/statue/knight/interior,
 /obj/structure/spacevine,
@@ -14285,6 +14037,12 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cave)
+"hYo" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hYB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -14306,10 +14064,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"hYH" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "hYU" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road{
@@ -14340,11 +14094,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"hZP" = (
-/obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "hZV" = (
 /obj/structure/roguemachine/mail/l{
 	pixel_x = 0
@@ -14395,13 +14144,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"ibw" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "ibW" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -14437,6 +14179,10 @@
 "icO" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town)
+"icP" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "icU" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave)
@@ -14532,7 +14278,6 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "ifq" = (
@@ -14557,10 +14302,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"igh" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"ifS" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
+"igd" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "igq" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -14571,28 +14324,10 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"igT" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"ihk" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
+"ihj" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"ihm" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "iho" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -14623,6 +14358,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"iie" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "iim" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -14635,10 +14374,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"iir" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "iiH" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/cobble/mossy,
@@ -14689,19 +14424,16 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/item/dice{
-	pixel_y = 13
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
 	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/church/chapel)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -14733,6 +14465,20 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"ilv" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"ilx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14779,10 +14525,13 @@
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
-"iot" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
+"inY" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iov" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
@@ -14812,6 +14561,15 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
+"ips" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ipQ" = (
 /obj/structure/bars/pipe{
 	dir = 9;
@@ -14856,6 +14614,12 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"iqP" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "iqY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14878,21 +14642,32 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"irE" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "irG" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"irI" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "irV" = (
 /turf/open/floor/rogue/twig{
 	dir = 8
 	},
 /area/rogue/indoors)
-"ism" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "isI" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/short,
@@ -14909,8 +14684,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/herringbone,
+/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "itR" = (
 /obj/effect/landmark/start/villager{
@@ -14919,8 +14693,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "iug" = (
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -14939,6 +14716,15 @@
 "iur" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"ius" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "iut" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -14976,6 +14762,12 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ivE" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -15020,6 +14812,14 @@
 "iwV" = (
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"ixk" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "ixt" = (
 /obj/item/grown/log/tree/small,
@@ -15164,10 +14964,6 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"iBe" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "iBA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -15279,13 +15075,6 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
-"iEA" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -15369,16 +15158,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"iGx" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "iHm" = (
 /obj/structure/timeddoor,
 /obj/structure/timeddoor,
@@ -15436,6 +15215,14 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"iKB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "iKR" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -15510,6 +15297,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"iMg" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "iMh" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles{
 	desc = "One of a trio that are joined hand-in-hand with the other nearby statues.";
@@ -15538,7 +15331,10 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
@@ -15586,6 +15382,19 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"iNA" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "iNE" = (
 /obj/machinery/anomalous_crystal,
 /turf/open/floor/rogue/grass,
@@ -15665,6 +15474,15 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
+"iPO" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "iPY" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
@@ -15701,11 +15519,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iRN" = (
-/obj/structure/chair/bench/church/smallbench{
-	dir = 4
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15738,10 +15556,15 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/indoors/town/church/chapel)
+"iSF" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "iSJ" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15764,6 +15587,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"iUn" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iUY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/neck/roguetown/gorget,
@@ -15774,12 +15601,6 @@
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"iVh" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "iVi" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -15823,8 +15644,17 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
+"iWn" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5"
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
@@ -15860,6 +15690,13 @@
 /obj/item/natural/bundle/cloth,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"iXi" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "iXn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
@@ -15877,6 +15714,12 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"iXU" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "iXZ" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood{
@@ -15925,6 +15768,16 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"iYS" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"iZb" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "iZl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -15966,6 +15819,10 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"jaA" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "jaF" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/purple,
@@ -16011,10 +15868,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"jbK" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "jcb" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/cobblerock,
@@ -16069,13 +15922,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
-"jdI" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "jdK" = (
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
@@ -16099,6 +15945,17 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"jeE" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jeR" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16107,15 +15964,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"jeS" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "jeW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16188,6 +16036,14 @@
 "jgK" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/shelter/mountains)
+"jgQ" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -16232,12 +16088,24 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"jjE" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"jka" = (
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "jkg" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16298,15 +16166,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
@@ -16342,13 +16203,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
-"jnc" = (
-/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "jnl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -16373,6 +16227,10 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"jpc" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jpg" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -16404,10 +16262,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -16439,10 +16296,6 @@
 "jqC" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
-"jqK" = (
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "jqM" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/maidendrape,
@@ -16528,17 +16381,16 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"juY" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/church/chapel)
-"jvr" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "jvt" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/garrison)
@@ -16570,14 +16422,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/under/town/basement)
-"jwm" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	redstone_id = "WH1";
-	name = "WH Lever 1"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "jwn" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -16609,6 +16453,13 @@
 "jxy" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/manor)
+"jxE" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "jxP" = (
 /obj/structure/table/wood,
 /obj/item/restraints/legcuffs/beartrap,
@@ -16678,10 +16529,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"jzM" = (
-/obj/structure/fluff/walldeco/rpainting/crown,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "jAb" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -16695,14 +16542,9 @@
 /obj/item/clothing/under/roguetown/loincloth/brown,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"jAC" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+"jAw" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "jAG" = (
 /obj/structure/flora/roguegrass/water,
@@ -16731,14 +16573,20 @@
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"jCm" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jCq" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/mountains)
 "jCs" = (
 /obj/structure/fluff/railing/border{
@@ -16830,13 +16678,16 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "jEB" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -16861,11 +16712,6 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"jFG" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "jFL" = (
 /obj/structure/flora/roguegrass,
 /obj/item/natural/worms,
@@ -16879,6 +16725,10 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jFP" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "jGw" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -16928,12 +16778,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"jHX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "jIy" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -16952,24 +16796,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"jJg" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "jJq" = (
 /obj/structure/statue/saints/paladin2_r,
 /turf/open/floor/rogue/blocks,
@@ -16984,29 +16819,14 @@
 /obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"jKi" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+"jJS" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
-"jKP" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "jKW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -17016,10 +16836,6 @@
 "jKY" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/town)
-"jLi" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "jLs" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -17106,6 +16922,10 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jNk" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -17166,15 +16986,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"jOr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "jOI" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -17228,6 +17039,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jQk" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "jQo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -17249,10 +17067,11 @@
 "jQy" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
-"jQV" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+"jQK" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jRk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -17344,13 +17163,6 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
-"jUZ" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -17359,13 +17171,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/magician)
-"jVO" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
 "jWf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -17444,6 +17249,14 @@
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"jYL" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "jYR" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -17471,6 +17284,26 @@
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"jZp" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
+"jZA" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jZJ" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -17487,23 +17320,10 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kaf" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
-"kal" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatew"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+"kad" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kan" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/mineral_door/bars{
@@ -17573,14 +17393,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
-"kcu" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "kcG" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -17592,11 +17404,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kdj" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "kds" = (
 /obj/structure/table/wood,
 /obj/item/dice{
@@ -17615,11 +17422,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"kdY" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/wood,
+"kdN" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"kei" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "keq" = (
 /obj/structure/fluff/walldeco/painting{
@@ -17645,11 +17455,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"keX" = (
-/obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "kfe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -17692,6 +17497,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"kfI" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kfT" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
@@ -17726,17 +17535,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
+/obj/structure/table/wood{
 	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "khC" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -17770,20 +17574,26 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"kiL" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "kiR" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"kiS" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "kiU" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"kja" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "kjb" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -17795,12 +17605,6 @@
 "kjH" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town)
-"kjI" = (
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "kjR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -17891,10 +17695,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
-"koE" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "kpk" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -17924,21 +17724,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kqw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/rogueweapon/huntingknife/idagger/steel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
-"kqD" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "kqI" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree,
@@ -17949,10 +17734,6 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kqO" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "kqT" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -18049,9 +17830,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
 "ksK" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone,
@@ -18097,10 +17879,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"ktI" = (
-/obj/machinery/light/rogue/torchholder/r,
+"ktU" = (
+/obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/church/chapel)
 "ktW" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/boss,
 /turf/open/floor/rogue/blocks,
@@ -18141,19 +17923,21 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"kve" = (
-/obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
+"kvp" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -18194,19 +17978,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
 	},
-/area/rogue/outdoors/rtfield)
-"kxq" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -18257,6 +18033,12 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"kzs" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "kzv" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -18434,14 +18216,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"kEf" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "kEn" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
@@ -18457,10 +18231,6 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
-"kEE" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "kEI" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -18470,24 +18240,18 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"kEV" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "kFc" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 8
 	},
 /area/rogue/indoors)
 "kFh" = (
-/turf/closed/mineral/rogue/gem,
-/area/rogue/indoors/shelter/rtfield)
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -18530,10 +18294,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"kGp" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+"kGB" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kGR" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/woodturned,
@@ -18610,6 +18377,10 @@
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
+"kJx" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kJJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -18649,6 +18420,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"kKG" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "kKS" = (
 /obj/structure/mineral_door/bars{
 	lockid = "dungeon"
@@ -18673,6 +18451,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kLw" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "kLK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
@@ -18710,10 +18496,24 @@
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
+"kMO" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "kMT" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"kMV" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "kNa" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -18752,6 +18552,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"kNR" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "kNY" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
@@ -18835,6 +18639,10 @@
 "kPC" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"kPK" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kPO" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 8
@@ -18853,17 +18661,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"kQu" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
-"kQC" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "kQN" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
@@ -18879,15 +18676,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
-"kRc" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
 "kRA" = (
 /obj/effect/landmark/start/mercenary{
 	dir = 4
@@ -18963,25 +18751,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
-"kTw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -19129,6 +18898,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"kZx" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "kZA" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -19190,14 +18967,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"lbH" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "lbV" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
@@ -19211,6 +18980,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lcF" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ldf" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -19230,6 +19006,10 @@
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"lea" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "lec" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt,
@@ -19246,14 +19026,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
-"leS" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "leV" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -19279,6 +19051,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"lfG" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lfI" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19347,9 +19126,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -19359,25 +19142,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
-"lhv" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
-"lhN" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "lhO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -19392,12 +19156,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"lhZ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "lia" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/blocks,
@@ -19405,14 +19163,6 @@
 "lih" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/shop)
-"lip" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "lis" = (
 /obj/structure/bed/rogue/shit,
 /obj/item/soap,
@@ -19438,6 +19188,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"liH" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "liM" = (
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/hexstone,
@@ -19454,6 +19212,12 @@
 "lji" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
+"ljG" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "ljM" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -19470,17 +19234,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"ljW" = (
-/obj/item/candle/skull,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/church/chapel)
 "ljZ" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/water/swamp,
@@ -19505,6 +19258,16 @@
 "lkM" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"lkT" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "lli" = (
 /obj/structure/rogue/trophy/deer,
 /obj/item/natural/rock,
@@ -19526,6 +19289,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"llV" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lma" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -19550,6 +19322,16 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"lmT" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lmV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -19605,18 +19387,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -19677,6 +19450,14 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"lpY" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -19695,15 +19476,60 @@
 "lqR" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
+"lqU" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"lqV" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"lrF" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lsc" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lsg" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lsD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -19726,10 +19552,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"ltl" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "ltA" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -19784,20 +19606,23 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"lvj" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "lvr" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"lvu" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"lvy" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lvA" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
@@ -19841,6 +19666,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"lya" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "lyh" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/large,
@@ -19877,11 +19706,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"lzh" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "lzl" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/blocks,
@@ -19953,6 +19777,12 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"lBJ" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "lBK" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -19969,6 +19799,14 @@
 /obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"lBY" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "lCn" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -20003,12 +19841,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"lDI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lDQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -20091,23 +19923,30 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"lFQ" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lFV" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"lGo" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
+"lGE" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lGI" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
@@ -20249,13 +20088,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"lLn" = (
-/obj/structure/chair/wood/rogue/chair3,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "lLp" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
@@ -20269,14 +20101,6 @@
 /obj/effect/landmark/start/druid,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
-"lLV" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/stool/rogue,
@@ -20300,13 +20124,28 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/obj/structure/long_sleep,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/rtfield)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lNY" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lOl" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20353,6 +20192,15 @@
 "lPu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"lPI" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "lPQ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20362,15 +20210,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"lQe" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/closed,
-/area/rogue/indoors/town/dwarfin)
 "lQy" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -20391,6 +20230,12 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
+"lRd" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "lRJ" = (
 /obj/structure/table/wood,
 /obj/item/natural/feather,
@@ -20408,12 +20253,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
-"lSj" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "lSn" = (
 /obj/structure/plough,
 /obj/machinery/light/rogue/torchholder{
@@ -20431,6 +20270,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"lTy" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "lTz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/c,
@@ -20446,6 +20291,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"lUc" = (
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lUj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/churchrough,
@@ -20480,6 +20332,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"lVF" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "lVS" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks{
@@ -20497,6 +20362,11 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
+"lWI" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
@@ -20521,6 +20391,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"lXv" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "lXJ" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
@@ -20576,6 +20450,13 @@
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"lYV" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lYY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors/town/shop)
@@ -20583,6 +20464,13 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"lZf" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lZh" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
@@ -20594,12 +20482,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"lZo" = (
-/obj/structure/bookcase/random{
-	desc = s
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "lZp" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood,
@@ -20633,10 +20515,33 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"maV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "mbm" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mbx" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -20660,16 +20565,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"mcB" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "mcC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -20687,6 +20582,11 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"mdm" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "mdo" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20704,9 +20604,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -20767,6 +20666,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"meF" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "meV" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/structure/table/wood{
@@ -20804,10 +20709,30 @@
 "mfK" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician)
-"mge" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
+"mgd" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "mgk" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/bog)
@@ -20821,6 +20746,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"mgR" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -20894,9 +20823,15 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -20905,13 +20840,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"mkj" = (
-/obj/item/cooking/pan,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "mkk" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -20938,6 +20866,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"mkS" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mle" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -20978,6 +20912,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"mnG" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -21079,10 +21021,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"mrd" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "mrl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21094,8 +21032,14 @@
 	},
 /area/rogue/indoors/town)
 "mrE" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/storage/backpack/rogue/backpack/surgery,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "mrN" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21133,10 +21077,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"msN" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21155,6 +21095,12 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
+"mtO" = (
+/mob/living/simple_animal/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "mtR" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
@@ -21193,26 +21139,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter)
-"muU" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
-"mvc" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "mvp" = (
 /obj/structure/mineral_door/wood{
 	lockid = "townroom2"
@@ -21247,6 +21173,13 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"mwM" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "mwR" = (
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /obj/structure/rack/rogue,
@@ -21271,6 +21204,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"mxy" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "mxK" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21305,13 +21245,6 @@
 	},
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
-"mzd" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/obj/structure/bars,
-/turf/closed,
 /area/rogue/indoors/town)
 "mzk" = (
 /obj/structure/table/wood{
@@ -21479,11 +21412,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "mGn" = (
-/obj/structure/stairs{
+/obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
@@ -21516,6 +21450,21 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"mHK" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"mJt" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -21575,25 +21524,17 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"mMb" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+"mLO" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"mMs" = (
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "mMv" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
@@ -21628,14 +21569,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"mNs" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "mNz" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/grass,
@@ -21709,15 +21642,6 @@
 /obj/structure/gate,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors)
-"mPn" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
 "mPV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -21733,28 +21657,53 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"mQg" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "mQq" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
-"mQA" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/garrison)
+"mQx" = (
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"mQA" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"mRp" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mRr" = (
 /obj/structure/fluff/wallclock{
 	dir = 3
@@ -21788,24 +21737,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"mSE" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
 "mSG" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/chair/bench{
@@ -21815,10 +21746,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"mSY" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
 "mTd" = (
 /obj/structure/fermenting_barrel/random,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -21884,8 +21811,9 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
 /area/rogue/indoors/town)
 "mVN" = (
 /obj/item/flint,
@@ -21986,6 +21914,12 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"mYZ" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "mZo" = (
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
@@ -22012,6 +21946,17 @@
 "nad" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/tribalfort)
+"nap" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "naI" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/manor)
@@ -22070,6 +22015,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town/roofs)
+"nbF" = (
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"nca" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "ncb" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -22087,10 +22040,6 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"ncR" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
 "nda" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/keyring,
@@ -22124,15 +22073,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"ndE" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "ndL" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/twig,
@@ -22174,17 +22114,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"nes" = (
-/obj/item/rogueweapon/thresher,
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
-"neF" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
 "neP" = (
 /turf/open/water/river{
 	dir = 4;
@@ -22202,6 +22131,15 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"nfd" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"nfn" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
@@ -22223,25 +22161,20 @@
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"nhz" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
 "nhC" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph5"
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/iron,
-/obj/item/rogueweapon/sword/iron,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -22271,20 +22204,10 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"niC" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "niU" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"njm" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "njq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -22302,13 +22225,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"nkv" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "nkB" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -22387,13 +22303,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
-"nnx" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "nnz" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -22448,6 +22357,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
+"npZ" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nqf" = (
 /obj/machinery/light/rogue/firebowl/church/acolyte,
 /turf/open/floor/rogue/blocks,
@@ -22548,13 +22461,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"ntl" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "ntK" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -22572,14 +22478,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"nuB" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "nuD" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
@@ -22599,19 +22497,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/gate/bars{
+	gid = "viking1";
+	redstone_id = "viking1"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -22621,16 +22512,6 @@
 "nvd" = (
 /turf/open/water/bath,
 /area/rogue/indoors/shelter/rtfield)
-"nvk" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "nvA" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
@@ -22674,6 +22555,24 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"nwC" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "nwT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -22710,10 +22609,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"nxn" = (
-/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "nxr" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder/c,
@@ -22761,9 +22656,6 @@
 /obj/machinery/anomalous_crystal,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/rtfield)
-"nxZ" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/mountains)
 "nyb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -22804,13 +22696,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"nyO" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "nyP" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -22825,14 +22710,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"nzL" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+"nzI" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "nzO" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/naturalstone,
@@ -22868,11 +22749,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -23006,10 +22884,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"nGK" = (
-/obj/structure/rack/rogue/shelf/big,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "nGL" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/fluff/walldeco/church/line{
@@ -23018,11 +22892,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"nGQ" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "nGV" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned,
@@ -23041,19 +22910,12 @@
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"nHm" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "nHz" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"nHM" = (
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "nIk" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -23089,6 +22951,13 @@
 /obj/structure/plasticflaps,
 /turf/open/water/swamp,
 /area/rogue/indoors/town)
+"nIA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "nIH" = (
 /obj/structure/bars/tough,
 /turf/open/water/sewer,
@@ -23107,10 +22976,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "HC"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cave)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
@@ -23222,12 +23088,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"nNM" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "nNQ" = (
 /obj/structure/closet/dirthole/grave,
 /obj/item/natural/worms,
@@ -23235,16 +23095,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"nNV" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/rtfield)
 "nNX" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	lockid = "farm"
@@ -23269,6 +23119,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"nPg" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nPt" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/closet/crate/drawer,
@@ -23301,6 +23156,11 @@
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"nQh" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "nQi" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/shoes/roguetown/boots,
@@ -23389,8 +23249,10 @@
 /area/rogue/indoors/town)
 "nSr" = (
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -23431,9 +23293,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/closed/mineral/rogue,
-/area/rogue/under/cave)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -23501,20 +23365,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"nWd" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "nWj" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -23530,6 +23380,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"nWG" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"nWJ" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "nWM" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -23579,10 +23446,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"nXF" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/town)
 "nXI" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -23633,6 +23496,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"nYv" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "nYO" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -23685,14 +23553,34 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"oaN" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"oaV" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "obq" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -23825,6 +23713,15 @@
 "ofq" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
+"ofs" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ofB" = (
 /obj/item/needle/thorn,
 /obj/structure/table/wood{
@@ -23842,6 +23739,13 @@
 /obj/structure/flora/newtree,
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
+"ogj" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ogo" = (
 /obj/structure/statue/saints/acolyte_alt,
 /turf/open/floor/rogue/cobble,
@@ -23860,9 +23764,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -23925,6 +23829,18 @@
 "ohU" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
+"ohY" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -23997,13 +23913,13 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"olm" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"olC" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "olD" = (
 /turf/open/floor/grass/snow{
 	icon_state = "ice"
@@ -24023,12 +23939,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"olW" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+"olZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oma" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
@@ -24056,10 +23972,6 @@
 /obj/item/clothing/neck/roguetown/psicross/astrata,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
-"omn" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
 "omr" = (
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
@@ -24082,14 +23994,14 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"onQ" = (
-/obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "onR" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"onS" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "onT" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -24217,6 +24129,19 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"otk" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "ots" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
@@ -24278,29 +24203,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -24336,19 +24243,6 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
-"owf" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24391,14 +24285,6 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
-"oxJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "oxL" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/item/needle,
@@ -24456,6 +24342,10 @@
 /obj/item/flint,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"oza" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "oze" = (
 /obj/item/roguekey/tribal,
 /turf/open/floor/rogue/grass,
@@ -24464,13 +24354,6 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"ozu" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "ozw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -24526,12 +24409,6 @@
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"oAA" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "oAC" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/woodturned,
@@ -24557,21 +24434,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"oBs" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "oBx" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/church,
@@ -24582,13 +24444,6 @@
 	icon_state = "knightstatue_r"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
-"oBC" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "oBU" = (
 /obj/effect/landmark/start/priest,
@@ -24761,6 +24616,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"oHu" = (
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "oHA" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 10
@@ -24783,15 +24645,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/obj/structure/bars,
-/obj/structure/roguewindow/openclose{
-	dir = 1;
-	icon_state = "woodwindowdir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -24819,18 +24674,8 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"oJM" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 99999
-	},
-/obj/structure/table/wood,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "oJO" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/cobble,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
@@ -24853,6 +24698,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"oKL" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oLb" = (
 /obj/structure/stairs{
 	dir = 1
@@ -24874,9 +24724,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -24917,9 +24767,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"oNn" = (
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
 "oNx" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -25018,17 +24865,14 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
-"oQD" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH2";
-	name = "WH Lever 2"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "oQZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/rtfield)
+"oRb" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "oRc" = (
 /obj/structure/lever/wall{
 	pixel_x = 12;
@@ -25053,10 +24897,10 @@
 /area/rogue/indoors)
 "oRp" = (
 /obj/structure/chair/wood{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -25064,6 +24908,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"oRB" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "oRF" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/father,
@@ -25106,12 +24956,6 @@
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"oSH" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "oSV" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25181,11 +25025,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"oVj" = (
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "oVp" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town)
@@ -25345,6 +25184,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
+"oZA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "oZC" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -25458,6 +25305,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"pcr" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pct" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith,
 /turf/open/floor/rogue/dirt/road{
@@ -25495,9 +25349,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -25510,12 +25364,22 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"pdm" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+"pdl" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/item/rogue/instrument/lute,
-/turf/open/floor/rogue/ruinedwood,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
+"pdm" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
@@ -25527,6 +25391,9 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"pdP" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "pel" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -25535,6 +25402,13 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"pes" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "peN" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -25557,6 +25431,12 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"peX" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "peZ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -25619,10 +25499,6 @@
 "pgm" = (
 /obj/structure/pillory/dungeon/reinforced,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
-"pgW" = (
-/obj/machinery/light/rogue/forge,
-/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "phk" = (
 /obj/structure/closet/crate/chest,
@@ -25722,13 +25598,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
-"pkf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/mace/church{
-	name = "Ringer of Wuthering Heights"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
 "pkj" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
@@ -25736,16 +25605,6 @@
 "pku" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/manor)
-"pkD" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "INDOOR GARDEN"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH4"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "pkK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -25773,10 +25632,6 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"plJ" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -25966,12 +25821,9 @@
 "prZ" = (
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
-"psi" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/herringbone,
+"psj" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "psz" = (
 /obj/structure/closet/crate/roguecloset,
@@ -26003,6 +25855,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"ptu" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "pty" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8;
@@ -26043,11 +25903,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"pum" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
 "pur" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -26055,13 +25910,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"puY" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -26121,10 +25969,6 @@
 /obj/effect/landmark/start/tribalvillager,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"pxe" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
 "pxi" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/wood,
@@ -26163,6 +26007,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"pxY" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "pyh" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -26189,16 +26039,6 @@
 "pyI" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
-"pyO" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"pyT" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "pyY" = (
 /obj/item/rogueweapon/sword/falchion,
@@ -26254,6 +26094,13 @@
 "pAa" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
+"pAb" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "pAg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -26296,6 +26143,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"pBp" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pBx" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/roguebin/water,
@@ -26310,18 +26163,26 @@
 	icon_state = "stonewindow"
 	},
 /area/rogue/indoors)
+"pBQ" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pBS" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"pBW" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+"pCk" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "pCl" = (
 /obj/structure/handcart,
 /obj/item/grown/log/tree,
@@ -26409,6 +26270,15 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"pEw" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "pEC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -26416,10 +26286,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"pFf" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -26501,13 +26367,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"pIB" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "pJa" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -26521,6 +26380,23 @@
 /obj/item/storage/belt/rogue/leather/black,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"pJP" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "pKb" = (
 /obj/structure/winch{
 	gid = "townin2";
@@ -26545,21 +26421,12 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -26614,14 +26481,13 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -26639,20 +26505,6 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"pMQ" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32;
-	name = "The Funniest Thing Ever Seen";
-	desc = "Painting depicting a skull of a pickle... Odd."
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
-"pNc" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "pNd" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/rooftop{
@@ -26763,6 +26615,13 @@
 "pPO" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/mountains)
+"pPY" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pQd" = (
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/town)
@@ -26787,6 +26646,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"pRt" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "pRE" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -26857,6 +26726,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"pTC" = (
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "pTE" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -26932,6 +26805,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"pWw" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -27090,6 +26970,16 @@
 /obj/item/clothing/cloak/stabard/guardhood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"qbA" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qbC" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -27157,6 +27047,15 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qdg" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "qdn" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -27202,9 +27101,23 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"qeH" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "qeY" = (
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -27250,6 +27163,14 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cave)
+"qgD" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qgH" = (
 /obj/structure/winch{
 	gid = "forestgate2";
@@ -27257,6 +27178,25 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"qgS" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qhg" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -27303,25 +27243,27 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qif" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "qil" = (
 /obj/structure/bars/passage{
 	redstone_id = "tourneytop"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"qip" = (
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qiu" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"qiv" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/obj/structure/bars,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "qiG" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/shoes/roguetown/boots/furlinedanklets,
@@ -27445,10 +27387,26 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"qmp" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "qmx" = (
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"qmC" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qne" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/naturalstone,
@@ -27517,6 +27475,14 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"qor" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qoE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
@@ -27567,7 +27533,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/turf/closed/wall/mineral/rogue/wood,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -27579,15 +27546,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
-"qqk" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "qqm" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/grass,
@@ -27598,11 +27556,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"qqz" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "qqA" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -27619,6 +27572,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"qqE" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qqV" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -27674,14 +27634,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors/town/manor)
-"qrI" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "qrN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
@@ -27756,13 +27708,12 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"quu" = (
-/obj/structure/winch{
-	gid = "forestgate1";
-	redstone_id = "estatesgatesouth"
+"quy" = (
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -27777,7 +27728,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/structure/bed/rogue/inn/double,
+/obj/structure/table/wood,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "quT" = (
@@ -27836,11 +27787,19 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -27892,13 +27851,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"qzb" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -27922,27 +27874,19 @@
 	},
 /area/rogue/outdoors/bog)
 "qzy" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/area/rogue/under/cave)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
-"qzJ" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
@@ -27988,16 +27932,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"qBG" = (
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+"qBH" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "qBX" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -28020,28 +27961,32 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/closet/crate/chest,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"qDl" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"qDm" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/item/dice{
+	pixel_y = 13
 	},
-/area/rogue/outdoors/mountains)
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "qDn" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -28049,6 +27994,12 @@
 "qDI" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/vikingarea)
+"qDL" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qDP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -28061,25 +28012,34 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qEr" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
-"qEH" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+"qEO" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qEY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
+"qFp" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qFu" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -28088,6 +28048,16 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
+"qFF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qFK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/churchbrick,
@@ -28101,20 +28071,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"qFU" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
 "qGh" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
-"qGB" = (
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/structure/rack/rogue,
+/turf/open/lava{
+	name = "an actual pit of lava"
+	},
+/area/rogue/under/cave)
+"qGy" = (
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -28229,32 +28192,21 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
-"qKU" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+"qKD" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
-"qLk" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
+"qKU" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -28304,6 +28256,20 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"qMB" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
+"qMF" = (
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
@@ -28330,11 +28296,6 @@
 "qOW" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
-"qPg" = (
-/obj/structure/chair/wood,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qPm" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -28354,6 +28315,16 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"qPF" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qPH" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
@@ -28387,6 +28358,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qQo" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -28405,42 +28383,27 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"qRh" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "qRm" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "qRp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/woodturned,
@@ -28464,10 +28427,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"qSx" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "qSA" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/outdoors/town)
@@ -28507,6 +28466,15 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"qUg" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "qUE" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -28550,13 +28518,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"qWg" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "qWh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -28615,8 +28576,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -28659,16 +28624,6 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"ras" = (
-/obj/structure/rack/rogue,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "raF" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/exposed)
@@ -28678,6 +28633,15 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"rba" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rbk" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -28727,6 +28691,10 @@
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
+"rbZ" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors)
 "rcg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -28734,6 +28702,9 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"rcm" = (
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rco" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -28741,9 +28712,7 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH2"
-	},
+/obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
 "rcC" = (
@@ -28889,12 +28858,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"rgw" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "rgO" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH7"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -28915,12 +28886,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"rhx" = (
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CE"
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "rhD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -28942,22 +28907,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"rhV" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Church Armory"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
-"ril" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "rio" = (
 /obj/structure/winch{
 	gid = "forestgate1";
@@ -29032,24 +28981,6 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"rlz" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
-"rlG" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/obj/item/natural/bundle/cloth,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "rlK" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -29124,6 +29055,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"rnq" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "rns" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/globe,
@@ -29131,15 +29069,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
-"rnv" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
-	},
-/area/rogue/under/cave)
 "rnN" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -29333,12 +29262,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"rtS" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "rtV" = (
 /obj/structure/bars,
 /turf/open/water/sewer,
@@ -29365,6 +29288,10 @@
 /obj/effect/landmark/map_load_mark/sewers_bottomleft,
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
+"rvU" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "rvZ" = (
 /obj/item/candle/skull,
 /obj/structure/table/wood{
@@ -29488,6 +29415,10 @@
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
+"rzb" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rzq" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -29565,10 +29496,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"rCR" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "rDg" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
@@ -29593,6 +29520,9 @@
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"rDR" = (
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -29687,17 +29617,37 @@
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"rGS" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "rGY" = (
-/obj/structure/closet/crate/chest/reward,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -29713,6 +29663,18 @@
 	dir = 8
 	},
 /area/rogue/indoors/town)
+"rIm" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
+"rIE" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "rIP" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -29867,10 +29829,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
-"rOc" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "rOe" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/belt/rogue/pouch/coins/mid,
@@ -29964,11 +29922,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -29982,19 +29938,24 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church/r{
+/obj/structure/chair/bench/church{
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -30085,21 +30046,24 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"rUf" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
+"rTT" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/mob/living/simple_animal/hostile/rogue/ghost/wraith{
-	name = "Every Catherine"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -30117,13 +30081,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"rUQ" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/closet/crate/coffin/vampire{
-	name = "CASKET OF DOUGH"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "rVl" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "TeleportOut";
@@ -30209,6 +30166,10 @@
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rXY" = (
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "rXZ" = (
 /obj/item/rogueweapon/mace/wsword,
 /obj/item/rogueweapon/mace/wsword,
@@ -30223,6 +30184,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"rYq" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "rYt" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -30260,6 +30229,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"rYO" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "rZk" = (
 /obj/structure/stairs{
 	dir = 4
@@ -30289,10 +30262,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
-"rZP" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "rZU" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -30303,10 +30272,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"rZV" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "rZY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -30327,25 +30292,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"saT" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "saW" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
-"sbp" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "sby" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/herringbone,
@@ -30355,10 +30305,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -30439,22 +30390,10 @@
 /obj/structure/statue/saints/magelady2_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"sdN" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+"sdD" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "sdR" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair/wood/rogue{
@@ -30485,15 +30424,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -30517,6 +30450,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"sgf" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sgi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -30571,6 +30510,14 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"sgY" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "shd" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -30692,10 +30639,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"slH" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
 "slS" = (
 /obj/item/clothing/shoes/roguetown/boots/armoriron,
 /turf/open/floor/rogue/dirt/road{
@@ -30791,10 +30734,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"soa" = (
-/obj/structure/stairs/stone,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/rtfield)
 "soi" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -30850,16 +30789,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"spM" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "spP" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
@@ -30987,6 +30916,12 @@
 "sue" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors)
+"suf" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "sux" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -31007,13 +30942,9 @@
 	},
 /area/rogue/outdoors/beach)
 "suN" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
+/obj/effect/landmark/start/templar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
-"suQ" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "suY" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -31022,13 +30953,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"svu" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "svx" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -31084,9 +31008,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/structure/bookcase,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/area/rogue/outdoors/mountains)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -31112,20 +31039,14 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"syi" = (
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sym" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
-/area/rogue/indoors/town)
-"syB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
-"syH" = (
-/obj/structure/fluff/wallclock/l,
-/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "syL" = (
 /obj/structure/chair/bench,
@@ -31218,6 +31139,10 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
+"sCf" = (
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "sCg" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -31307,6 +31232,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
+"sFM" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "sGj" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -31377,16 +31308,6 @@
 "sIl" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"sIu" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "sIy" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
@@ -31395,9 +31316,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -31413,6 +31334,26 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"sIT" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"sJd" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"sJt" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sJZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -31459,6 +31400,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"sLs" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sLF" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31470,6 +31417,14 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"sLY" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sMb" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/wood,
@@ -31482,6 +31437,12 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"sNj" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "sNp" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -31496,14 +31457,22 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
-"sNU" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
+"sNS" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/item/paper,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "sNY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -31528,6 +31497,15 @@
 "sPu" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"sPx" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "sPH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -31559,16 +31537,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"sQN" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
-"sRu" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
 "sRD" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -31640,6 +31618,10 @@
 "sTr" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/shelter)
+"sTN" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "sTW" = (
 /obj/structure/fluff/clodpile,
 /turf/open/floor/rogue/dirt/road{
@@ -31675,29 +31657,11 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sUJ" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/dwarfin)
 "sUQ" = (
 /obj/structure/table/church/m,
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"sUU" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "sUV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grass,
@@ -31731,12 +31695,27 @@
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sWs" = (
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
+"sWy" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "sWL" = (
 /obj/effect/landmark/start/squire{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"sWT" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "sWU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31754,6 +31733,16 @@
 /area/rogue/indoors/town/manor)
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/town)
+"sXO" = (
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "sXU" = (
 /obj/structure/fermenting_barrel/random,
@@ -31806,6 +31795,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"sZB" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -31820,8 +31813,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -31997,8 +31990,7 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "tfp" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/woodturned,
+/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/church/chapel)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -32037,12 +32029,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"thU" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"tig" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "til" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/tile,
@@ -32064,13 +32058,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -32120,6 +32110,13 @@
 	dir = 1;
 	icon_state = "wooden_floor2"
 	},
+/area/rogue/indoors/town/church/chapel)
+"tks" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "tkB" = (
 /obj/structure/fluff/railing/border{
@@ -32178,17 +32175,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"tlP" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear/billhook,
-/obj/item/rogueweapon/spear/billhook,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "tlQ" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "tlX" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32199,6 +32194,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"tmj" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tmE" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -32211,12 +32213,6 @@
 "tmI" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/shop)
-"tmR" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
 "tmW" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/carpet/lord/center,
@@ -32264,15 +32260,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"tnB" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
 "tnQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32282,6 +32269,18 @@
 "tou" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"toI" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"toM" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
@@ -32293,6 +32292,10 @@
 "tpz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
+"tpO" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "tqq" = (
 /obj/structure/table/wood{
@@ -32368,6 +32371,13 @@
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"tsJ" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "tsR" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -32381,6 +32391,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"ttB" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ttC" = (
 /obj/structure/lever/wall{
 	pixel_x = 32;
@@ -32388,9 +32406,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"ttR" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/town/roofs)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -32412,16 +32427,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"tuE" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "tuJ" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -32476,6 +32481,14 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"twz" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "twA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32488,6 +32501,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/mountains)
+"twL" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "twP" = (
 /obj/item/rogueweapon/spear{
 	color = gold;
@@ -32535,17 +32552,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"txs" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/bars/passage/shutter{
-	density = 0;
-	icon_state = "shutter1";
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "txC" = (
 /obj/structure/bars/pipe{
 	dir = 8
@@ -32612,6 +32618,18 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tzj" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tzy" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -32645,12 +32663,16 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"tAc" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
+"tAb" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "tAf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -32762,6 +32784,10 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"tCF" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
@@ -32794,6 +32820,10 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"tDB" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "tDJ" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -32802,22 +32832,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"tDK" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"tDO" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"tEg" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "tEs" = (
 /obj/structure/bars/pipe,
 /obj/structure/bars/pipe{
@@ -32982,10 +32996,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/closed/wall/mineral/rogue/wood,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
@@ -32999,16 +33014,19 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"tKx" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "tKE" = (
 /obj/structure/bars/pipe{
 	dir = 5
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tKO" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "tKW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -33018,13 +33036,6 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"tLe" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
 "tLm" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -33033,6 +33044,12 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"tLZ" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "tMb" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/item/clothing/cloak/tabard/crusader/astrata,
@@ -33063,16 +33080,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
-"tMO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH6"
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "tMZ" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/dirt/road{
@@ -33093,6 +33100,15 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"tNp" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "tNr" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -33144,6 +33160,15 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"tOk" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
@@ -33154,12 +33179,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tOW" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "tOZ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/dirt/road{
@@ -33194,12 +33213,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"tRG" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "tRV" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -33260,11 +33273,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
-/turf/open/water/river{
-	dir = 4;
-	icon_state = "rockwd"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/under/cave)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
@@ -33274,13 +33287,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/structure/bed/rogue/inn/double,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -33290,6 +33305,13 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"tUZ" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "tVd" = (
 /obj/structure/gate{
 	gid = "gatemanor2";
@@ -33306,6 +33328,11 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"tVB" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tVG" = (
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -33361,10 +33388,6 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"tYk" = (
-/obj/structure/bookcase,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "tYm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -33418,8 +33441,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "uaj" = (
 /obj/machinery/light/rogue/forge{
@@ -33598,6 +33621,10 @@
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"uhn" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uhw" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -33627,16 +33654,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
-"uiO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/roguemachine/scomm{
-	dir = 3;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
 "uiQ" = (
 /obj/structure/fluff/walldeco/rpainting/crown,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -33670,6 +33687,14 @@
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"uka" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "ukb" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -33678,20 +33703,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"ukj" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
-"ukm" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "ukv" = (
 /obj/item/roguebin/crackers,
 /obj/item/storage/foodbag/hardtack,
@@ -33735,14 +33746,45 @@
 /obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ulR" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
+"ulU" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ulY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"umA" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+"umi" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"umz" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "umH" = (
 /obj/structure/bars/pipe{
 	dir = 5
@@ -33872,8 +33914,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -33941,12 +33984,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"usK" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "usR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobble,
@@ -33993,20 +34030,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"utQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
-"utS" = (
-/obj/structure/mirror,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/church/chapel)
 "uuq" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
@@ -34048,12 +34071,13 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "uvu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
-/obj/structure/bars/tough,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34069,8 +34093,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
 "uwa" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -34119,16 +34148,24 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -34153,15 +34190,6 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
-"uyA" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "uyE" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt,
@@ -34181,26 +34209,13 @@
 "uzx" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/warehouse)
-"uzR" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
 "uzS" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
@@ -34289,13 +34304,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"uBQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+"uCD" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "uCF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -34327,18 +34342,8 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
@@ -34359,10 +34364,32 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"uEq" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+"uEA" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
+"uEB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "uEG" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34377,24 +34404,19 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -34404,10 +34426,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uFN" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uGc" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -34477,15 +34495,19 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uHk" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
 	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -34495,12 +34517,6 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"uIc" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "uIk" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
@@ -34515,16 +34531,11 @@
 "uJF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/town)
-"uJM" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
-"uJV" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+"uKf" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uKv" = (
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/churchmarble,
@@ -34626,15 +34637,14 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"uMB" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "uMO" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"uNa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "uNf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -34656,28 +34666,12 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"uOs" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
-"uOz" = (
-/obj/structure/fluff/railing/border{
+"uNW" = (
+/obj/structure/stairs/stone{
 	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -34725,13 +34719,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"uPw" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "uPB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34740,6 +34727,10 @@
 /turf/open/floor/rogue/twig{
 	dir = 4
 	},
+/area/rogue/indoors)
+"uPD" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "uPE" = (
 /obj/structure/mineral_door/wood{
@@ -34756,6 +34747,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"uQb" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uQp" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -34794,6 +34791,12 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"uRt" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uRH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -34815,20 +34818,20 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"uSP" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "uSS" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
-"uTd" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "WH3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "uTf" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -34896,11 +34899,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"uVd" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/water/bath,
-/area/rogue/indoors/town/church/chapel)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -35049,12 +35047,9 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uZD" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -35107,12 +35102,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"vbx" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
 "vbC" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -35148,6 +35137,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vcN" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -35155,7 +35150,13 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "vdg" = (
-/obj/structure/chair/bench/church/smallbench,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -35209,14 +35210,6 @@
 /obj/item/reagent_containers/food/snacks/grown/oat,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"vez" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "veC" = (
 /obj/structure/plasticflaps,
 /turf/open/water/cleanshallow,
@@ -35242,12 +35235,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/mountains)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/herringbone,
@@ -35280,6 +35269,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vfW" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "vgz" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -35299,10 +35299,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"vhe" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/shelter/rtfield)
 "vhg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -35345,6 +35341,9 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"vhV" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "vib" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 1
@@ -35359,36 +35358,21 @@
 "viq" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
-"viw" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	icon_state = "chair1"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "viI" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"viP" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "vjs" = (
 /obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+	dir = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -35408,6 +35392,21 @@
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"vjV" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vka" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/tavern)
@@ -35415,6 +35414,13 @@
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vkB" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "vkI" = (
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -35460,13 +35466,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"vmp" = (
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "vmx" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/blocks,
@@ -35508,13 +35507,6 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"vnR" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "vnX" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
@@ -35524,6 +35516,18 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"voc" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "vof" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road{
@@ -35549,9 +35553,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -35649,12 +35656,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/winch{
-	gid = "forestgate2";
-	redstone_id = "estatesgatenorth"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35698,20 +35703,19 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"vtF" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "vtZ" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"vua" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "vuh" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -35726,12 +35730,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"vum" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "vup" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -35783,10 +35781,24 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"vvo" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "vvJ" = (
 /obj/structure/pillory/tribal/double,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"vvU" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vvV" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -35860,10 +35872,6 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
-"vyk" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -35921,16 +35929,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"vzG" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
-"vzO" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "vzR" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -35957,10 +35955,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/town)
-"vAn" = (
-/obj/structure/fluff/railing/border,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
 "vAB" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -35995,25 +35989,6 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"vAY" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "West Shutters";
-	pixel_y = -8;
-	redstone_id = "eastgatew";
-	pixel_x = -2
-	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "East Shutters";
-	pixel_y = 6;
-	redstone_id = "estategatee"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -36078,14 +36053,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"vDn" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH4";
-	name = "WH Lever 4"
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "vDp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -36180,13 +36147,23 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "vFz" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope,
-/obj/item/rope,
-/obj/item/rope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
+"vFL" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
@@ -36210,12 +36187,13 @@
 /area/rogue/indoors/town/church/chapel)
 "vGQ" = (
 /obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/item/book/granter/trait/war/relentless,
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vGT" = (
 /obj/structure/spacevine,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -36226,23 +36204,16 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
 	},
-/mob/living/carbon/human/species/skeleton/no_equipment,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"vHr" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "vIa" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
@@ -36277,6 +36248,15 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
+"vJz" = (
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "vJU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -36303,11 +36283,12 @@
 /obj/structure/fluff/walldeco/maidendrape,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
+"vLy" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vLA" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "WUTHERING HEIGHTS"
-	},
+/obj/structure/bed/rogue/inn/double,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
 "vLD" = (
@@ -36385,24 +36366,29 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"vNE" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/outdoors/mountains)
 "vOa" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"vOe" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vOy" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"vOH" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "vOU" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/effect/decal/cleanable/cobweb,
@@ -36423,8 +36409,14 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -36466,10 +36458,11 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -36481,6 +36474,13 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"vRA" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "vRF" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/cobble,
@@ -36560,11 +36560,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"vTG" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/garrison)
 "vTK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
@@ -36575,9 +36570,10 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 9
@@ -36593,10 +36589,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"vVo" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town)
 "vVG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -36609,6 +36601,17 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vVP" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vWa" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -36657,8 +36660,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -36690,6 +36693,10 @@
 	},
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/shelter/mountains)
+"vYa" = (
+/obj/structure/fluff/wallclock/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vYw" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -36714,13 +36721,6 @@
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"vZi" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "vZv" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/chaincoif,
@@ -36757,11 +36757,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"wae" = (
-/obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "wan" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
@@ -36769,13 +36764,6 @@
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"waG" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
 "waI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -36839,12 +36827,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/town/roofs)
-"wdp" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wdJ" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
@@ -36913,6 +36895,18 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"wfJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"wfP" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "wfY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper/scroll,
@@ -36920,10 +36914,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "wgn" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/closed/wall/mineral/rogue/craftstone,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36969,12 +36967,6 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
-"wis" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -37002,12 +36994,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wkz" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
@@ -37095,17 +37081,26 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "wou" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/wood/nosmooth,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
+"woJ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -37116,6 +37111,16 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"wpc" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wpe" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -37133,8 +37138,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
@@ -37152,17 +37157,27 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"wqB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "wqE" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "boat1";
@@ -37185,14 +37200,22 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"wsx" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wsR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -37263,9 +37286,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"wvt" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
+"wvn" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "wvy" = (
 /obj/structure/flora/roguetree,
@@ -37309,19 +37336,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
-"wwK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -37329,6 +37343,10 @@
 "wxd" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"wxi" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "wxy" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -37355,9 +37373,12 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -37370,10 +37391,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"wzk" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/manor)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -37407,6 +37424,13 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"wAJ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "wAP" = (
 /obj/structure/rack/rogue,
 /obj/item/flint,
@@ -37474,13 +37498,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
-"wCy" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "wCB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/rogue,
@@ -37531,23 +37548,24 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/turf/open/lava{
-	name = "an actual pit of lava"
-	},
-/area/rogue/under/cave)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -37572,6 +37590,19 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"wFa" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "wFc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -37589,24 +37620,12 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"wFy" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/peppermill,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile/checker,
-/area/rogue/indoors/town)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -37648,6 +37667,12 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"wGR" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "wHa" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/cobble,
@@ -37661,6 +37686,18 @@
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
+"wIc" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -37675,16 +37712,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/bog)
-"wID" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wJm" = (
 /obj/structure/bars/passage/shutter,
 /turf/open/floor/rogue/dirt/road{
@@ -37777,15 +37804,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"wLf" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
@@ -37806,16 +37824,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"wLQ" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
-"wLX" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/closed,
-/area/rogue/indoors/town)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -37942,16 +37950,9 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
-"wPQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/mountains)
+"wPR" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "wPU" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/woodturned,
@@ -38011,10 +38012,10 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wRi" = (
-/obj/structure/fluff/statue/myth,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/outdoors/mountains)
+"wRw" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wRy" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -38033,15 +38034,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/obj/item/clothing/under/roguetown/chainlegs/skirt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -38053,26 +38052,18 @@
 	icon_state = "paving"
 	},
 /area/rogue/under/town/basement)
-"wSS" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "wSU" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -38095,17 +38086,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -38135,22 +38122,6 @@
 "wVI" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"wVL" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
 "wWC" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -38167,6 +38138,13 @@
 /obj/structure/fluff/statue/psy,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/bog)
+"wXi" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "wXj" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -38212,23 +38190,10 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
-"wYx" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town)
-"wYz" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
@@ -38238,10 +38203,6 @@
 /obj/item/rogueweapon/thresher,
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
-"wYQ" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/mountains)
 "wYW" = (
 /obj/machinery/light/rogue/firebowl/church,
@@ -38260,6 +38221,10 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"wZA" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wZJ" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword,
@@ -38271,8 +38236,9 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -38313,10 +38279,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town)
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -38329,6 +38295,29 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"xcm" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
+"xct" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "xcF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -38346,22 +38335,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"xcZ" = (
-/obj/structure/bars/tough,
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
-"xde" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "Feeding Line";
-	pixel_y = -6;
-	redstone_id = "feedingline"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
 "xdq" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
@@ -38381,12 +38354,27 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/effect/decal/cobbleedge{
+	dir = 10
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"xdQ" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -38414,16 +38402,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"xfa" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/obj/structure/roguemachine/atm{
-	pixel_y = -3;
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "xff" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -38455,12 +38433,6 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
-"xgn" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
 	},
 /area/rogue/indoors/town)
 "xgo" = (
@@ -38627,33 +38599,12 @@
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"xkj" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/outdoors/town)
-"xkl" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "xkm" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -38709,6 +38660,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"xmZ" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xna" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -38843,10 +38798,22 @@
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"xpF" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xpM" = (
-/mob/living/carbon/human/species/skeleton/no_equipment,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -38858,6 +38825,12 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
+"xqD" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "xqH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -38884,8 +38857,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "xrf" = (
-/obj/structure/chair/bench/church/mid{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -38929,11 +38902,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"xsJ" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+"xsL" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xtc" = (
 /turf/open/floor/rogue/ruinedwood{
@@ -39016,12 +38991,6 @@
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
-"xuT" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/church/chapel)
 "xvs" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -39071,13 +39040,24 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
+"xwo" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -39133,12 +39113,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
-"xxB" = (
-/mob/living/simple_animal/cow,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
 "xxF" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -39165,6 +39139,16 @@
 	dir = 9
 	},
 /area/rogue/outdoors/mountains)
+"xyB" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "xyC" = (
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/ruinedwood,
@@ -39183,13 +39167,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"xyK" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "xyL" = (
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue/shelf,
@@ -39199,6 +39176,14 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"xzx" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "xzN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road{
@@ -39221,9 +39206,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -39281,13 +39268,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"xCo" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "xCw" = (
 /obj/item/natural/stone,
 /turf/open/water/swamp,
@@ -39414,11 +39394,39 @@
 	muddy = true
 	},
 /area/rogue/outdoors/town)
-"xET" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+"xEF" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
 	},
-/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
+"xET" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"xFb" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
+"xFi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "xFk" = (
@@ -39501,18 +39509,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"xGX" = (
-/obj/machinery/anvil,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
 "xHe" = (
-/obj/item/quiver/bolts,
-/obj/item/quiver/bolts,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/roguewindow/openclose{
+	dir = 1
 	},
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -39557,6 +39559,23 @@
 /obj/item/rope,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"xIq" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
+"xIr" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "xID" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -39635,12 +39654,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"xLE" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xLK" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -39656,14 +39669,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
-"xLO" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/garrison)
 "xLQ" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/rooftop/green,
@@ -39683,16 +39688,22 @@
 "xMr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
-"xMA" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"xMs" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
 	},
-/area/rogue/indoors/town/garrison)
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "xMZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -39724,10 +39735,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"xNQ" = (
-/obj/structure/table/vtable/v2,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/outdoors/mountains)
 "xOt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -39742,13 +39749,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"xOC" = (
-/obj/structure/lever/wall{
-	redstone_id = "WH3";
-	name = "WH Lever 3"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
 "xOE" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -39998,6 +39998,14 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"xVB" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "xVJ" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
@@ -40097,18 +40105,6 @@
 "xYz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"xYA" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/obj/item/signal_horn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/garrison)
 "xYM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -40204,12 +40200,6 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
-"ybA" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/stone/stonepattern2,
-/area/rogue/under/cave)
 "ybH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/border{
@@ -40231,20 +40221,45 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"ych" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
+"ycs" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "ycv" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 8
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"ycX" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ydb" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp,
@@ -40316,6 +40331,11 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"yfe" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "yfj" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -40342,12 +40362,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"yft" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/riddleofsteel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "yfu" = (
 /obj/structure/roguemachine/merchantvend,
 /obj/structure/roguemachine/scomm,
@@ -40418,19 +40432,21 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"yih" = (
-/obj/structure/stairs{
-	dir = 1
+"yir" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "yiw" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors/shelter/rtfield)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -40457,12 +40473,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/mountains)
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -40502,16 +40517,6 @@
 "ykt" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/rtfield)
-"ykH" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "ykQ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -40520,18 +40525,13 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"yld" = (
-/obj/structure/mineral_door/wood{
-	lockid = "mansionvampire";
-	name = "MEDICAL WING"
-	},
-/obj/structure/bars/passage/shutter,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
 "ylk" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"yll" = (
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ylC" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/basement)
@@ -184128,13 +184128,13 @@ bpD
 bpD
 bpD
 bpD
-bPv
-bPv
-bPv
-bPv
-bPv
-bPv
-bPv
+nJy
+nJy
+nJy
+nJy
+nJy
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -184530,13 +184530,13 @@ bpD
 bpD
 bpD
 bpD
-bPv
-rGY
-xaD
-xaD
-rUr
-rGY
-bPv
+nJy
+bKE
+goz
+goz
+vQV
+bKE
+nJy
 bpD
 bpD
 bpD
@@ -184932,17 +184932,17 @@ bpD
 bpD
 bpD
 bpD
-bPv
-xaD
-xaD
-rUr
-xaD
-bBs
-bPv
-bPv
-bPv
-bPv
-bPv
+nJy
+goz
+goz
+vQV
+goz
+jNk
+nJy
+nJy
+nJy
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -185334,17 +185334,17 @@ bpD
 bpD
 bpD
 bpD
-bPv
-dCX
-nkv
-xaD
-xaD
-xaD
-xaD
-xaD
-jbK
-bPv
-bPv
+nJy
+tUp
+nIA
+goz
+goz
+goz
+goz
+goz
+hMb
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -185736,17 +185736,17 @@ bpD
 bpD
 bpD
 bpD
-bPv
-wDZ
-wDZ
-utQ
-ybA
-xAh
-xaD
-rUr
-jbK
-bPv
-bPv
+nJy
+qGh
+qGh
+aBW
+sIT
+loE
+goz
+vQV
+hMb
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -186138,17 +186138,17 @@ bpD
 bpD
 bpD
 bpD
-bPv
-rhx
-wDZ
-wDZ
-gvZ
-qRm
-xaD
-xaD
-xaD
-oSH
-bPv
+nJy
+lRd
+qGh
+qGh
+uwa
+qif
+goz
+goz
+goz
+uNW
+nJy
 bpD
 bpD
 bpD
@@ -186540,17 +186540,17 @@ bpD
 bpD
 bpD
 bpD
-bPv
 nJy
-wDZ
-wDZ
-vGQ
-qRm
-xaD
-xaD
-xaD
-oSH
-bPv
+bmk
+qGh
+qGh
+adK
+qif
+goz
+goz
+goz
+uNW
+nJy
 bpD
 bpD
 bpD
@@ -186942,17 +186942,17 @@ sSS
 sSS
 sSS
 sSS
-bPv
-wDZ
-wDZ
-dbB
-xaD
-xAh
-xaD
-rUr
-jbK
-bPv
-bPv
+nJy
+qGh
+qGh
+oaV
+goz
+loE
+goz
+vQV
+hMb
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -187344,17 +187344,17 @@ sSS
 sSS
 sSS
 sSS
-bPv
-kqD
-dTZ
-xaD
-xaD
-xaD
-xaD
-xaD
-jbK
-bPv
-bPv
+nJy
+oaN
+eza
+goz
+goz
+goz
+goz
+goz
+hMb
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -187746,17 +187746,17 @@ sSS
 sSS
 sSS
 sSS
-bPv
-xaD
-xaD
-xaD
-xaD
-bBs
-bPv
-bPv
-bPv
-bPv
-bPv
+nJy
+goz
+goz
+goz
+goz
+jNk
+nJy
+nJy
+nJy
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -188148,13 +188148,13 @@ sSS
 sSS
 sSS
 sSS
-bPv
-rGY
-xaD
-rUr
-rUr
-rGY
-bPv
+nJy
+bKE
+goz
+vQV
+vQV
+bKE
+nJy
 bpD
 bpD
 bpD
@@ -188550,13 +188550,13 @@ sSS
 sSS
 sSS
 sSS
-bPv
-bPv
-bPv
-bPv
-bPv
-bPv
-bPv
+nJy
+nJy
+nJy
+nJy
+nJy
+nJy
+nJy
 bpD
 bpD
 bpD
@@ -227515,7 +227515,7 @@ acD
 acD
 fhw
 acD
-aPR
+dol
 acD
 acD
 acD
@@ -227918,8 +227918,8 @@ acD
 acD
 acD
 vuH
-dbH
-tUp
+bVa
+qzy
 acD
 azH
 azH
@@ -228317,7 +228317,7 @@ vRu
 vRu
 acD
 qgC
-tUp
+qzy
 qgC
 vuH
 qgC
@@ -228718,12 +228718,12 @@ vRu
 vRu
 vRu
 acD
-tUp
+qzy
 qgC
-dbH
+bVa
 vuH
-dbH
-tUp
+bVa
+qzy
 acD
 qgC
 qgC
@@ -229121,11 +229121,11 @@ vRu
 vRu
 acD
 qgC
-tUp
+qzy
 qgC
 vuH
-dbH
-tUp
+bVa
+qzy
 acD
 qgC
 qgC
@@ -229522,12 +229522,12 @@ vRu
 vRu
 vRu
 acD
-tUp
+qzy
 qgC
 qgC
 vuH
-dbH
-tUp
+bVa
+qzy
 acD
 qgC
 qgC
@@ -229926,9 +229926,9 @@ vRu
 acD
 qgC
 qgC
-sRu
+jaA
 vuH
-dbH
+bVa
 qgC
 acD
 vRu
@@ -230329,7 +230329,7 @@ acD
 acD
 acD
 acD
-rnv
+nhR
 acD
 acD
 acD
@@ -231130,12 +231130,12 @@ vRu
 vRu
 acD
 qgC
-tUp
-abZ
+qzy
+dSi
 vuH
 ffw
 qgC
-tUp
+qzy
 acD
 vRu
 vRu
@@ -231533,7 +231533,7 @@ vRu
 acD
 qgC
 qgC
-abZ
+dSi
 qgC
 vuH
 vuH
@@ -231934,9 +231934,9 @@ vRu
 vRu
 acD
 qgC
-tUp
+qzy
 qgC
-abZ
+dSi
 vuH
 vuH
 qgC
@@ -232738,9 +232738,9 @@ vRu
 vRu
 acD
 qgC
-nTR
+kja
 qgC
-nTR
+kja
 ffw
 vuH
 qgC
@@ -233141,11 +233141,11 @@ vRu
 acD
 qgC
 vRu
-abZ
+dSi
 vuH
 vuH
 vuH
-tUp
+qzy
 acD
 vRu
 vRu
@@ -233545,8 +233545,8 @@ acD
 acD
 acD
 acD
-qCT
-oMa
+mdm
+atE
 acD
 acD
 vRu
@@ -265425,8 +265425,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -265828,8 +265828,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -266232,9 +266232,9 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -266636,8 +266636,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -267040,8 +267040,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -267444,7 +267444,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -267847,7 +267847,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -268250,8 +268250,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 vIa
@@ -268653,8 +268653,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 vIa
 rbn
@@ -269056,8 +269056,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 aUc
 aUc
 vIa
@@ -280614,12 +280614,12 @@ hcW
 hcW
 hcW
 cWT
-yiI
-yiI
-yiI
-yiI
-yiI
-yiI
+qeY
+qeY
+qeY
+qeY
+qeY
+qeY
 uSw
 uSw
 uSw
@@ -280639,35 +280639,35 @@ uSw
 uSw
 uSw
 uSw
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281015,12 +281015,12 @@ uaL
 uaL
 uaL
 uaL
-uwa
-vPA
-pgW
+veW
+itC
+rcr
 mwq
 mwq
-cjJ
+aok
 nrw
 nrw
 nrw
@@ -281050,26 +281050,26 @@ ykt
 ykt
 ykt
 ykt
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
+veW
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281417,61 +281417,61 @@ wSn
 wSn
 uaL
 uaL
-uwa
-vPA
-njm
-mwq
-mwq
-mwq
-nrw
-nrw
-spM
-tlQ
-tlQ
-obq
-obq
-tDK
-nrw
-kzQ
-bqt
-bqt
-bqt
-kzQ
-bLe
-xbW
-xbW
-eMC
-rlz
-nrw
-mwq
-mwq
+veW
 itC
+rYO
+mwq
+mwq
+mwq
+nrw
+nrw
+qbA
+bPv
+bPv
+vOe
+vOe
+qEO
+nrw
+kzQ
+mdB
+mdB
+mdB
+kzQ
+hnL
+mVz
+mVz
+gCr
+ewu
+nrw
+mwq
+mwq
+htf
 uaL
-xxB
+mtO
 paf
 qvR
 qvR
-sIE
+jpw
 uaL
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
 kVc
-uwa
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -281819,62 +281819,62 @@ wSn
 wSn
 tzK
 uaL
-uwa
-vPA
-wae
-mwq
-mwq
-hNB
-nrw
-nrw
-kcu
-tlQ
-mjP
-mVz
-mVz
-mVz
-nrw
-jlO
-bqt
-kQu
-bqt
-jlO
-bLe
-xbW
-xbW
-iGx
-aem
-nrw
-mwq
-mwq
+veW
 itC
+ebb
+mwq
+mwq
+cGQ
+nrw
+nrw
+kvp
+bPv
+aNG
+bPz
+bPz
+bPz
+nrw
+jlO
+mdB
+hbi
+mdB
+jlO
+hnL
+mVz
+mVz
+bBc
+pRt
+nrw
+mwq
+mwq
+htf
 uaL
-xxB
+mtO
 paf
 qvR
 qvR
-sIE
+jpw
 uaL
 uaL
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 cWT
 cWT
@@ -282221,65 +282221,65 @@ wSn
 uaL
 uaL
 uaL
-uwa
-vPA
-suQ
+veW
+itC
+iZb
 mwq
 mwq
-hNB
+cGQ
 nrw
 nrw
-svu
-tlQ
-tlQ
-tlQ
-tlQ
-tlQ
-cwd
+vHd
+bPv
+bPv
+bPv
+bPv
+bPv
+jZA
 jlO
-bqt
-jJg
-eSH
+mdB
+wUw
+hhY
 jlO
 evo
-rRD
-xbW
-uOs
-xbW
+wTs
+mVz
+qmp
+mVz
 nrw
 mwq
 mwq
-itC
+htf
 uaL
 uaL
 paf
 qvR
 qvR
-sIE
+jpw
 fxx
 aJj
 wSn
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 cWT
 hcW
 hcW
@@ -282623,66 +282623,66 @@ wSn
 uaL
 uaL
 uaL
-uwa
-vPA
-vPA
-dbt
-dbt
-pyT
-vPA
-nrw
-sbp
-alw
-mjP
-tlQ
-mjP
-tlQ
-cwd
-jlO
-bqt
-pMn
-bqt
-jlO
-nrw
-wVL
-xbW
-xbW
-xbW
-qiv
-mwq
-mwq
+veW
 itC
+itC
+jlY
+jlY
+exq
+itC
+nrw
+peX
+xqD
+aNG
+bPv
+aNG
+bPv
+jZA
+jlO
+mdB
+glV
+mdB
+jlO
+nrw
+xFb
+mVz
+mVz
+mVz
+qmC
+mwq
+mwq
+htf
 uaL
 uaL
-kwN
+aPR
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 wSn
 wSn
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 hcW
@@ -283025,68 +283025,68 @@ wSn
 wSn
 uaL
 uaL
-uwa
-vPA
-suQ
-dbt
-dbt
-pyT
-vPA
-nrw
-nBf
-tlQ
-tlQ
-hbc
-hbc
-hbc
-nrw
-jlO
-bqt
-wFy
-bqt
-jlO
-nrw
-eMm
-xbW
-tKx
-mwq
-qiv
-mwq
-mwq
+veW
 itC
+iZb
+jlY
+jlY
+exq
+itC
+nrw
+ogj
+bPv
+bPv
+fVM
+fVM
+fVM
+nrw
+jlO
+mdB
+hsp
+mdB
+jlO
+nrw
+cuh
+mVz
+uFp
+mwq
+qmC
+mwq
+mwq
+htf
 ykt
 ykt
 ykt
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 wSn
 aJj
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 uaL
@@ -283388,7 +283388,7 @@ cWT
 hcW
 hcW
 hcW
-cJi
+xwo
 wSn
 wSn
 wSn
@@ -283427,69 +283427,69 @@ uaL
 uaL
 uaL
 uaL
-uwa
-vPA
-pgW
-dbt
-dbt
-dbt
-nNV
-tlQ
-tlQ
-mjP
-uFN
-mVz
-mVz
-hZP
-nrw
-jwm
-bqt
-bqt
-bqt
-fmV
-nrw
-rRD
-xbW
-tKx
-mwq
-qiv
-rHj
-mwq
+veW
 itC
+rcr
+jlY
+jlY
+jlY
+lMZ
+bPv
+bPv
+aNG
+iUn
+bPz
+bPz
+nPg
+nrw
+ycs
+mdB
+mdB
+mdB
+oRb
+nrw
+wTs
+mVz
+uFp
+mwq
+qmC
+nBf
+mwq
+htf
 uaL
 uaL
-kwN
+aPR
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 wSn
 uaL
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 uaL
 uaL
 wSn
@@ -283829,68 +283829,68 @@ hcW
 hcW
 uaL
 uaL
-uwa
-vPA
-njm
-dbt
-dbt
-dbt
-vPA
-nrw
-cwd
-nrw
-nrw
-nrw
-nrw
-nrw
-nrw
-nrw
-fmV
-vVo
-jlO
-jlO
-nrw
-xgn
-xbW
-mwq
-puY
-nrw
-ogC
-mwq
+veW
 itC
-fLK
+rYO
+jlY
+jlY
+jlY
+itC
+nrw
+jZA
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+oRb
+cWS
+jlO
+jlO
+nrw
+lBJ
+mVz
+mwq
+qqE
+nrw
+eoz
+mwq
+htf
+pxY
 uaL
 paf
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
 wSn
 uaL
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 wSn
@@ -284231,67 +284231,67 @@ hcW
 hcW
 uaL
 uaL
-uwa
-vPA
-wae
-xOC
-dbt
-dbt
-rcr
-mwq
-mwq
-syH
-mwq
-mwq
-mwq
-mwq
-mwq
-nrw
-aCa
-nrw
-jlO
-jlO
-nrw
-jAC
-mkj
-mwq
-wCy
-nrw
-rHj
-mwq
+veW
 itC
-tOW
+ebb
+jQk
+jlY
+jlY
+umi
+mwq
+mwq
+hIn
+mwq
+mwq
+mwq
+mwq
+mwq
+nrw
+jZp
+nrw
+jlO
+jlO
+nrw
+vJz
+cOS
+mwq
+qBH
+nrw
+nBf
+mwq
+htf
+sFM
 uaL
 paf
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
 uaL
 wSn
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 qvR
@@ -284633,65 +284633,65 @@ hcW
 hcW
 hcW
 uaL
-uwa
-vPA
-vPA
-vPA
-vPA
-nrw
-nrw
-mwq
-mwq
-mwq
-mwq
-tKx
-mwq
-mwq
-mwq
-mwq
-mwq
-nrw
-qzJ
-nrw
-nrw
-nrw
-nrw
-mzd
-nrw
-nrw
-mwq
-mwq
+veW
 itC
+itC
+itC
+itC
+nrw
+nrw
+mwq
+mwq
+mwq
+mwq
+uFp
+mwq
+mwq
+mwq
+mwq
+mwq
+nrw
+cMs
+nrw
+nrw
+nrw
+nrw
+tUZ
+nrw
+nrw
+mwq
+mwq
+htf
 lsD
 lsD
-bZo
+dFa
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
 fxx
 wSn
-uwa
+veW
 kVc
-uwa
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -285035,65 +285035,65 @@ hcW
 hcW
 uaL
 uaL
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
 evo
 nrw
 nrw
-wLX
-wLX
-nyO
-ism
-jdI
-jdI
-jdI
-fwP
+mYZ
+mYZ
+uCD
+jAw
+mxy
+mxy
+mxy
+rcm
 mwq
 nrw
-tlQ
-aWh
-wkz
-xET
-onQ
-rHj
-ogC
-rHj
+bPv
+qDL
+pBp
+sJt
+fcf
+nBf
+eoz
+nBf
 mwq
 mwq
-itC
+htf
 rhD
 rhD
 rhD
 rhD
 rhD
-sIE
+jpw
 fxx
 fxx
 fxx
 fxx
 uaL
-uwa
+veW
 kVc
-uwa
-kVc
-kVc
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 uaL
@@ -285441,31 +285441,31 @@ uaL
 uaL
 qvR
 qvR
-uwa
+veW
 evo
-jzM
-ogC
+uEA
+eoz
 cbG
 cbG
-vjs
-fwP
-sNU
-vZi
-jKP
-fwP
-tKx
+maV
+rcm
+ilv
+hCW
+kZx
+rcm
+uFp
 nrw
-tlQ
-lSj
-tlQ
-qzJ
+bPv
+oRp
+bPv
+cMs
 mwq
 mwq
-rHj
+nBf
 mwq
 mwq
 mwq
-usK
+ulR
 fxx
 fxx
 fxx
@@ -285478,24 +285478,24 @@ fxx
 fxx
 aJj
 wSn
-uwa
-uwa
+veW
+veW
 kVc
 kVc
-uwa
+veW
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 uaL
@@ -285843,34 +285843,34 @@ uaL
 uaL
 qvR
 qvR
-fSe
+wPR
 evo
-nXF
-ogC
+sWT
+eoz
 cbG
 cbG
-nyO
-fwP
-nuB
-fRl
-csw
-fwP
+uCD
+rcm
+uka
+wqq
+kKG
+rcm
 mwq
-dTy
-tlQ
-mjP
-tlQ
-qzJ
-mwq
-mwq
+gff
+bPv
+aNG
+bPv
+cMs
 mwq
 mwq
 mwq
 mwq
-usK
+mwq
+mwq
+ulR
 fxx
 fxx
-heM
+meF
 fxx
 fxx
 fxx
@@ -285880,24 +285880,24 @@ fxx
 fxx
 uaL
 wSn
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 wSn
@@ -286245,31 +286245,31 @@ uaL
 uaL
 qvR
 qvR
-fSe
+wPR
 evo
-omn
-ogC
+qzH
+eoz
 cbG
 cbG
-nyO
-fwP
-fDR
-xCo
-gqo
-fwP
+uCD
+rcm
+lhd
+kFh
+bEJ
+rcm
 mwq
 nrw
-lDI
-vnR
-tlQ
-qzJ
+olZ
+gtr
+bPv
+cMs
 mwq
 mwq
 mwq
 mwq
 mwq
 mwq
-usK
+ulR
 fxx
 fxx
 fxx
@@ -286283,23 +286283,23 @@ fxx
 uaL
 uaL
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -286611,7 +286611,7 @@ uaL
 uaL
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -286647,37 +286647,37 @@ uaL
 uaL
 qvR
 qvR
-fSe
+wPR
 evo
 nrw
 nrw
-wYx
-wYx
-nyO
-fwP
-viw
-viw
-viw
-fwP
-tKx
+frp
+frp
+uCD
+rcm
+avO
+avO
+avO
+rcm
+uFp
 nrw
-yih
-ntl
-tlQ
-xET
+eYG
+aac
+bPv
+sJt
 mwq
 mwq
-rHj
+nBf
 mwq
 mwq
 mwq
-itC
+htf
 rhD
 rhD
 rhD
 rhD
 rhD
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -286685,23 +286685,23 @@ fxx
 fxx
 aJj
 kVc
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -287049,14 +287049,14 @@ uaL
 uaL
 qvR
 qvR
-uwa
+veW
 evo
 nrw
 mwq
 mwq
 mwq
 mwq
-tKx
+uFp
 mwq
 mwq
 mwq
@@ -287065,21 +287065,21 @@ mwq
 nrw
 nrw
 nrw
-cld
+dQi
 nrw
-onQ
-rHj
-ogC
-rHj
+fcf
+nBf
+eoz
+nBf
 mwq
 mwq
-itC
-nes
+htf
+eKb
 qvR
 qvR
 qvR
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -287087,23 +287087,23 @@ fxx
 fxx
 uaL
 aJj
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
-uwa
+veW
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
-uwa
+veW
 kVc
 qvR
 qvR
@@ -287451,37 +287451,37 @@ uaL
 uaL
 uaL
 qvR
-uwa
+veW
 evo
 nrw
-oQD
+tmj
 mwq
-ema
-mwq
-mwq
+vYa
 mwq
 mwq
 mwq
-nrw
-nrw
-nrw
-nrw
-sxM
-tlQ
-nrw
-nrw
-eda
-nrw
-nrw
-rHj
 mwq
-itC
+mwq
+nrw
+nrw
+nrw
+nrw
+uZC
+bPv
+nrw
+nrw
+wGR
+nrw
+nrw
+nBf
+mwq
+htf
 uaL
 uaL
 uaL
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -287489,23 +287489,23 @@ fxx
 fxx
 wSn
 aJj
-uwa
-uwa
-uwa
+veW
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 uaL
 wSn
@@ -287822,7 +287822,7 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -287851,9 +287851,9 @@ uaL
 uaL
 uaL
 hcW
-uwa
-uwa
-uwa
+veW
+veW
+veW
 evo
 nrw
 nrw
@@ -287865,25 +287865,25 @@ nrw
 nrw
 nrw
 nrw
-dcq
-dcq
+cCS
+cCS
 nrw
-sxM
-tlQ
-sxM
-cJR
-kqO
-obq
+uZC
+bPv
+uZC
+wRw
+dcU
+vOe
 nrw
-ogC
+eoz
 mwq
-itC
+htf
 uaL
 uaL
 uaL
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -287892,20 +287892,20 @@ fxx
 wSn
 aJj
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-eHF
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+sdD
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -288255,37 +288255,37 @@ hcW
 hcW
 hcW
 cWT
-yiI
-yiI
-yiI
-yiI
-sxM
-sxM
-sxM
-dcq
-dcq
-sxM
-sxM
-sxM
-tlQ
-cMs
+qeY
+qeY
+qeY
+qeY
+uZC
+uZC
+uZC
+cCS
+cCS
+uZC
+uZC
+uZC
+bPv
+bVe
 nrw
-gOu
-tlQ
-mjP
-tlQ
-lSj
-tlQ
-aym
-rHj
+sLs
+bPv
+aNG
+bPv
+oRp
+bPv
+inY
+nBf
 mwq
-itC
+htf
 qvR
 qvR
 qvR
 qvR
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -288294,20 +288294,20 @@ fxx
 wSn
 wSn
 kVc
-uwa
+veW
 kVc
-uwa
+veW
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 kVc
@@ -288654,40 +288654,40 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 cWT
-yiI
+qeY
 iJR
-soa
-cCS
-tlQ
-sbF
-cMs
-cMs
-sbF
-sbF
-cMs
-sbF
-sbF
-tlQ
-nXF
-kqO
-tlQ
-tlQ
-tlQ
-mjP
-tlQ
-xET
+sCf
+kMO
+bPv
+xFi
+bVe
+bVe
+xFi
+xFi
+bVe
+xFi
+xFi
+bPv
+sWT
+dcU
+bPv
+bPv
+bPv
+aNG
+bPv
+sJt
 mwq
 mwq
-itC
+htf
 uaL
 uaL
 uaL
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -288702,15 +288702,15 @@ kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 lyL
@@ -289020,25 +289020,22 @@ uaL
 uaL
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
-kFh
-hcW
-hcW
-hcW
-hcW
-kFh
+qRm
 hcW
 hcW
 hcW
+hcW
+qRm
 hcW
 hcW
 hcW
@@ -289047,11 +289044,14 @@ hcW
 hcW
 hcW
 hcW
-kFh
 hcW
 hcW
 hcW
-kFh
+qRm
+hcW
+hcW
+hcW
+qRm
 hcW
 hcW
 hcW
@@ -289059,37 +289059,37 @@ hcW
 hcW
 hcW
 cWT
-yiI
+qeY
 iJR
-vhe
-cCS
-tlQ
-sbF
-uNa
-hvB
-sbF
-cMs
-uNa
-cMs
-cMs
-mjP
+nzI
+kMO
+bPv
+xFi
+vUf
+ilx
+xFi
+bVe
+vUf
+bVe
+bVe
+aNG
 nrw
-tlQ
-tlQ
-hbc
-hbc
-tlQ
-tlQ
-xET
+bPv
+bPv
+fVM
+fVM
+bPv
+bPv
+sJt
 mwq
 mwq
-itC
+htf
 uaL
 uaL
 uaL
 uaL
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -289097,22 +289097,22 @@ fxx
 fxx
 uaL
 wSn
-uwa
+veW
 kVc
 kVc
 kVc
-uwa
+veW
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -289456,42 +289456,42 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 cWT
-yiI
-yiI
-yiI
-yiI
-sxM
-sxM
-sxM
-hKN
-hKN
-sxM
-sxM
-sxM
-cMs
-tlQ
-cPr
-tlQ
-tlQ
-tUR
-eoz
-uxV
-sxM
+qeY
+qeY
+qeY
+qeY
+uZC
+uZC
+uZC
+wSl
+wSl
+uZC
+uZC
+uZC
+bVe
+bPv
+ius
+bPv
+bPv
+lpY
+nbF
+kNR
+uZC
 nrw
 mwq
 mwq
-itC
-fRp
+htf
+iPO
 qvR
 qvR
 qvR
 qvR
-sIE
+jpw
 fxx
 fxx
 fxx
@@ -289499,22 +289499,22 @@ fxx
 fxx
 fxx
 wSn
-uwa
+veW
 kVc
-uwa
-kVc
-kVc
+veW
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -289851,7 +289851,7 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -289866,7 +289866,7 @@ cWT
 cWT
 cWT
 cWT
-yiI
+qeY
 nrw
 nrw
 nrw
@@ -289903,20 +289903,20 @@ fxx
 uaL
 kVc
 kVc
-uwa
+veW
 kVc
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 uaL
@@ -290235,7 +290235,7 @@ qvR
 uaL
 uaL
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -290253,14 +290253,14 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -290269,10 +290269,10 @@ hcW
 hcW
 hcW
 cWT
-fSe
-fSe
-vWY
-vWY
+wPR
+wPR
+iSF
+iSF
 evo
 ykt
 ykt
@@ -290307,17 +290307,17 @@ aJj
 kVc
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 kVc
 qvR
@@ -290638,7 +290638,7 @@ qvR
 qvR
 hcW
 hcW
-kFh
+qRm
 hcW
 kYc
 kYS
@@ -290647,7 +290647,7 @@ mzx
 kYc
 mzx
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -290671,8 +290671,8 @@ hcW
 hcW
 hcW
 hcW
-vWY
-fSe
+iSF
+wPR
 evo
 evo
 evo
@@ -290707,19 +290707,19 @@ fxx
 uaL
 uaL
 uaL
-uwa
+veW
 uaL
 kVc
 kVc
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
-uwa
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 kVc
 qvR
 qvR
@@ -291052,16 +291052,16 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -291452,18 +291452,18 @@ msk
 ntQ
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -291516,13 +291516,13 @@ uaL
 uaL
 fxx
 fxx
-xcZ
-gip
-gip
-gip
-gip
-gip
-xcZ
+vox
+vjs
+vjs
+vjs
+vjs
+vjs
+vox
 wSn
 uaL
 uaL
@@ -291843,7 +291843,7 @@ sJZ
 sJZ
 qvR
 hcW
-kFh
+qRm
 hcW
 hcW
 ldI
@@ -291918,13 +291918,13 @@ fxx
 fxx
 fxx
 fxx
-elx
+qQo
 peN
 peN
 peN
 peN
 peN
-axV
+vOH
 fxx
 fxx
 fxx
@@ -292233,7 +292233,7 @@ uaL
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 qvR
@@ -292265,13 +292265,13 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -292320,13 +292320,13 @@ fxx
 fxx
 fxx
 fxx
-gip
+vjs
 peN
 peN
 peN
-kGp
+twL
 peN
-gip
+vjs
 fxx
 fxx
 fxx
@@ -292670,10 +292670,10 @@ hcW
 hcW
 hcW
 hcW
-kFh
-kFh
+qRm
+qRm
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -292694,14 +292694,14 @@ wSn
 wSn
 wSn
 xKz
-lLV
-cRP
+rTT
+hGr
 lLa
 xKz
 xKz
-dad
-dAf
-kal
+nap
+jCm
+rHj
 xKz
 jeb
 jeb
@@ -293067,8 +293067,8 @@ hcW
 hcW
 hcW
 hcW
-kFh
-kFh
+qRm
+qRm
 hcW
 hcW
 hcW
@@ -293096,18 +293096,18 @@ wSn
 wSn
 wSn
 xKz
-ltl
+sQN
 iYQ
 fVQ
-qYw
+mQr
 qpt
 sDa
 peN
 kIf
-lvj
-qYw
+wgn
+mQr
 fVQ
-jKi
+bmO
 xKz
 qvR
 qvR
@@ -293124,13 +293124,13 @@ wSn
 uaL
 fTe
 wSn
-uvu
-xyK
-jHX
-jHX
-jHX
-xyK
-uvu
+rUr
+bay
+oRB
+oRB
+oRB
+bay
+rUr
 uaL
 uaL
 uaL
@@ -293471,7 +293471,7 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -293498,18 +293498,18 @@ wSn
 wSn
 wSn
 xKz
-sUU
-cRP
+nYv
+hGr
 fVQ
 lLa
 qpt
 sDa
 peN
 kIf
-lvj
+wgn
 lLa
 fVQ
-qzb
+pWw
 xKz
 qvR
 qvR
@@ -293529,7 +293529,7 @@ uaL
 xKz
 bOK
 jeb
-xkF
+bYy
 jeb
 bOK
 xKz
@@ -293866,14 +293866,14 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -293900,18 +293900,18 @@ wSn
 wSn
 wSn
 xKz
-ltl
+sQN
 iYQ
 fVQ
-qLk
+qRp
 qpt
 sDa
 peN
 kIf
-lvj
+wgn
 hmU
 fVQ
-qzb
+pWw
 xKz
 qvR
 qvR
@@ -293931,7 +293931,7 @@ uaL
 bOK
 tYP
 tYP
-kiL
+uQb
 tYP
 tYP
 xKz
@@ -294244,7 +294244,7 @@ uaL
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 qvR
 qvR
@@ -294266,7 +294266,7 @@ ndD
 kYc
 msk
 nxV
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -294302,8 +294302,8 @@ wSn
 wSn
 wSn
 xKz
-sUU
-cRP
+nYv
+hGr
 fVQ
 jeb
 jeb
@@ -294313,7 +294313,7 @@ kIf
 jeb
 jeb
 fVQ
-qzb
+pWw
 xKz
 qvR
 qvR
@@ -294330,11 +294330,11 @@ uaL
 qvR
 qvR
 uaL
-ibw
+fKy
 tYP
-vsg
+tsJ
 tYP
-quu
+oHu
 tYP
 xKz
 qvR
@@ -294704,18 +294704,18 @@ wSn
 wSn
 wSn
 xKz
-uBQ
+eSt
 iYQ
 fVQ
 fVQ
 jeb
-bdw
+mGn
 peN
 kIf
 jeb
 fVQ
 tYP
-wLf
+vGQ
 xKz
 qvR
 qvR
@@ -294733,7 +294733,7 @@ qvR
 uaL
 wSn
 xKz
-bzl
+sWs
 tYP
 tYP
 tYP
@@ -295058,7 +295058,7 @@ uaL
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -295106,7 +295106,7 @@ wSn
 wSn
 wSn
 xKz
-wis
+gvi
 lLa
 fVQ
 fVQ
@@ -295117,7 +295117,7 @@ kIf
 hZF
 fVQ
 sCg
-hOb
+dTa
 xKz
 qvR
 uaL
@@ -295136,10 +295136,10 @@ uaL
 wSn
 bOK
 tYP
-wLQ
+iie
 tYP
 sCg
-umA
+sZB
 xKz
 qvR
 qvR
@@ -295467,7 +295467,7 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -295508,18 +295508,18 @@ xKz
 xKz
 xKz
 xKz
-wis
+gvi
 lLa
 kMi
-bXL
+fKs
 jeb
-bdw
+mGn
 peN
 kIf
 jeb
 fVQ
 sCg
-hOb
+dTa
 xKz
 qvR
 uaL
@@ -295539,9 +295539,9 @@ wSn
 xKz
 xKz
 xKz
-dDc
+uhn
 sCg
-hOb
+dTa
 xKz
 qvR
 qvR
@@ -295913,7 +295913,7 @@ fVQ
 fVQ
 fVQ
 kMi
-uBQ
+eSt
 jeb
 sDa
 peN
@@ -295921,7 +295921,7 @@ kIf
 jeb
 fVQ
 tYP
-hOb
+dTa
 xKz
 qvR
 qvR
@@ -295943,7 +295943,7 @@ xKz
 xKz
 tYP
 sCg
-hOb
+dTa
 xKz
 qvR
 qvR
@@ -296253,7 +296253,7 @@ hcW
 wSn
 uaL
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -296320,10 +296320,10 @@ qpt
 sDa
 peN
 kIf
-lvj
+wgn
 lLa
 fVQ
-wdp
+eGy
 xKz
 qvR
 uaL
@@ -296343,9 +296343,9 @@ wSn
 xKz
 xKz
 xKz
-dDc
+uhn
 sCg
-umA
+sZB
 xKz
 qvR
 uaL
@@ -296655,7 +296655,7 @@ wSn
 wSn
 uaL
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
@@ -296664,7 +296664,7 @@ hcW
 hcW
 hcW
 hcW
-kFh
+qRm
 wSn
 wSn
 qvR
@@ -296711,7 +296711,7 @@ xqL
 wSn
 wSn
 xKz
-bXL
+fKs
 gqa
 fVQ
 fVQ
@@ -296722,10 +296722,10 @@ qpt
 sDa
 peN
 kIf
-lvj
+wgn
 lLa
 fVQ
-olm
+uxZ
 xKz
 qvR
 qvR
@@ -296745,7 +296745,7 @@ uaL
 xKz
 xKz
 xKz
-jlY
+uHk
 xKz
 xKz
 xKz
@@ -297054,19 +297054,19 @@ fyc
 cWT
 cWT
 wSn
-kFh
-kFh
-kFh
-kFh
+qRm
+qRm
+qRm
+qRm
 hcW
-kFh
+qRm
 hcW
 hcW
 hcW
-kFh
-kFh
-kFh
-kFh
+qRm
+qRm
+qRm
+qRm
 wSn
 wSn
 qvR
@@ -297113,7 +297113,7 @@ aJj
 uaL
 qvR
 xKz
-ltl
+sQN
 iYQ
 lLa
 fVQ
@@ -297124,10 +297124,10 @@ qpt
 sDa
 peN
 kIf
-lvj
-vAY
+wgn
+qgS
 fVQ
-aYG
+vkB
 xKz
 uaL
 uaL
@@ -297456,9 +297456,9 @@ fyc
 cWT
 cWT
 uaL
-kFh
-kFh
-kFh
+qRm
+qRm
+qRm
 hcW
 hcW
 hcW
@@ -297515,18 +297515,18 @@ evo
 evo
 evo
 xKz
-uBQ
-cRP
+eSt
+hGr
 kds
-vHr
+sJd
 xKz
-qLk
+qRp
 fVQ
 xKz
-txs
-mMs
-saT
-wgn
+vFL
+jgQ
+tNp
+xAh
 xKz
 xKz
 xKz
@@ -297926,29 +297926,29 @@ xKz
 xKz
 xKz
 uWL
-vum
-vum
+xET
+xET
 xKz
 xKz
-iug
-iug
-vTG
-vTG
-vTG
-vTG
-vTG
-vTG
-ezu
-ezu
-vTG
-vTG
-iug
-iug
-iug
-iug
-vTG
-vTG
-vTG
+dAf
+dAf
+bqt
+bqt
+bqt
+bqt
+bqt
+bqt
+vhV
+vhV
+bqt
+bqt
+dAf
+dAf
+dAf
+dAf
+bqt
+bqt
+bqt
 axq
 dnx
 axl
@@ -305163,7 +305163,7 @@ xKz
 wVI
 wbg
 wbg
-wyA
+lea
 wbg
 wbg
 wbg
@@ -305519,7 +305519,7 @@ mcK
 nBW
 mOY
 nBW
-rZP
+igd
 nBW
 wtF
 wbg
@@ -307133,7 +307133,7 @@ wtF
 wbg
 wbg
 wbg
-wyA
+lea
 wbg
 wbg
 wbg
@@ -309258,7 +309258,7 @@ bwS
 lVe
 hHF
 goK
-kQC
+uPD
 sux
 pYf
 pYf
@@ -310393,12 +310393,12 @@ wbg
 wbg
 wVI
 wVI
-lMZ
+kdN
 nHz
 wVI
 wVI
 wVI
-xfa
+xyB
 wVI
 wVI
 tUw
@@ -310435,7 +310435,7 @@ fxx
 fxx
 fxx
 fxx
-iSJ
+bmL
 fxx
 boU
 fxx
@@ -310453,13 +310453,13 @@ qvR
 wSn
 cyr
 hHF
-bwb
+wFp
 wlD
 sIG
 wlD
 wlD
 wlD
-kQC
+uPD
 wlD
 sIG
 wlD
@@ -310760,7 +310760,7 @@ wbg
 xXq
 yhZ
 yhZ
-wzk
+kMV
 yhZ
 yhZ
 xXq
@@ -311173,13 +311173,13 @@ xez
 wbg
 wbg
 wbg
-wyA
+lea
 wbg
 wbg
 wbg
 wbg
 wbg
-wyA
+lea
 wbg
 wbg
 wbg
@@ -311227,7 +311227,7 @@ fxx
 fxx
 fxx
 fxx
-iSJ
+bmL
 fxx
 fxx
 fxx
@@ -311595,7 +311595,7 @@ wbg
 wbg
 wbg
 wbg
-wyA
+lea
 wbg
 wbg
 wbg
@@ -311603,7 +311603,7 @@ wbg
 wbg
 wbg
 wbg
-wyA
+lea
 wbg
 wbg
 wbg
@@ -312853,7 +312853,7 @@ trG
 ryI
 fZw
 fxx
-iSJ
+bmL
 rhD
 qvR
 qvR
@@ -313211,9 +313211,9 @@ wew
 wxZ
 nRo
 bQf
-bgb
+mQA
 iPY
-xkj
+eEp
 wsR
 ukb
 wvE
@@ -313568,7 +313568,7 @@ aOn
 aOn
 lpa
 nCh
-wyA
+lea
 wbg
 wbg
 hOh
@@ -313601,9 +313601,9 @@ pUl
 rJX
 tCr
 guP
-lhv
+bZX
 guP
-asR
+olC
 wbg
 qtV
 iPY
@@ -313613,9 +313613,9 @@ wew
 wVI
 weX
 wVI
-bgb
+mQA
 iPY
-xkj
+eEp
 wsR
 xMr
 yho
@@ -314003,7 +314003,7 @@ rJX
 eai
 tCr
 guP
-sUJ
+otk
 guP
 iGf
 viq
@@ -314015,9 +314015,9 @@ wew
 wxZ
 wVI
 bQf
-khc
+bzl
 nXd
-ykH
+uSP
 wsR
 dHZ
 xww
@@ -314407,13 +314407,13 @@ fQm
 guP
 guP
 guP
-iot
+tCF
 uTQ
 qtV
 nXd
 nXd
 nXd
-jeS
+hrf
 wVI
 wVI
 wVI
@@ -314477,7 +314477,7 @@ lVe
 uxL
 sZI
 xlx
-slH
+rbZ
 iTv
 cXU
 iTv
@@ -314755,7 +314755,7 @@ uOL
 jxy
 vbO
 oif
-dWu
+oza
 oif
 uJk
 tOz
@@ -314812,16 +314812,16 @@ sxR
 sxR
 abh
 wbg
-iRN
-iRN
+woq
+woq
 aSH
-iRN
+woq
 wVI
 wVI
 wVI
 wVI
 wVI
-qzy
+iYS
 oUn
 xMr
 vwQ
@@ -314864,7 +314864,7 @@ hLK
 nht
 fxx
 fxx
-gqb
+nuH
 wxd
 wSn
 wSn
@@ -315203,7 +315203,7 @@ tYm
 oAn
 wbg
 wbg
-woq
+xVB
 dTB
 tVP
 tVP
@@ -315212,7 +315212,7 @@ tCG
 tVP
 tVP
 tCG
-oJM
+qdg
 wbg
 wVI
 wVI
@@ -315614,9 +315614,9 @@ tVP
 tVP
 tVP
 tVP
-ndE
+pEw
 qtV
-uPw
+pKQ
 rZY
 wVI
 wxZ
@@ -316004,21 +316004,21 @@ pAS
 sZN
 sZN
 xdq
-uHk
+jIP
 wbg
 wbg
-woq
+xVB
 rJC
 tVP
-tmR
+yjP
 tVP
 tVP
-ihm
+tZZ
 tVP
 tVP
-ndE
+pEw
 qtV
-uPw
+pKQ
 rZY
 wVI
 wxZ
@@ -316028,7 +316028,7 @@ wVI
 bQf
 wVI
 rZY
-jvr
+pAb
 kjH
 kjH
 kjH
@@ -316058,7 +316058,7 @@ vLS
 uaL
 sjP
 wSn
-iSJ
+bmL
 fxx
 lcg
 fQg
@@ -316412,17 +316412,17 @@ wbg
 wKT
 kFS
 tVP
-muU
-dFg
-qRh
-nGQ
+wZA
+hWr
+uEB
+aWQ
 tVP
 tCG
-ndE
+pEw
 wbg
 wbg
 wVI
-iir
+jJS
 wVI
 wVI
 wVI
@@ -316758,7 +316758,7 @@ oif
 oif
 oif
 oif
-cyy
+mbx
 eUJ
 eUJ
 jxy
@@ -316808,7 +316808,7 @@ sZN
 sZN
 lzC
 xdq
-uHk
+jIP
 wbg
 wbg
 wKT
@@ -316816,7 +316816,7 @@ eWj
 yfY
 ijS
 mmb
-tZZ
+xcm
 uaj
 yfY
 yfY
@@ -316826,8 +316826,8 @@ qEa
 vXm
 vXm
 vXm
-gwF
-lhN
+abZ
+vPA
 wVI
 wVI
 wVI
@@ -317228,12 +317228,12 @@ wbg
 uqe
 ewM
 uqe
-kTw
+xct
 wew
 wVI
 wVI
 rZY
-ikM
+qDm
 rZY
 jXw
 xgi
@@ -317612,7 +317612,7 @@ pDy
 sZN
 sZN
 xdq
-uHk
+jIP
 wbg
 wbg
 cCQ
@@ -317624,18 +317624,18 @@ yfY
 yfY
 yfY
 yfY
-lQe
+hAx
 wbg
-bbG
+lya
 uqe
 uqe
 uqe
-qFU
+yir
 wew
 weX
 wVI
 rZY
-oBs
+lqU
 rZY
 jXw
 xgi
@@ -317677,7 +317677,7 @@ gkv
 hLK
 njv
 fxx
-iSJ
+bmL
 wxd
 wxd
 wSn
@@ -317983,7 +317983,7 @@ wrj
 jDm
 jDm
 mwE
-qEH
+cHY
 mwE
 wbg
 wbg
@@ -318019,20 +318019,20 @@ wbg
 wbg
 cJz
 yfY
-lhd
+cye
 kfr
-tRG
+cZx
 uaj
-tZZ
-igT
-eJX
+xcm
+jEB
+lsg
 wKT
 cIh
 wbg
 uqe
 ewM
 uqe
-qFU
+yir
 wew
 wVI
 wVI
@@ -318416,7 +318416,7 @@ ygF
 ygF
 uDv
 xdq
-uHk
+jIP
 wbg
 wbg
 wKT
@@ -318434,13 +318434,13 @@ qEa
 gGZ
 gGZ
 gGZ
-ovj
-jeS
-wqq
-wqq
-wqq
-wqq
-wqq
+mgd
+hrf
+xdw
+xdw
+xdw
+xdw
+xdw
 kjH
 kjH
 kjH
@@ -318822,14 +318822,14 @@ qls
 wbg
 wbg
 wKT
-rtS
-yft
-ksK
-vQV
-ksK
-vQV
-ksK
-vQV
+iMg
+ewf
+urF
+xbW
+urF
+xbW
+urF
+xbW
 wKT
 wbg
 wbg
@@ -319622,7 +319622,7 @@ pMj
 pPI
 xdq
 xdq
-uHk
+jIP
 wbg
 wbg
 wKT
@@ -319640,13 +319640,13 @@ wbg
 usR
 ncb
 ncb
-oxJ
+ifS
 wbg
 wVI
 wVI
 wVI
 wVI
-qSx
+cld
 wVI
 wVI
 wbg
@@ -320024,18 +320024,18 @@ pOs
 pRW
 xdq
 qls
-bVa
+mJt
 wbg
 wbg
 wKT
 wKT
 jCs
-ksK
-wFp
-ksK
-wFp
-ksK
-wFp
+urF
+xwi
+urF
+xwi
+urF
+xwi
 wKT
 wbg
 wbg
@@ -320425,7 +320425,7 @@ xdq
 xdq
 xdq
 xdq
-xdw
+uEX
 wbg
 wbg
 wbg
@@ -320443,7 +320443,7 @@ wbg
 wbg
 vAB
 bnQ
-mMb
+oZA
 nWM
 wbg
 kjH
@@ -321229,7 +321229,7 @@ dCV
 csA
 dCV
 hXf
-uHk
+jIP
 wbg
 wbg
 wbg
@@ -321631,7 +321631,7 @@ dCV
 dCV
 dCV
 qee
-bVa
+mJt
 wbg
 wbg
 wbg
@@ -322437,11 +322437,11 @@ xMr
 xMr
 gGZ
 qCy
-hju
+hcT
 wVI
 weX
 wVI
-nvk
+sXO
 wbg
 ekQ
 qDx
@@ -322838,7 +322838,7 @@ bmi
 mgx
 xMr
 xAt
-uiO
+vvo
 wbg
 wVI
 wVI
@@ -323241,11 +323241,11 @@ oVp
 xMr
 qnO
 oZC
-ebe
+uxV
 wVI
 xbo
 wVI
-nvk
+sXO
 wbg
 hOh
 qDx
@@ -323643,11 +323643,11 @@ nTe
 qhC
 wbg
 wbg
-ebe
+uxV
 wVI
 wVI
 wVI
-nvk
+sXO
 wbg
 hOh
 qDx
@@ -324043,7 +324043,7 @@ oXn
 oXn
 oXn
 xMr
-tuE
+bUi
 wbg
 wbg
 wVI
@@ -324445,13 +324445,13 @@ paz
 bmi
 bmi
 xMr
-xdw
+uEX
 wbg
-hju
+hcT
 wVI
 weX
 wVI
-nvk
+sXO
 wbg
 lHf
 rfx
@@ -324847,7 +324847,7 @@ gVS
 gVS
 bmi
 xMr
-uHk
+jIP
 wbg
 wbg
 wbg
@@ -325249,7 +325249,7 @@ poR
 pPs
 bmi
 qhR
-xdw
+uEX
 wbg
 wbg
 wbg
@@ -326053,7 +326053,7 @@ orY
 orY
 bmi
 xMr
-uHk
+jIP
 wbg
 wbg
 wbg
@@ -326076,7 +326076,7 @@ ewt
 cEF
 wbg
 xll
-oVj
+ksK
 aOn
 jHc
 mwE
@@ -326455,7 +326455,7 @@ bmi
 mou
 bmi
 xMr
-uHk
+jIP
 wbg
 wbg
 wbg
@@ -328143,7 +328143,7 @@ kVc
 kVc
 hcW
 cWT
-uwa
+veW
 hcW
 hcW
 hcW
@@ -328544,8 +328544,8 @@ kVc
 kVc
 kVc
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -328946,8 +328946,8 @@ wxd
 kVc
 kVc
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -329348,8 +329348,8 @@ wxd
 kVc
 kVc
 kVc
-uwa
-uwa
+veW
+veW
 hcW
 hcW
 hcW
@@ -329662,9 +329662,9 @@ xKF
 xKF
 xKF
 xKF
-dRp
-plJ
-ncR
+tks
+tpO
+uMB
 xKF
 xKF
 xKF
@@ -329750,8 +329750,8 @@ xqL
 kVc
 kVc
 kVc
-uwa
-uwa
+veW
+veW
 hcW
 hcW
 hcW
@@ -330058,21 +330058,21 @@ uaL
 xAt
 xAt
 xKF
-mQA
-dIj
-dIj
-rCR
+wvn
+lGI
+lGI
+ebt
 xKF
 xKF
 eBN
 eBN
 eBN
-mGn
-mGn
-aha
+iug
+iug
+vcN
 trI
-cdn
-cdn
+aem
+aem
 hcp
 tkZ
 xKF
@@ -330152,8 +330152,8 @@ wxd
 kVc
 kVc
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -330460,22 +330460,22 @@ paf
 xAt
 xAt
 xKF
-jqK
-dIj
-dIj
-rCR
+lXv
+lGI
+lGI
+ebt
 xKF
 xKF
 ejY
 eBN
 eBN
-mGn
-mGn
+iug
+iug
 ejY
 trI
-cdn
+aem
 rTm
-cdn
+aem
 obL
 xKF
 vtw
@@ -330554,8 +330554,8 @@ sJZ
 wxd
 wxd
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -330862,10 +330862,10 @@ afX
 xAt
 xAt
 xKF
-nHm
-dIj
-dIj
-rCR
+rgO
+lGI
+lGI
+ebt
 xKF
 xKF
 xKF
@@ -330875,9 +330875,9 @@ xKF
 xKF
 xKF
 xKF
-cdn
-cdn
-cdn
+aem
+aem
+aem
 oiC
 xKF
 vtw
@@ -330956,8 +330956,8 @@ sJZ
 sJZ
 feP
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -331264,22 +331264,22 @@ paf
 xAt
 xAt
 xKF
-fsm
-dIj
-dIj
-lhZ
+eIr
+lGI
+lGI
+xpM
 xKF
 xKF
 xKF
 xKF
-xuT
+lTy
 ofq
 eBN
-cdn
-uHj
-cdn
+aem
+suN
+aem
 bok
-cdn
+aem
 tkZ
 xKF
 vtw
@@ -331358,8 +331358,8 @@ sJZ
 sJZ
 wxd
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -331666,10 +331666,10 @@ paf
 xAt
 xAt
 xKF
-utS
-dIj
-dIj
-etc
+nfd
+lGI
+lGI
+wIc
 xKF
 xKF
 iuo
@@ -331678,8 +331678,8 @@ ofq
 ofq
 eBN
 bok
-uHj
-cdn
+suN
+aem
 nrx
 idG
 obL
@@ -331760,8 +331760,8 @@ qet
 sJZ
 wxd
 kVc
-uwa
-uwa
+veW
+veW
 kVc
 hcW
 hcW
@@ -332068,10 +332068,10 @@ paf
 xAt
 xAt
 xKF
-hiA
-dIj
-eJZ
-niC
+jFP
+lGI
+cSR
+jjE
 xKF
 xKF
 iuo
@@ -332079,9 +332079,9 @@ wVy
 ofq
 ofq
 eBN
-cdn
-uHj
-cdn
+aem
+suN
+aem
 iIl
 xKF
 xKF
@@ -332162,8 +332162,8 @@ qet
 qet
 wxd
 kVc
-uwa
-uwa
+veW
+veW
 hcW
 hcW
 hcW
@@ -332470,10 +332470,10 @@ paf
 xAt
 xAt
 xKF
-anR
-uZC
+mwM
+vRA
 xKF
-vbx
+fDD
 xKF
 xKF
 xKF
@@ -332482,8 +332482,8 @@ xKF
 ofq
 eBN
 bok
-uHj
-cdn
+suN
+aem
 tkZ
 xKF
 vtw
@@ -332564,8 +332564,8 @@ qet
 qet
 wxd
 kVc
-uwa
-uwa
+veW
+veW
 hcW
 hcW
 hcW
@@ -332871,21 +332871,21 @@ uaL
 afX
 xAt
 xAt
-eqh
+seC
 fCM
 fCM
 cNo
 twX
 cNo
-eIH
+ohY
 eeO
-jOr
+qUg
 xKF
 eBN
 eBN
-cdn
-uHj
-cdn
+aem
+suN
+aem
 vCr
 xKF
 vtw
@@ -333273,20 +333273,20 @@ uaL
 paf
 xAt
 xAt
-eqh
+seC
 fCM
 fCM
 fCM
 fCM
-tfp
-jVO
+nca
+fvl
 dsW
 sKd
 xgL
-cdn
-cdn
-cdn
-cdn
+aem
+aem
+aem
+aem
 nrx
 obL
 xKF
@@ -333676,21 +333676,21 @@ uaL
 xAt
 xAt
 xKF
-mrd
+tiH
 iuo
 iuo
 iuo
-tfp
+nca
 wPC
 dsW
 sKd
 xgL
-mdB
-cdn
-cdn
-cdn
-cdn
-cdn
+oIv
+aem
+aem
+aem
+aem
+aem
 xKF
 vtw
 vWe
@@ -334078,21 +334078,21 @@ paf
 xAt
 xAt
 xKF
-xsJ
-xsJ
-xsJ
+aiZ
+aiZ
+aiZ
 iuo
 fCM
 sKd
 sKd
 vSM
-oIv
-cdn
-cdn
+fQq
+aem
+aem
 wIl
 dXw
 uHg
-cdn
+aem
 xKF
 vtw
 vWe
@@ -334103,7 +334103,7 @@ vtw
 qZh
 ltk
 mwE
-qEH
+cHY
 mwE
 mwE
 aOv
@@ -334480,11 +334480,11 @@ paf
 xAt
 xAt
 xKF
-cly
-ljW
-ihk
+dJz
+ych
+vtF
 iuo
-olW
+kzs
 sKd
 sKd
 xKF
@@ -334890,7 +334890,7 @@ xKF
 xKF
 xKF
 xKF
-hmr
+uvu
 eCn
 eCn
 xKF
@@ -336507,7 +336507,7 @@ oOU
 smO
 buj
 smO
-eFI
+xEF
 kSh
 sKd
 uHb
@@ -383527,31 +383527,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-iME
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
+ifg
+ifg
+ifg
+ifg
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
 erZ
 erZ
 erZ
@@ -383565,8 +383565,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -383929,31 +383929,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-iME
-qpX
+ifg
+ifg
+ifg
+ifg
+qDn
 rST
-bMe
-uxZ
-uxZ
-qpX
-uxZ
-uxZ
-qpX
-dFY
-iME
-lzh
-iME
-seC
-iME
-iME
-vLA
-iME
-iME
-rOc
-vNE
+juY
+wou
+wou
+qDn
+wou
+wou
+qDn
+toI
+ifg
+qip
+ifg
+eHv
+ifg
+ifg
+tJC
+ifg
+ifg
+psj
+xHe
 erZ
 erZ
 erZ
@@ -383967,8 +383967,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -384331,31 +384331,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-iME
-qpX
+ifg
+ifg
+ifg
+ifg
+qDn
 rST
-fNz
-uxZ
-uxZ
-qpX
-uxZ
-uxZ
-qpX
-vzO
-iME
-iME
-vzO
-qpX
-iME
-iME
-qpX
-rZV
-iME
+kiS
 wou
-vNE
+wou
+qDn
+wou
+wou
+qDn
+uzT
+ifg
+ifg
+uzT
+qDn
+ifg
+ifg
+qDn
+quL
+ifg
+rvU
+xHe
 erZ
 erZ
 erZ
@@ -384370,8 +384370,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -384733,31 +384733,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-iME
-qpX
-qpX
-qpX
-nGK
-uxZ
-qpX
-uxZ
-uxZ
-qpX
-qRp
-vHd
-iME
-owf
-qpX
 ifg
-iME
-qpX
-eTE
-qWg
-quL
-vNE
+ifg
+ifg
+ifg
+qDn
+qDn
+qDn
+sIE
+wou
+qDn
+wou
+wou
+qDn
+bCb
+pes
+ifg
+hFp
+qDn
+uHj
+ifg
+qDn
+lcF
+dwu
+vLA
+xHe
 erZ
 erZ
 erZ
@@ -384772,8 +384772,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385135,31 +385135,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-iME
-qpX
-qpX
-qpX
-nGK
-uxZ
-qpX
-uxZ
-uxZ
-qpX
-ycz
-iME
-iME
-faD
-qpX
-iME
-iME
-qpX
-qpX
-qpX
-qpX
-qpX
+ifg
+ifg
+ifg
+ifg
+qDn
+qDn
+qDn
+sIE
+wou
+qDn
+wou
+wou
+qDn
+vsg
+ifg
+ifg
+yiI
+qDn
+ifg
+ifg
+qDn
+qDn
+qDn
+qDn
+qDn
 erZ
 erZ
 erZ
@@ -385174,8 +385174,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385537,31 +385537,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-iME
-qpX
-qpX
-qpX
-fYb
-uxZ
-qpX
-uxZ
-uxZ
-qpX
-ycz
-iME
 ifg
-faD
-qpX
-iME
 ifg
-qpX
-qpX
-qpX
-qpX
-qpX
+ifg
+ifg
+qDn
+qDn
+qDn
+exJ
+wou
+qDn
+wou
+wou
+qDn
+vsg
+ifg
+uHj
+yiI
+qDn
+ifg
+uHj
+qDn
+qDn
+qDn
+qDn
+qDn
 erZ
 erZ
 erZ
@@ -385576,8 +385576,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385596,8 +385596,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 aUc
 vIa
 erZ
@@ -385939,31 +385939,31 @@ erZ
 erZ
 erZ
 erZ
-iME
-iME
-iME
-qpX
-qpX
-qpX
-qpX
-qpX
-tMO
-qpX
-qpX
-qpX
-qpX
-kEV
-qzH
-iME
-uDi
-qpX
-iME
 ifg
-vLA
-iME
-wou
-rOc
-vNE
+ifg
+ifg
+qDn
+qDn
+qDn
+qDn
+qDn
+qFF
+qDn
+qDn
+qDn
+qDn
+aZg
+iSJ
+ifg
+rRD
+qDn
+ifg
+uHj
+tJC
+ifg
+rvU
+psj
+xHe
 erZ
 erZ
 erZ
@@ -385978,8 +385978,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -385998,9 +385998,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386341,31 +386341,31 @@ vIa
 erZ
 erZ
 erZ
-iME
-iME
-iME
-qpX
-goP
-uxZ
-uxZ
-uxZ
-uxZ
-mQr
-qpX
-kdj
-iME
-iME
 ifg
-iME
-vzO
-qpX
-iME
-iME
-qpX
-iME
-iME
-iME
-vNE
+ifg
+ifg
+qDn
+wXi
+wou
+wou
+wou
+wou
+vLy
+qDn
+tVB
+ifg
+ifg
+uHj
+ifg
+uzT
+qDn
+ifg
+ifg
+qDn
+ifg
+ifg
+ifg
+xHe
 erZ
 erZ
 erZ
@@ -386380,8 +386380,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386399,10 +386399,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386743,31 +386743,31 @@ vIa
 erZ
 erZ
 erZ
-iME
-iME
-iME
-qpX
-rlG
-uxZ
-uxZ
-uxZ
-uxZ
-tEg
-qpX
-kdj
-iME
-vDn
-iME
-aKz
-vzO
-qpX
-iME
-iME
-qpX
-qPg
-hzI
-quL
-vNE
+ifg
+ifg
+ifg
+qDn
+eUt
+wou
+wou
+wou
+wou
+dtf
+qDn
+tVB
+ifg
+cwd
+ifg
+wsx
+uzT
+qDn
+ifg
+ifg
+qDn
+oKL
+nWG
+vLA
+xHe
 erZ
 erZ
 erZ
@@ -386782,8 +386782,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -386800,11 +386800,11 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387145,31 +387145,31 @@ vIa
 vIa
 erZ
 erZ
-iME
-iME
-iME
-qpX
-wYQ
-uxZ
-uxZ
-uxZ
-uxZ
-tEg
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-uTd
-uTd
-qpX
-qpX
-qpX
-qpX
-qpX
+ifg
+ifg
+ifg
+qDn
+lvu
+wou
+wou
+wou
+wou
+dtf
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+xdQ
+xdQ
+qDn
+qDn
+qDn
+qDn
+qDn
 erZ
 erZ
 erZ
@@ -387185,7 +387185,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -387202,10 +387202,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387550,24 +387550,24 @@ erZ
 erZ
 erZ
 erZ
-qpX
-bCb
-uxZ
-uxZ
-uxZ
-uxZ
-mQr
-qpX
-pFf
-keX
-bmL
-tYk
-bmL
-keX
-oAA
-uxZ
-uxZ
-cVu
+qDn
+mgR
+wou
+wou
+wou
+wou
+vLy
+qDn
+npZ
+wYv
+pcQ
+fvW
+pcQ
+wYv
+hQD
+wou
+wou
+ycz
 erZ
 erZ
 erZ
@@ -387587,7 +387587,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -387603,9 +387603,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -387952,24 +387952,24 @@ erZ
 erZ
 erZ
 erZ
-qpX
-jnc
-uxZ
-uxZ
-uxZ
-uxZ
-vUf
-qpX
-uxZ
-pyO
-pyO
-uxZ
-psi
-psi
-uxZ
-xpM
-uxZ
-cVu
+qDn
+eAP
+wou
+wou
+wou
+wou
+enF
+qDn
+wou
+iRN
+iRN
+wou
+lfG
+lfG
+wou
+rRA
+wou
+ycz
 erZ
 erZ
 erZ
@@ -387989,7 +387989,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -388005,9 +388005,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -388354,24 +388354,24 @@ erZ
 erZ
 erZ
 erZ
-qpX
-ebC
-uxZ
-uxZ
-uxZ
-uxZ
-fVM
-yld
-uxZ
-uxZ
-uxZ
-xpM
-uxZ
-uxZ
-xpM
-uxZ
-uxZ
-cVu
+qDn
+jQK
+wou
+wou
+wou
+wou
+yll
+ttB
+wou
+wou
+wou
+rRA
+wou
+wou
+rRA
+wou
+wou
+ycz
 erZ
 erZ
 erZ
@@ -388391,7 +388391,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -388407,9 +388407,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -388756,24 +388756,24 @@ erZ
 erZ
 erZ
 erZ
-qpX
-xNQ
-uxZ
-uxZ
-uxZ
-uxZ
-vUf
-qpX
-uxZ
-gzY
-gzY
-uxZ
-uxZ
-fQq
-fQq
-xpM
-uxZ
-cVu
+qDn
+bFX
+wou
+wou
+wou
+wou
+enF
+qDn
+wou
+uRt
+uRt
+wou
+wou
+hYo
+hYo
+rRA
+wou
+ycz
 erZ
 erZ
 erZ
@@ -388793,7 +388793,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -388809,9 +388809,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389158,24 +389158,24 @@ erZ
 erZ
 erZ
 erZ
-qpX
-dNL
-uxZ
-uxZ
-uxZ
-uxZ
-gXf
-qpX
-pFf
-bmL
-bmL
-oAA
-uxZ
-uxZ
-bMe
-fEX
-uxZ
-cVu
+qDn
+fxA
+wou
+wou
+wou
+wou
+xmZ
+qDn
+npZ
+pcQ
+pcQ
+hQD
+wou
+wou
+juY
+suf
+wou
+ycz
 erZ
 erZ
 erZ
@@ -389195,8 +389195,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389210,10 +389210,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389560,24 +389560,24 @@ erZ
 erZ
 erZ
 erZ
-qpX
-vox
-uxZ
-uxZ
-uxZ
-uxZ
-gXf
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-pkD
-pkD
-qpX
+qDn
+vvU
+wou
+wou
+wou
+wou
+xmZ
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+pBQ
+pBQ
+qDn
 erZ
 erZ
 erZ
@@ -389597,8 +389597,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389612,10 +389612,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -389962,28 +389962,28 @@ erZ
 erZ
 erZ
 erZ
-qpX
-xNQ
-uxZ
-uxZ
-uxZ
-uxZ
-gPF
-qpX
-uEX
-lGI
-qDl
-wPQ
-qDl
-lGI
-wPQ
-fEX
-uxZ
-qpX
-qpX
-qpX
-qpX
-qpX
+qDn
+bFX
+wou
+wou
+wou
+wou
+yfe
+qDn
+lPI
+pdl
+sgY
+tUR
+sgY
+pdl
+tUR
+suf
+wou
+qDn
+qDn
+qDn
+qDn
+qDn
 erZ
 erZ
 erZ
@@ -390000,7 +390000,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -390014,10 +390014,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -390363,29 +390363,29 @@ erZ
 erZ
 aUc
 erZ
-qpX
-qpX
-nGK
-uxZ
-uxZ
-uxZ
-uxZ
-koE
-qpX
-uxZ
-xpM
-uxZ
-uxZ
-uxZ
-uxZ
-xpM
-uxZ
-uxZ
-vLA
-iME
-iME
-rOc
-vNE
+qDn
+qDn
+sIE
+wou
+wou
+wou
+wou
+bHX
+qDn
+wou
+rRA
+wou
+wou
+wou
+wou
+rRA
+wou
+wou
+tJC
+ifg
+ifg
+psj
+xHe
 erZ
 erZ
 erZ
@@ -390402,7 +390402,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -390416,10 +390416,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -390765,29 +390765,29 @@ vIa
 vIa
 aUc
 aUc
-qpX
-qpX
-nGK
-uxZ
-uxZ
-uxZ
-uxZ
-fVM
-qpX
-ukj
-uxZ
-uxZ
-xpM
-xpM
-uxZ
-uxZ
-uxZ
-uxZ
-qpX
-oRp
-iME
-iME
-vNE
+qDn
+qDn
+sIE
+wou
+wou
+wou
+wou
+yll
+qDn
+rzb
+wou
+wou
+rRA
+rRA
+wou
+wou
+wou
+wou
+qDn
+quy
+ifg
+ifg
+xHe
 erZ
 erZ
 erZ
@@ -390804,7 +390804,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -390818,10 +390818,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -391167,29 +391167,29 @@ vIa
 vIa
 aUc
 aUc
-nxZ
-nxZ
-nGK
-aBG
-fVM
-uxZ
-uxZ
-uxZ
-bib
-uxZ
-uxZ
-uxZ
-xpM
-xpM
-uxZ
-uxZ
-uxZ
-uxZ
-qpX
-rZV
-iME
-iME
-vNE
+uDi
+uDi
+sIE
+toM
+yll
+wou
+wou
+wou
+wpc
+wou
+wou
+wou
+rRA
+rRA
+wou
+wou
+wou
+wou
+qDn
+quL
+ifg
+ifg
+xHe
 erZ
 erZ
 erZ
@@ -391206,7 +391206,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -391220,9 +391220,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -391570,28 +391570,28 @@ vIa
 vIa
 vIa
 aUc
-nxZ
-nxZ
-nxZ
-fVM
-fVM
-uxZ
-uxZ
-vua
-eUi
-xpM
-uxZ
-uxZ
-uxZ
-uxZ
-xpM
-uxZ
-uxZ
-qpX
-wpm
-iME
-iME
-vNE
+uDi
+uDi
+uDi
+yll
+yll
+wou
+wou
+aiu
+iWn
+rRA
+wou
+wou
+wou
+wou
+rRA
+wou
+wou
+qDn
+oMa
+ifg
+ifg
+xHe
 erZ
 erZ
 erZ
@@ -391608,7 +391608,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -391622,9 +391622,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -391974,26 +391974,26 @@ vIa
 vIa
 aUc
 aUc
-nxZ
-nxZ
-fVM
-fVM
-fVM
-qpX
-qpX
-gbA
-gbA
-mPn
-gbA
-fEX
-uxZ
-uxZ
-uxZ
-qpX
-uEq
-quL
-jCr
-vNE
+uDi
+uDi
+yll
+yll
+yll
+qDn
+qDn
+ffN
+ffN
+dNL
+ffN
+suf
+wou
+wou
+wou
+qDn
+kJx
+vLA
+uKf
+xHe
 erZ
 erZ
 erZ
@@ -392010,7 +392010,7 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -392024,9 +392024,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392377,25 +392377,25 @@ vIa
 vIa
 aUc
 aUc
-nxZ
-nxZ
-nxZ
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-dcZ
-dcZ
-dcZ
-dcZ
-qpX
-qpX
-qpX
-qpX
-qpX
+uDi
+uDi
+uDi
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+gds
+gds
+gds
+gds
+qDn
+qDn
+qDn
+qDn
+qDn
 erZ
 erZ
 erZ
@@ -392412,8 +392412,8 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392426,9 +392426,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392783,7 +392783,7 @@ aUc
 aUc
 aUc
 aUc
-ebb
+oJO
 erZ
 erZ
 erZ
@@ -392814,9 +392814,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -392827,10 +392827,10 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -393218,20 +393218,20 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -393624,15 +393624,15 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -394027,13 +394027,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qGh
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+dbt
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -394429,13 +394429,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-veW
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+khc
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -394807,12 +394807,12 @@ xKz
 xKz
 xKz
 xKz
-qGB
-xHe
-ras
-bHX
-tiH
-nhR
+aym
+kLw
+cjy
+tAb
+eSj
+foQ
 xKz
 erZ
 erZ
@@ -394831,13 +394831,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qGh
-qeY
-qGh
-mSY
-qeY
-gvi
+wpm
+dbt
+kvj
+dbt
+tDB
+kvj
+obq
 erZ
 erZ
 erZ
@@ -395204,10 +395204,10 @@ erZ
 fVQ
 fVQ
 xKz
-bPH
-fyv
-fyv
-wSS
+lGE
+hsd
+hsd
+ayc
 xKz
 fVQ
 fVQ
@@ -395233,13 +395233,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qeY
-qeY
-veW
-qGh
-qeY
-gvi
+wpm
+kvj
+kvj
+khc
+dbt
+kvj
+obq
 erZ
 erZ
 erZ
@@ -395614,14 +395614,14 @@ xKz
 fVQ
 fVQ
 jeb
-aFc
+mnG
 fVQ
-fLr
+qgD
 xKz
 fVQ
 bvN
 tYP
-pxe
+xaD
 jeb
 erZ
 erZ
@@ -395635,13 +395635,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qeY
-qeY
-qGh
-mSY
-qeY
-gvi
+wpm
+kvj
+kvj
+dbt
+tDB
+kvj
+obq
 erZ
 erZ
 erZ
@@ -396012,18 +396012,18 @@ fVQ
 fVQ
 fVQ
 fVQ
-qqk
+gip
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
-qqk
+gip
 fVQ
 bvN
 tYP
-gBS
+rGS
 jeb
 erZ
 erZ
@@ -396037,13 +396037,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qGh
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+dbt
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -396408,24 +396408,24 @@ erZ
 erZ
 erZ
 xKz
-xkl
-vdg
+qPF
+sbF
 fVQ
 fVQ
 lLa
-eSt
+vdg
 jeb
-vFz
-sIu
-eza
-eOt
+ips
+xpF
+rba
+lvy
 fVQ
 lLa
 xKz
 fVQ
 tYP
 tYP
-tDO
+ycX
 jeb
 erZ
 erZ
@@ -396439,13 +396439,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-veW
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+khc
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -396810,12 +396810,12 @@ erZ
 erZ
 erZ
 xKz
-dAG
-vdg
+tKO
+sbF
 fVQ
 fVQ
 lLa
-eSt
+vdg
 jeb
 xKz
 xKz
@@ -396827,7 +396827,7 @@ xKz
 fVQ
 tYP
 tYP
-htf
+pMn
 jeb
 erZ
 erZ
@@ -396841,13 +396841,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qGh
-qeY
-qGh
-mSY
-qeY
-gvi
+wpm
+dbt
+kvj
+dbt
+tDB
+kvj
+obq
 erZ
 erZ
 erZ
@@ -397212,24 +397212,24 @@ erZ
 erZ
 erZ
 xKz
-gww
-vdg
+bmc
+sbF
 fVQ
 fVQ
 fVQ
 fVQ
-qqk
+gip
 fVQ
-cZN
-wID
-tlP
+sLY
+wDz
+ulU
 fVQ
-kqw
+iKB
 xKz
 fVQ
 bvN
 tYP
-pxe
+xaD
 jeb
 erZ
 erZ
@@ -397243,13 +397243,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qeY
-qeY
-veW
-qGh
-qeY
-gvi
+wpm
+kvj
+kvj
+khc
+dbt
+kvj
+obq
 erZ
 erZ
 erZ
@@ -397614,24 +397614,24 @@ erZ
 erZ
 erZ
 xKz
-xLO
-vdg
+lBY
+sbF
 fVQ
-eqw
+fzR
 fVQ
 fVQ
 jeb
-ril
+dGv
 fVQ
 fVQ
 fVQ
 fVQ
-thU
+cmQ
 xKz
 fVQ
 bvN
 tYP
-gBS
+rGS
 jeb
 erZ
 erZ
@@ -397645,13 +397645,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qGh
-qeY
-qGh
-mSY
-qeY
-gvi
+wpm
+dbt
+kvj
+dbt
+tDB
+kvj
+obq
 erZ
 erZ
 erZ
@@ -398020,20 +398020,20 @@ xKz
 xKz
 xKz
 xKz
-fIW
+qYw
 xKz
 xKz
-xLE
+qGy
 fVQ
 jeb
-aFc
+mnG
 fVQ
-bep
+dNz
 xKz
 fVQ
 tYP
 tYP
-tDO
+ycX
 jeb
 erZ
 erZ
@@ -398047,13 +398047,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-veW
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+khc
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -398425,7 +398425,7 @@ fVQ
 fVQ
 fVQ
 xKz
-wYz
+lFQ
 fVQ
 fVQ
 fVQ
@@ -398435,7 +398435,7 @@ xKz
 fVQ
 tYP
 tYP
-htf
+pMn
 jeb
 erZ
 erZ
@@ -398449,13 +398449,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qGh
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+dbt
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -398827,17 +398827,17 @@ vZP
 lLa
 fVQ
 xKz
-xMA
-wSl
-fBj
-sdN
+lqV
+mRp
+tzj
+qFp
 fVQ
-xYA
+ftE
 xKz
 fVQ
 fIB
 tYP
-pxe
+xaD
 jeb
 erZ
 erZ
@@ -398851,13 +398851,13 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qeY
-qeY
-qeY
-qeY
-qeY
-gvi
+wpm
+kvj
+kvj
+kvj
+kvj
+kvj
+obq
 erZ
 erZ
 erZ
@@ -399227,7 +399227,7 @@ fVQ
 lLa
 noC
 lLa
-fLr
+qgD
 xKz
 xKz
 xKz
@@ -399253,10 +399253,10 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qeY
+wpm
+kvj
 xKz
-dgS
+lmT
 bOK
 jeb
 xKz
@@ -399638,7 +399638,7 @@ fVQ
 fVQ
 xKz
 xKz
-fIW
+qYw
 xKz
 xKz
 xKz
@@ -399655,8 +399655,8 @@ erZ
 erZ
 erZ
 erZ
-oJO
-qeY
+wpm
+kvj
 jeb
 fVQ
 ugK
@@ -418911,7 +418911,7 @@ ygF
 ygF
 ygF
 ygF
-mge
+rIm
 jYR
 lHe
 lHe
@@ -431771,8 +431771,8 @@ wAm
 wAm
 wAm
 wAm
-kRc
-kRc
+xIr
+xIr
 wAm
 wAm
 wAm
@@ -432173,9 +432173,9 @@ rwH
 uSx
 teW
 kqc
-eRc
+woJ
 jjS
-pKQ
+sNS
 vMQ
 vsf
 rwH
@@ -432183,8 +432183,8 @@ nKu
 jiv
 rwH
 teW
-uzR
-eAs
+vVP
+qeH
 wte
 enq
 fZJ
@@ -432572,10 +432572,10 @@ teW
 dvD
 jiv
 jiv
-hcc
+ixk
 teW
-eVP
-goz
+cdn
+ikM
 jiv
 jiv
 jiv
@@ -432586,7 +432586,7 @@ jiv
 jjS
 teW
 hqI
-oNn
+rDR
 uGf
 enq
 fZJ
@@ -432977,7 +432977,7 @@ jiv
 teW
 teW
 vMQ
-goz
+ikM
 jiv
 jiv
 jiv
@@ -432988,7 +432988,7 @@ jiv
 vIX
 teW
 hqI
-oNn
+rDR
 uGf
 enq
 fZJ
@@ -433373,7 +433373,7 @@ erZ
 fZJ
 fZJ
 teW
-cBG
+mrE
 jiv
 jiv
 hcx
@@ -433383,14 +433383,14 @@ jiv
 jiv
 jiv
 qfh
-nSr
+wra
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
-oNn
+rDR
 uGf
 enq
 fZJ
@@ -433775,7 +433775,7 @@ erZ
 fZJ
 fZJ
 teW
-cBG
+mrE
 jiv
 jiv
 hcx
@@ -433784,15 +433784,15 @@ jiv
 xSI
 jiv
 jiv
-hSs
-fBz
+nSr
+icP
 htU
 teW
 ael
 hqI
 hqI
 hqI
-oNn
+rDR
 uGf
 enq
 fZJ
@@ -434177,14 +434177,14 @@ erZ
 fZJ
 fZJ
 teW
-cBG
+mrE
 vAK
 xSI
 tML
 tML
 tML
-tnB
-tnB
+tOk
+tOk
 tML
 aGb
 tML
@@ -434194,7 +434194,7 @@ pDA
 hqI
 hqI
 hqI
-oNn
+rDR
 uGf
 enq
 fZJ
@@ -434589,14 +434589,14 @@ nyc
 ntK
 ntK
 cAe
-gEF
-qDn
+nWJ
+rSg
 teW
 ulu
 hqI
 fVE
-oNn
-oNn
+rDR
+rDR
 uGf
 enq
 fZJ
@@ -434990,15 +434990,15 @@ swm
 nyc
 ntK
 ntK
-mcB
-xrf
-xrf
+tak
+fLK
+fLK
 teW
 uNz
 hqI
 hqI
-oNn
-mvc
+rDR
+xMs
 ojc
 enq
 fZJ
@@ -435392,9 +435392,9 @@ swm
 nyc
 ntK
 ntK
-qBG
-rSg
-rSg
+mjP
+iqP
+iqP
 teW
 ajj
 lLK
@@ -435795,8 +435795,8 @@ ntK
 ntK
 ntK
 lYl
-uJM
-uJM
+xrf
+xrf
 ohA
 bcN
 bcN
@@ -436594,11 +436594,11 @@ uKB
 aur
 uZa
 cPw
-htG
+fEa
 ntK
 ntK
 ntK
-tak
+dwO
 ybm
 ybm
 ohA
@@ -437001,8 +437001,8 @@ nyc
 ntK
 ntK
 cAe
-qDn
-qDn
+rSg
+rSg
 teW
 eYI
 vGN
@@ -437402,13 +437402,13 @@ swm
 nyc
 ntK
 ntK
-mcB
-xrf
-xrf
+tak
+fLK
+fLK
 tML
-cTT
-cTT
-cTT
+vfW
+vfW
+vfW
 wAm
 tML
 tML
@@ -437804,13 +437804,13 @@ aXE
 nyc
 ntK
 ntK
-loE
-fwK
-dhJ
+iNA
+lkT
+qMF
 tML
-pcQ
-pcQ
-pcQ
+rgw
+rgw
+rgw
 wAm
 hKU
 hKU
@@ -437827,7 +437827,7 @@ squ
 squ
 squ
 rTC
-ttR
+aIl
 squ
 squ
 squ
@@ -438203,7 +438203,7 @@ tML
 teW
 tML
 tML
-xwi
+aNu
 fnF
 tML
 aGb
@@ -438217,7 +438217,7 @@ wpe
 fQd
 eCn
 sNY
-ozu
+aSo
 teW
 teW
 teW
@@ -438229,7 +438229,7 @@ squ
 squ
 squ
 rTC
-ttR
+aIl
 rTC
 rTC
 rTC
@@ -438623,7 +438623,7 @@ eCn
 teW
 aor
 xfh
-gcs
+rGY
 teW
 squ
 squ
@@ -439019,8 +439019,8 @@ cfY
 cfY
 teW
 aTF
-fpk
-jUZ
+jeE
+fPi
 eCn
 mYi
 gbX
@@ -439421,8 +439421,8 @@ uZy
 cfY
 alk
 eCn
-hRk
-tLe
+qor
+gSA
 eCn
 mYi
 gbX
@@ -439805,14 +439805,14 @@ erZ
 fZJ
 fZJ
 rxp
-kjI
+fJl
 uKB
 uBv
 tML
 tML
 tML
 xnv
-lbH
+tig
 tML
 rMM
 cfY
@@ -439827,9 +439827,9 @@ eCn
 eCn
 eCn
 teW
-mSE
-hfA
-eKj
+nwC
+sPx
+tlQ
 teW
 squ
 squ
@@ -440611,8 +440611,8 @@ fZJ
 rxp
 uKB
 uKB
-igh
-uJV
+ktU
+gbA
 uKB
 nIr
 swm
@@ -441410,14 +441410,14 @@ vIa
 vIa
 aUc
 teW
-pMQ
+xIq
 teW
 uKB
 uKB
-brj
-kvj
-iBe
-xGX
+jpc
+diu
+gpA
+kfI
 tML
 swm
 swm
@@ -441812,10 +441812,10 @@ vIa
 vIa
 aUc
 teW
-gHn
+ihj
 teW
-kxq
-rhV
+ptu
+rIE
 tML
 tML
 ydR
@@ -441831,10 +441831,10 @@ idu
 sct
 sNp
 cfY
-qKU
-nnx
-nzL
-leS
+twz
+mQx
+xsL
+wfJ
 eCn
 teW
 xJe
@@ -442226,17 +442226,17 @@ pjB
 swm
 swm
 tML
-lZo
+ivE
 cfY
 cfY
 bWq
 iMA
 pxR
 cfY
-qKU
-wvt
-pum
-oBC
+twz
+aiR
+kei
+hqZ
 eCn
 teW
 xJe
@@ -442630,15 +442630,15 @@ swm
 tML
 rMM
 eVa
-xde
+qKD
 tcW
 tcW
 tcW
 eVa
-aGc
-uFp
-lip
-kEf
+xzx
+pcr
+liH
+rYq
 eCn
 teW
 xJe
@@ -443018,7 +443018,7 @@ vIa
 vIa
 aUc
 teW
-gZn
+rXY
 nMd
 uKB
 uKB
@@ -443027,7 +443027,7 @@ tML
 tML
 tML
 wAm
-lbH
+tig
 wAm
 wAm
 teW
@@ -443422,14 +443422,14 @@ aUc
 teW
 teW
 teW
-uJV
+gbA
 uKB
 uKB
-pIB
+rnq
 iYx
-rRA
-aok
-aok
+cLL
+vWY
+vWY
 teW
 iYx
 iYx
@@ -443824,18 +443824,18 @@ aUc
 xJe
 xJe
 teW
-uJV
+gbA
 uKB
 uKB
-vmp
+bmj
 iYx
 vaa
-aok
-kdY
+vWY
+fWa
 teW
-cqJ
-tAc
-msN
+llV
+ljG
+ogC
 iYx
 xJe
 xJe
@@ -444226,18 +444226,18 @@ vIa
 lAs
 xJe
 teW
-uJV
+gbA
 uKB
 uKB
-dof
+kGB
 iYx
-uIc
-aok
-aok
+ePv
+vWY
+vWY
 teW
-pNc
-aok
-aok
+ebe
+vWY
+vWY
 iYx
 xJe
 lAs
@@ -444628,18 +444628,18 @@ vIa
 lAs
 xJe
 teW
-jFG
+viP
 uKB
 uKB
-gxP
+pJP
 iYx
-uVd
-aok
-aok
-mNs
-aok
-aok
-kaf
+nQh
+vWY
+vWY
+vFz
+vWY
+vWY
+mLO
 iYx
 xJe
 lAs
@@ -445035,13 +445035,13 @@ teW
 teW
 teW
 iYx
-lGo
-aok
-cfb
+hbc
+vWY
+eil
 iYx
-kve
-wYv
-qqz
+lWI
+sTN
+cdQ
 iYx
 xJe
 lAs
@@ -445437,9 +445437,9 @@ iYx
 iYx
 iYx
 iYx
-rRA
-aok
-hGr
+cLL
+vWY
+pCk
 iYx
 iYx
 iYx
@@ -445836,16 +445836,16 @@ lAs
 lAs
 xJe
 iYx
-hGr
-fTX
+pCk
+lYV
 iYx
 iYx
-aok
-cfb
+vWY
+eil
 iYx
-cqJ
-tAc
-msN
+llV
+ljG
+ogC
 iYx
 xJe
 lAs
@@ -446238,16 +446238,16 @@ lAs
 lAs
 xJe
 iYx
-pNc
-aok
-xwi
-aok
-aok
-aok
+ebe
+vWY
+aNu
+vWY
+vWY
+vWY
 iYx
-pNc
-aok
-aok
+ebe
+vWY
+vWY
 iYx
 xJe
 lAs
@@ -446640,16 +446640,16 @@ lAs
 lAs
 xJe
 iYx
-aok
-aok
+vWY
+vWY
 iYx
-aok
-aok
-aok
-mNs
-aok
-aok
-kaf
+vWY
+vWY
+vWY
+vFz
+vWY
+vWY
+mLO
 iYx
 xJe
 lAs
@@ -447042,16 +447042,16 @@ lAs
 lAs
 xJe
 iYx
-vyk
-qqz
+cQP
+cdQ
 iYx
-aok
-jLi
-nuH
+vWY
+fRy
+qwp
 iYx
-kve
-wYv
-qqz
+lWI
+sTN
+cdQ
 iYx
 xJe
 lAs
@@ -447443,18 +447443,18 @@ vIa
 vIa
 vIa
 aUc
-aac
+pdP
 iYx
 iYx
 iYx
-jEB
+eZX
 iYx
 iYx
 iYx
 iYx
 iYx
 iYx
-aac
+pdP
 aUc
 vIa
 vIa
@@ -447848,7 +447848,7 @@ aUc
 aUc
 iYx
 iYx
-neF
+qMB
 tWY
 tWY
 iyd
@@ -448249,8 +448249,8 @@ vIa
 vIa
 aUc
 iYx
-kEE
-wTs
+dUD
+tfp
 tWY
 tWY
 iyd
@@ -448651,8 +448651,8 @@ vIa
 vIa
 aUc
 iYx
-suN
-wTs
+wxi
+tfp
 tWY
 tWY
 iyd
@@ -449053,8 +449053,8 @@ vIa
 vIa
 aUc
 iYx
-nhz
-jQV
+fWp
+onS
 vGN
 vGN
 vGN
@@ -449457,9 +449457,9 @@ aUc
 iYx
 iYx
 iYx
-mrE
-mrE
-hYH
+mQg
+mQg
+sWy
 iYx
 xJe
 xJe
@@ -486033,36 +486033,36 @@ vIa
 aUc
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-vAn
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+dbH
 erZ
 erZ
 erZ
@@ -486432,39 +486432,39 @@ vIa
 vIa
 vIa
 vIa
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-iME
-iVh
-qpX
-qpX
-qpX
-iME
-iME
-iME
-iME
-iME
-vLA
-iME
-qpX
-lLn
-qEr
-gpb
-qwp
-jpw
-qwp
-uyA
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+ifg
+iXU
+qDn
+qDn
+qDn
+ifg
+ifg
+ifg
+ifg
+ifg
+tJC
+ifg
+qDn
+irI
+jYL
+mHK
+sgf
+aSD
+sgf
+cUj
 erZ
 erZ
 erZ
@@ -486834,39 +486834,39 @@ vIa
 erZ
 erZ
 erZ
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-iME
-syB
-qpX
-qpX
-qpX
-iME
-iME
-cOn
-eES
-eES
-qpX
-iME
-bPz
-jpw
-jpw
-jpw
-jpw
-jpw
-jpw
-dkD
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+ifg
+iWj
+qDn
+qDn
+qDn
+ifg
+ifg
+bzU
+iXi
+iXi
+qDn
+ifg
+lNY
+aSD
+aSD
+aSD
+aSD
+aSD
+aSD
+aXv
 erZ
 erZ
 erZ
@@ -487236,39 +487236,39 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-iME
-iME
-faD
-qpX
-qRp
-cjI
-dwO
-dHx
-qpX
-qpX
-qpX
-vLA
-qpX
-nNM
-jpw
-jpw
-jpw
-jpw
-jpw
-aYC
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+ifg
+ifg
+yiI
+qDn
+bCb
+sxM
+wDZ
+dkw
+qDn
+qDn
+qDn
+tJC
+qDn
+mkS
+aSD
+aSD
+aSD
+aSD
+aSD
+ofs
 erZ
 erZ
 erZ
@@ -487638,39 +487638,39 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-iME
-iME
-faD
-qpX
-cLL
-iME
-iME
-nxn
-qpX
-wpm
-iME
-iME
-qpX
-etX
-wDz
-vez
-jpw
-jpw
-jpw
-uyA
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+ifg
+ifg
+yiI
+qDn
+cRP
+ifg
+ifg
+syi
+qDn
+oMa
+ifg
+ifg
+qDn
+csm
+pdm
+irE
+aSD
+aSD
+aSD
+cUj
 erZ
 erZ
 erZ
@@ -488040,39 +488040,39 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-vLA
-qpX
-qpX
-qpX
-cLL
-iME
-iME
-nxn
-qpX
-dTa
-iME
-iME
-vAn
-yjP
-pdm
-bUi
-aew
-jpw
-jpw
-dkD
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+tJC
+qDn
+qDn
+qDn
+cRP
+ifg
+ifg
+syi
+qDn
+far
+ifg
+ifg
+dbH
+wyA
+wAJ
+hQz
+vjV
+aSD
+aSD
+aXv
 erZ
 erZ
 erZ
@@ -488442,39 +488442,39 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+qDn
 qpX
 qpX
-hsF
-hsF
-pBW
-qpX
-qRp
-qzH
-iME
-owf
-qpX
-iME
-dwO
-iME
-vAn
+auL
+qDn
+bCb
+iSJ
+ifg
+hFp
+qDn
+ifg
+wDZ
+ifg
+dbH
 wQI
-eWs
+sNj
 wQI
-dnc
-jpw
-jpw
-aYC
+umz
+aSD
+aSD
+ofs
 erZ
 erZ
 erZ
@@ -488844,39 +488844,39 @@ erZ
 erZ
 erZ
 erZ
-ebb
+oJO
 fIL
 wQD
 aUc
 aUc
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-qRp
-qzH
-iME
-dHx
-qpX
-cLL
-dwO
-dwO
-nxn
-qpX
-iME
-iME
-iME
-vAn
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+bCb
+iSJ
+ifg
+dkw
+qDn
+cRP
+wDZ
+wDZ
+syi
+qDn
+ifg
+ifg
+ifg
+dbH
 wQI
 wQI
 wQI
-wwK
-jpw
-jpw
-uyA
+lVF
+aSD
+aSD
+cUj
 erZ
 erZ
 erZ
@@ -489251,34 +489251,34 @@ eNY
 hby
 aUc
 aUc
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-cLL
-iME
-iME
-nxn
-qpX
-cLL
-iME
-iME
-nxn
-qpX
-dTa
-iME
-dTa
-vAn
-hMe
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+cRP
+ifg
+ifg
+syi
+qDn
+cRP
+ifg
+ifg
+syi
+qDn
+far
+ifg
+far
+dbH
+wfP
 wQI
-hMe
-dSd
-jpw
-jpw
-dkD
+wfP
+fhK
+aSD
+aSD
+aXv
 erZ
 erZ
 erZ
@@ -489654,33 +489654,33 @@ twI
 aUc
 aUc
 aUc
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+vsg
+ifg
 qpX
-ycz
-iME
-hsF
-faD
-qpX
-qRp
-qzH
-iME
-owf
-qpX
-wpm
-iME
-dwO
-qpX
-qpX
-qpX
-qpX
-wDz
-wDz
-wDz
-wUw
+yiI
+qDn
+bCb
+iSJ
+ifg
+hFp
+qDn
+oMa
+ifg
+wDZ
+qDn
+qDn
+qDn
+qDn
+pdm
+pdm
+pdm
+voc
 erZ
 erZ
 erZ
@@ -490055,30 +490055,30 @@ twI
 twI
 twI
 aUc
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-jIP
-qzH
-iME
-cOn
-qpX
-ycz
-iME
-iME
-faD
-qpX
-iME
-dwO
-iME
-rUf
-iME
-dTa
-hON
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+lZf
+iSJ
+ifg
+bzU
+qDn
+vsg
+ifg
+ifg
+yiI
+qDn
+ifg
+wDZ
+ifg
+qKU
+ifg
+far
+kPK
 erZ
 erZ
 erZ
@@ -490456,31 +490456,31 @@ aUc
 aUc
 xGC
 oWI
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-waG
-qzH
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+eIC
+iSJ
+ifg
+dkw
+qDn
+cRP
+ifg
+ifg
+syi
+qDn
+qKU
+ifg
+ifg
+ifg
+fnD
 iME
-dHx
-qpX
-cLL
-iME
-iME
-nxn
-qpX
-rUf
-iME
-iME
-iME
-ukm
-auL
-qrI
+lrF
 erZ
 erZ
 erZ
@@ -490858,31 +490858,31 @@ vIa
 aUc
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+vsg
 qpX
-ycz
-hsF
-iME
-nxn
-qpX
-qRp
-qzH
-iME
-owf
-qpX
-dTa
-iME
-dwO
-iME
-akO
-fvS
-rUQ
+ifg
+syi
+qDn
+bCb
+iSJ
+ifg
+hFp
+qDn
+far
+ifg
+wDZ
+ifg
+fDB
+kwN
+lUc
 erZ
 erZ
 erZ
@@ -491257,34 +491257,34 @@ erZ
 erZ
 erZ
 bQB
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-cLL
-iME
-iME
-faD
-qpX
-faD
-dwO
-dwO
-nxn
-qpX
-wpm
-rUf
-iME
-iME
-akO
-nHM
-iWj
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+cRP
+ifg
+ifg
+yiI
+qDn
+yiI
+wDZ
+wDZ
+syi
+qDn
+oMa
+qKU
+ifg
+ifg
+fDB
+xkF
+kad
 erZ
 erZ
 erZ
@@ -491659,34 +491659,34 @@ erZ
 erZ
 erZ
 bQB
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-qRp
-qzH
-iME
-rgO
-rgO
-rgO
-iME
-iME
-rgO
-rgO
-dwO
-iME
-rUf
-rUf
-akO
-nHM
-iWj
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+bCb
+iSJ
+ifg
+nTR
+nTR
+nTR
+ifg
+ifg
+nTR
+nTR
+wDZ
+ifg
+qKU
+qKU
+fDB
+xkF
+kad
 erZ
 erZ
 erZ
@@ -492061,34 +492061,34 @@ erZ
 erZ
 erZ
 bQB
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+cRP
 qpX
-cLL
-hsF
-iME
-uOz
-qpX
-kEV
-qzH
-iME
-uDi
-qpX
-wpm
-dwO
-iME
-dTa
-cEr
-cEr
-hea
+ifg
+wFa
+qDn
+aZg
+iSJ
+ifg
+rRD
+qDn
+oMa
+wDZ
+ifg
+far
+ovj
+ovj
+fTV
 erZ
 erZ
 erZ
@@ -492463,37 +492463,37 @@ erZ
 erZ
 erZ
 bQB
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+cRP
+ifg
 qpX
-cLL
-iME
-hsF
-iME
-vLA
-iME
-iME
-iME
-qpX
-qpX
-qpX
-qpX
-qpX
-wpm
-iME
-iME
+ifg
+tJC
+ifg
+ifg
+ifg
+qDn
+qDn
+qDn
+qDn
+qDn
+oMa
+ifg
+ifg
 uLh
 uLh
-bwP
-fDB
+nfn
+bBo
 uLh
 erZ
 erZ
@@ -492865,39 +492865,39 @@ erZ
 erZ
 erZ
 bQB
-ebb
+oJO
 uXW
 oRe
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-dKU
-qzH
-iME
-nWd
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-ebb
-ebb
-qpX
-iME
-iME
-dTa
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+aDD
+iSJ
+ifg
+wqB
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+oJO
+oJO
+qDn
+ifg
+ifg
+far
 uLh
-vzG
-urF
-pkf
+tLZ
+jCr
+dsq
 uLh
-wRi
+pTC
 erZ
 erZ
 erZ
@@ -493261,46 +493261,46 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 hqA
 pCW
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-qpX
-qpX
-qpX
-qpX
-qpX
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-dTa
-iME
-iME
-aSD
-urF
-urF
-bkL
-fDB
-urF
-urF
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+qDn
+qDn
+qDn
+qDn
+qDn
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+far
+ifg
+ifg
+gcf
+jCr
+jCr
+jka
+bBo
+jCr
+jCr
 erZ
 erZ
 erZ
@@ -493658,13 +493658,13 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 lgg
 lgg
 lgg
@@ -493676,33 +493676,33 @@ lgg
 lgg
 lgg
 lgg
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-qpX
-qpX
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-dTa
-iME
-iME
-aSD
-urF
-urF
-urF
-aSD
-urF
-urF
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+qDn
+qDn
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+far
+ifg
+ifg
+gcf
+jCr
+jCr
+jCr
+gcf
+jCr
+jCr
 erZ
 erZ
 erZ
@@ -494056,13 +494056,13 @@ vIa
 vIa
 vIa
 vIa
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
 lgg
 lgg
 lgg
@@ -494082,29 +494082,29 @@ lgg
 lgg
 vIa
 vIa
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-wpm
-iME
-iME
-aSD
-urF
-urF
-urF
-fDB
-urF
-urF
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+oMa
+ifg
+ifg
+gcf
+jCr
+jCr
+jCr
+bBo
+jCr
+jCr
 erZ
 erZ
 erZ
@@ -494487,25 +494487,25 @@ vIa
 vIa
 vIa
 vIa
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
-qpX
-aWt
-iME
-iME
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+oJO
+qDn
+pPY
+ifg
+ifg
 uLh
-ktI
-urF
-urF
+gog
+jCr
+jCr
 uLh
-wRi
+pTC
 erZ
 erZ
 erZ
@@ -494891,22 +494891,22 @@ vIa
 vIa
 vIa
 aUc
-ebb
-qpX
-tJC
-tJC
-tJC
-tJC
-tJC
-tJC
-tJC
-goR
-goR
+oJO
+qDn
+qCT
+qCT
+qCT
+qCT
+qCT
+qCT
+qCT
+bLa
+bLa
 uLh
 uLh
-uzT
-uzT
-iEA
+hNE
+hNE
+jxE
 erZ
 erZ
 erZ
@@ -495293,8 +495293,8 @@ vIa
 vIa
 vIa
 vIa
-ebb
-ebb
+oJO
+oJO
 erZ
 erZ
 erZ
@@ -496915,14 +496915,14 @@ erZ
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -497312,19 +497312,19 @@ erZ
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -497714,24 +497714,24 @@ erZ
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -498116,24 +498116,24 @@ erZ
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -498516,26 +498516,26 @@ sri
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -498918,26 +498918,26 @@ sri
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -499320,26 +499320,26 @@ sri
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -499722,26 +499722,26 @@ erZ
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -500124,26 +500124,26 @@ erZ
 erZ
 erZ
 erZ
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -500526,7 +500526,7 @@ erZ
 erZ
 erZ
 erZ
-wra
+cBG
 iJC
 bOK
 nEd
@@ -500534,18 +500534,18 @@ nEd
 nEd
 bOK
 iJC
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -500928,7 +500928,7 @@ erZ
 erZ
 erZ
 erZ
-wra
+cBG
 bOK
 fVQ
 fVQ
@@ -500936,18 +500936,18 @@ bmG
 fVQ
 fVQ
 bOK
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -501330,7 +501330,7 @@ erZ
 erZ
 erZ
 erZ
-wra
+cBG
 nEd
 fVQ
 lgN
@@ -501338,18 +501338,18 @@ jJC
 lgN
 fVQ
 nEd
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -501732,7 +501732,7 @@ erZ
 erZ
 erZ
 erZ
-wra
+cBG
 nEd
 fVQ
 qxZ
@@ -501746,12 +501746,12 @@ vxC
 vxC
 vxC
 ppx
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -502134,7 +502134,7 @@ erZ
 erZ
 erZ
 erZ
-wra
+cBG
 nEd
 fVQ
 fVQ
@@ -502148,12 +502148,12 @@ fZJ
 fZJ
 fZJ
 kZS
-wra
-wra
-wra
-wra
-wra
-wra
+cBG
+cBG
+cBG
+cBG
+cBG
+cBG
 erZ
 erZ
 erZ
@@ -543519,8 +543519,8 @@ vIa
 vIa
 vIa
 vIa
-adK
-adK
+cjJ
+cjJ
 lAs
 woj
 qPA
@@ -543921,8 +543921,8 @@ vIa
 vIa
 vIa
 vIa
-adK
-adK
+cjJ
+cjJ
 lAs
 woj
 qPA
@@ -544323,8 +544323,8 @@ vIa
 vIa
 vIa
 vIa
-adK
-adK
+cjJ
+cjJ
 lAs
 woj
 qPA
@@ -544725,8 +544725,8 @@ vIa
 vIa
 vIa
 vIa
-adK
-adK
+cjJ
+cjJ
 lAs
 eJN
 bHY
@@ -545127,8 +545127,8 @@ vIa
 vIa
 vIa
 vIa
-adK
-adK
+cjJ
+cjJ
 lAs
 lAs
 lAs
@@ -545529,7 +545529,7 @@ vIa
 vIa
 vIa
 vIa
-adK
+cjJ
 vIa
 vIa
 vIa
@@ -545931,7 +545931,7 @@ vIa
 vIa
 vIa
 vIa
-adK
+cjJ
 vIa
 vIa
 vIa
@@ -546333,7 +546333,7 @@ vIa
 vIa
 vIa
 vIa
-adK
+cjJ
 vIa
 vIa
 vIa


### PR DESCRIPTION
## About The Pull Request

At the request of Gisela, I've done a map update and have done a lot. Ranging from some OP item removal, the tree removal, apple trees are less common as to encourage people going to the Inn, and etc ec. Theres a LOT to unpack here. Church has their longly requested work area (with a secret easter egg there) with the Church getting an office for thine Grandmaster. Oh yeah and they get a drive through and better windows.

Smithy gets full frontal vision too and a meister is added to the Merchants line, with a railing line added for the Smithy too! They also get greater forges for them and their apprentice(s) too, so no longer in need of fighting. Beyond this, the doors got some good integrity so dont break them down!! Oh and the main plaza got updated too, and there are more gob portals so the priest fucking up and dying has actual consequences now.

There is a new area called the estates, which I'll be working on sometime soon:tm: that acts as a dungeon and reclaimable living space for any player driven faction. There are also some references there as well, added in good fun. Beyond that, the main gimmick is levers, players GOTTA pull the levers to fight through the entire mansion with some VERY GOOD rewards there. Oh and theres a new crypt somewhere too. So that's neat now is it? Oh and in prep of the bog/town watch merger, a new gate has been placed down as well that leads to the estates/mining area.

## Why It's Good For The Game

More content is good.

## FEEDBACK
PLEASE REPORT BUGS TO ME OR OVERSIGHTS