### PR TITLE
Wood to Coal and Crafting Menu Optimize

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -169,6 +169,20 @@
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2)
 	craftdiff = 3
 
+//	Having a regular log to coal craft broke things by allowing an unintended exploit using bundled sticks to craft infinite coal. 
+
+/datum/crafting_recipe/roguetown/alchemy/wst2coa
+	name = "transmute sticks to coal"
+	result = list(/obj/item/rogueore/coal = 1)
+	reqs = list(/obj/item/grown/log/tree/stick = 3)
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/alchemy/wsl2coa
+	name = "transmute small log to coals"
+	result = list(/obj/item/rogueore/coal, /obj/item/rogueore/coal)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+	craftdiff = 1
+
 /datum/crafting_recipe/roguetown/alchemy/s2coa
 	name = "transmute stone to coal"
 	result = list(/obj/item/rogueore/coal = 1)

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -178,8 +178,8 @@
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/alchemy/wsl2coa
-	name = "transmute small log to coals"
-	result = list(/obj/item/rogueore/coal, /obj/item/rogueore/coal)
+	name = "transmute small log to coal"
+	result = list(/obj/item/rogueore/coal)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	craftdiff = 1
 

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -101,19 +101,6 @@
 	verbage = "sews"
 	craftdiff = 0
 
-/datum/crafting_recipe/roguetown/bagx5
-	name = "bag x5"
-	result = list(/obj/item/storage/roguebag/crafted,
-		/obj/item/storage/roguebag/crafted,
-		/obj/item/storage/roguebag/crafted,
-		/obj/item/storage/roguebag/crafted,
-		/obj/item/storage/roguebag/crafted,)
-	reqs = list(/obj/item/natural/fibers = 5,
-		/obj/item/natural/cloth = 5)
-	tools = list(/obj/item/needle)
-	skillcraft = /datum/skill/misc/sewing
-	req_table = FALSE
-
 /datum/crafting_recipe/roguetown/bait
 	name = "bait"
 	result = /obj/item/bait
@@ -145,6 +132,19 @@
 		/obj/item/reagent_containers/food/snacks/rogue/meat = 2)
 	req_table = FALSE
 	subtype_reqs = TRUE
+
+/datum/crafting_recipe/roguetown/bagx5
+	name = "bag x5"
+	result = list(/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,)
+	reqs = list(/obj/item/natural/fibers = 5,
+		/obj/item/natural/cloth = 5)
+	tools = list(/obj/item/needle)
+	skillcraft = /datum/skill/misc/sewing
+	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/bag
 	name = "bag"
@@ -188,10 +188,11 @@
 	result = /obj/item/reagent_containers/glass/bucket/wooden
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
-/datum/crafting_recipe/roguetown/pot
-	name = "stone pot"
-	result = /obj/item/reagent_containers/glass/bucket/pot
-	reqs = list(/obj/item/natural/stone = 2)
+/datum/crafting_recipe/roguetown/pestle
+	name = "stone pestle"
+	result = /obj/item/pestle
+	reqs = list(/obj/item/natural/stone = 1)
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/mortar
 	name = "stone mortar"
@@ -199,11 +200,10 @@
 	reqs = list(/obj/item/natural/stone = 1)
 	craftdiff = 1
 
-/datum/crafting_recipe/roguetown/pestle
-	name = "stone pestle"
-	result = /obj/item/pestle
-	reqs = list(/obj/item/natural/stone = 1)
-	craftdiff = 1
+/datum/crafting_recipe/roguetown/pot
+	name = "stone pot"
+	result = /obj/item/reagent_containers/glass/bucket/pot
+	reqs = list(/obj/item/natural/stone = 2)
 
 /datum/crafting_recipe/roguetown/boneaxe
 	name = "bone axe"
@@ -439,6 +439,14 @@
 	result = /obj/item/kitchen/rollingpin
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
+/datum/crafting_recipe/roguetown/woodmealset
+	name = "wooden meal set (tray, mug, bowl, and spoon.)"
+	result = list(,/obj/item/storage/bag/tray,
+		/obj/item/reagent_containers/glass/cup/wooden/crafted,
+		/obj/item/reagent_containers/glass/bowl,
+		/obj/item/kitchen/spoon)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+
 /datum/crafting_recipe/roguetown/woodcup
 	name = "wooden cups (x3)"
 	result = list(/obj/item/reagent_containers/glass/cup/wooden/crafted,
@@ -449,12 +457,6 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted
 	sellprice = 3
 
-/datum/crafting_recipe/roguetown/woodtray
-	name = "wooden trays (x2)"
-	result = list(/obj/item/storage/bag/tray,
-		/obj/item/storage/bag/tray)
-	reqs = list(/obj/item/grown/log/tree/small = 1)
-
 /datum/crafting_recipe/roguetown/woodbowl
 	name = "wooden bowls (x3)"
 	result = list(/obj/item/reagent_containers/glass/bowl,
@@ -463,10 +465,17 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /datum/crafting_recipe/roguetown/spoon
-	name = "spoon"
+	name = "wooden spoons (x3)"
 	result = list(/obj/item/kitchen/spoon,
 		/obj/item/kitchen/spoon,
 		/obj/item/kitchen/spoon)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+
+/datum/crafting_recipe/roguetown/woodtray
+	name = "wooden trays (x3)"
+	result = list(/obj/item/storage/bag/tray,
+		/obj/item/storage/bag/tray,
+		/obj/item/storage/bag/tray)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /datum/crafting_recipe/roguetown/poisonarrow_five //Arrows and bolts can be smithed in batches of five. Makes sense for them to be dipped in batches of five, too

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -10,31 +10,21 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 0
 
-/datum/crafting_recipe/roguetown/cloth
-	name = "cloth"
-	result = /obj/item/natural/cloth
-	reqs = list(/obj/item/natural/fibers = 2)
-	tools = list(/obj/item/needle)
-	skillcraft = /datum/skill/misc/sewing
-	verbage_simple = "sew"
-	verbage = "sews"
+/datum/crafting_recipe/roguetown/ropebelt
+	name = "rope belt"
+	result = /obj/item/storage/belt/rogue/leather/rope
+	reqs = list(/obj/item/rope = 1)
 	craftdiff = 0
+	verbage_simple = "tie"
+	verbage = "ties"
 
-/datum/crafting_recipe/roguetown/cloth5x
-	name = "cloth 5x"
-	result = list(
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				)
-	reqs = list(/obj/item/natural/fibers = 10)
-	tools = list(/obj/item/needle)
-	skillcraft = /datum/skill/misc/sewing
-	verbage_simple = "sew"
-	verbage = "sews"
+/datum/crafting_recipe/roguetown/unropebelt
+	name = "untie rope belt"
+	result = /obj/item/rope
+	reqs = list(/obj/item/storage/belt/rogue/leather/rope = 1)
 	craftdiff = 0
+	verbage_simple = "untie"
+	verbage = "unties"
 
 /datum/crafting_recipe/roguetown/clothbelt
 	name = "cloth belt"
@@ -52,21 +42,121 @@
 	verbage_simple = "untie"
 	verbage = "unties"
 
-/datum/crafting_recipe/roguetown/ropebelt
-	name = "rope belt"
-	result = /obj/item/storage/belt/rogue/leather/rope
-	reqs = list(/obj/item/rope = 1)
-	craftdiff = 0
-	verbage_simple = "tie"
-	verbage = "ties"
+/datum/crafting_recipe/roguetown/book_crafting_kit
+	name = "book crafting kit"
+	result = /obj/item/book_crafting_kit
+	reqs = list(/obj/item/natural/hide = 2,
+		/obj/item/natural/cloth = 1)
+	tools = list(/obj/item/needle = 1)
+	req_table = TRUE
 
-/datum/crafting_recipe/roguetown/unropebelt
-	name = "untie rope belt"
-	result = /obj/item/rope
-	reqs = list(/obj/item/storage/belt/rogue/leather/rope = 1)
+/datum/crafting_recipe/roguetown/paperscroll
+	name = "scroll of parchment (x5)"
+	result = list(/obj/item/paper/scroll,
+		/obj/item/paper/scroll,
+		/obj/item/paper/scroll,
+		/obj/item/paper/scroll,
+		/obj/item/paper/scroll)
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/datum/reagent/water = 50)
+	tools = list(/obj/item/rogueweapon/huntingknife = 1)
+	structurecraft = /obj/structure/fluff/dryingrack
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/torch
+	name = "torch"
+	result = /obj/item/flashlight/flare/torch
+	reqs = list(/obj/item/grown/log/tree/stick = 1,
+		/obj/item/natural/fibers = 1)
 	craftdiff = 0
-	verbage_simple = "untie"
-	verbage = "unties"
+
+/datum/crafting_recipe/roguetown/candle
+	name = "candle (x3)"
+	result = list(/obj/item/candle/yellow,
+		/obj/item/candle/yellow,
+		/obj/item/candle/yellow)
+	reqs = list(/obj/item/reagent_containers/food/snacks/fat = 2)
+
+/datum/crafting_recipe/roguetown/cloth5x
+	name = "cloth 5x"
+	result = list(/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,)
+	reqs = list(/obj/item/natural/fibers = 10)
+	tools = list(/obj/item/needle)
+	skillcraft = /datum/skill/misc/sewing
+	verbage_simple = "sew"
+	verbage = "sews"
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/cloth
+	name = "cloth"
+	result = /obj/item/natural/cloth
+	reqs = list(/obj/item/natural/fibers = 2)
+	tools = list(/obj/item/needle)
+	skillcraft = /datum/skill/misc/sewing
+	verbage_simple = "sew"
+	verbage = "sews"
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/bagx5
+	name = "bag x5"
+	result = list(/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,
+		/obj/item/storage/roguebag/crafted,)
+	reqs = list(/obj/item/natural/fibers = 5,
+		/obj/item/natural/cloth = 5)
+	tools = list(/obj/item/needle)
+	skillcraft = /datum/skill/misc/sewing
+	req_table = FALSE
+
+/datum/crafting_recipe/roguetown/bait
+	name = "bait"
+	result = /obj/item/bait
+	reqs = list(/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/food/snacks/grown/wheat = 2)
+	req_table = FALSE
+	subtype_reqs = TRUE
+
+/datum/crafting_recipe/roguetown/sbaita
+	name = "sweetbait (apple)"
+	result = /obj/item/bait/sweet
+	reqs = list(/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/food/snacks/grown/apple = 2)
+	req_table = FALSE
+	subtype_reqs = TRUE
+
+/datum/crafting_recipe/roguetown/sbait
+	name = "sweetbait (berry)"
+	result = /obj/item/bait/sweet
+	reqs = list(/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2)
+	req_table = FALSE
+	subtype_reqs = TRUE
+
+/datum/crafting_recipe/roguetown/bloodbait
+	name = "bloodbait"
+	result = /obj/item/bait/bloody
+	reqs = list(/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/food/snacks/rogue/meat = 2)
+	req_table = FALSE
+	subtype_reqs = TRUE
+
+/datum/crafting_recipe/roguetown/bag
+	name = "bag"
+	result = /obj/item/storage/roguebag/crafted
+	reqs = list(/obj/item/natural/fibers = 1,
+		/obj/item/natural/cloth = 1)
+	tools = list(/obj/item/needle)
+	skillcraft = /datum/skill/misc/sewing
+	req_table = FALSE
+
+/obj/item/storage/roguebag/crafted
+	sellprice = 4
 
 /datum/crafting_recipe/roguetown/rope
 	name = "rope"
@@ -74,6 +164,205 @@
 	reqs = list(/obj/item/natural/fibers = 3)
 	verbage_simple = "braid"
 	verbage = "braids"
+
+/datum/crafting_recipe/roguetown/rod
+	name = "fishing rod"
+	result = /obj/item/fishingrod/crafted
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/fibers = 2)
+
+/obj/item/fishingrod/crafted
+	sellprice = 8
+
+/datum/crafting_recipe/roguetown/woodspade
+	name = "wood spade"
+	result = /obj/item/rogueweapon/shovel/small
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/grown/log/tree/stick = 1)
+
+/obj/item/rogueweapon/shovel/small/crafted
+	sellprice = 6
+
+/datum/crafting_recipe/roguetown/woodbucket
+	name = "wooden bucket"
+	result = /obj/item/reagent_containers/glass/bucket/wooden
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+
+/datum/crafting_recipe/roguetown/pot
+	name = "stone pot"
+	result = /obj/item/reagent_containers/glass/bucket/pot
+	reqs = list(/obj/item/natural/stone = 2)
+
+/datum/crafting_recipe/roguetown/mortar
+	name = "stone mortar"
+	result = /obj/item/reagent_containers/glass/mortar
+	reqs = list(/obj/item/natural/stone = 1)
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/pestle
+	name = "stone pestle"
+	result = /obj/item/pestle
+	reqs = list(/obj/item/natural/stone = 1)
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/boneaxe
+	name = "bone axe"
+	result = /obj/item/rogueweapon/stoneaxe/boneaxe
+	reqs = list(/obj/item/natural/stone = 1,
+		/obj/item/natural/bone = 2,
+		/obj/item/natural/fibers = 1)
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/bonespear
+	name = "bone spear"
+	result = /obj/item/rogueweapon/spear/bonespear
+	reqs = list(/obj/item/natural/stone = 1,
+		/obj/item/natural/bone = 2,
+		/obj/item/natural/fibers = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/antlerhood
+	name = "antlerhood"
+	result = /obj/item/clothing/head/roguetown/antlerhood
+	reqs = list(/obj/item/natural/hide = 1,
+		/obj/item/natural/antler = 2)
+	sellprice = 12
+	tools = list(/obj/item/needle)
+	skillcraft = /datum/skill/misc/sewing
+	verbage_simple = "sew"
+	verbage = "sews"
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/tribalskull
+	name = "wendigo helmet"
+	result = /obj/item/clothing/head/roguetown/tribalskull
+	reqs = list(/obj/item/natural/bone = 3,
+		/obj/item/natural/fibers = 1)
+	sellprice = 10
+	verbage_simple = "craft"
+	verbage = "crafted"
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/bonearmor
+	name = "bone armor"
+	result = /obj/item/clothing/suit/roguetown/armor/bone/chestplate
+	reqs = list(/obj/item/natural/bone = 3,
+		/obj/item/natural/fibers = 1)
+	sellprice = 1
+	verbage_simple = "craft"
+	verbage = "crafted"
+	craftdiff = 0	
+
+/datum/crafting_recipe/roguetown/bonegreaves
+	name = "bone greaves"
+	result = /obj/item/clothing/shoes/roguetown/boots/bonegreaves
+	reqs = list(/obj/item/natural/bone = 2,
+		/obj/item/natural/fibers = 1)
+	sellprice = 1
+	verbage_simple = "craft"
+	verbage = "crafted"
+	craftdiff = 0	
+
+/datum/crafting_recipe/roguetown/skullmask
+	name = "skull mask"
+	result = /obj/item/clothing/mask/rogue/skullmask
+	reqs = list(/obj/item/natural/bone = 3,
+		/obj/item/natural/fibers = 1)
+	sellprice = 10
+	verbage_simple = "craft"
+	verbage = "crafted"
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/skullcrotch
+	name = "skull belt"
+	result = /obj/item/storage/belt/rogue/bone/skullbelt
+	reqs = list(/obj/item/natural/bone = 1,
+		/obj/item/natural/fibers = 1)
+	sellprice = 4
+	verbage_simple = "craft"
+	verbage = "crafted"
+	craftdiff = 0	
+
+/datum/crafting_recipe/roguetown/skullnecklace
+	name = "skull necklace"
+	result = /obj/item/clothing/neck/roguetown/psicross/skull
+	reqs = list(/obj/item/natural/bone = 1,
+		/obj/item/natural/fibers = 1)
+	sellprice = 1
+	verbage_simple = "craft"
+	verbage = "crafted"
+	craftdiff = 0		
+
+/datum/crafting_recipe/roguetown/stoneknife
+	name = "stone knife"
+	result = /obj/item/rogueweapon/huntingknife/stoneknife
+	reqs = list(/obj/item/grown/log/tree/stick = 1,
+		/obj/item/natural/stone = 1)
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/stoneaxe
+	name = "stone axe"
+	result = /obj/item/rogueweapon/stoneaxe
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/stone = 1)
+
+/datum/crafting_recipe/roguetown/stonepick
+	name = "stone pick"
+	result = /obj/item/rogueweapon/pick/stone
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/stone = 2)
+
+/datum/crafting_recipe/roguetown/stonehammer
+	name = "stone hammer"
+	result = /obj/item/rogueweapon/hammer/stone
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/stone = 3)
+
+/datum/crafting_recipe/roguetown/stonetongs
+	name = "stone tongs"
+	result = /obj/item/rogueweapon/tongs/stone
+	reqs = list(/obj/item/grown/log/tree/stick = 2,
+		/obj/item/natural/stone = 1)
+
+/datum/crafting_recipe/roguetown/stonespear
+	name = "stone spear"
+	result = /obj/item/rogueweapon/spear/stone
+	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
+		/obj/item/natural/stone = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/woodclub
+	name = "wood club"
+	result = /obj/item/rogueweapon/mace/woodclub/crafted
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+
+/obj/item/rogueweapon/mace/woodclub/crafted
+	sellprice = 8
+
+/datum/crafting_recipe/roguetown/woodstaff
+	name = "wood staff"
+	result = list(/obj/item/rogueweapon/woodstaff,
+		/obj/item/rogueweapon/woodstaff,
+		/obj/item/rogueweapon/woodstaff)
+	reqs = list(/obj/item/grown/log/tree = 1)
+
+/datum/crafting_recipe/roguetown/woodsword
+	name = "wood sword"
+	result = list(/obj/item/rogueweapon/mace/wsword,
+		/obj/item/rogueweapon/mace/wsword)
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/fibers = 1)
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/woodshield
+	name = "wooden shield"
+	result = /obj/item/rogueweapon/shield/wood/crafted
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/hide = 1)
+	skillcraft = /datum/skill/craft/carpentry
+
+/obj/item/rogueweapon/shield/wood/crafted
+	sellprice = 10
 
 /datum/crafting_recipe/roguetown/bowstring
 	name = "fiber bowstring"
@@ -93,75 +382,37 @@
 /datum/crafting_recipe/roguetown/bow
 	name = "wooden bow"
 	result = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
-	reqs = list(/obj/item/natural/bowstring = 1, /obj/item/grown/log/tree/bowpartial = 1)
+	reqs = list(/obj/item/natural/bowstring = 1,
+		/obj/item/grown/log/tree/bowpartial = 1)
 	skillcraft = /datum/skill/combat/bows
 	verbage_simple = "string together"
 	verbage = "strings together"
 	craftdiff = 2
 
-/datum/crafting_recipe/roguetown/torch
-	name = "torch"
-	result = /obj/item/flashlight/flare/torch
+/datum/crafting_recipe/roguetown/stonearrow_five
+	name = "stone arrow (x5)"
+	result = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone)
+	reqs = list(/obj/item/grown/log/tree/stick = 5,
+		/obj/item/natural/stone = 5)
+	req_table = TRUE
+
+/datum/crafting_recipe/roguetown/stonearrow
+	name = "stone arrow"
+	result = /obj/item/ammo_casing/caseless/rogue/arrow/stone
 	reqs = list(/obj/item/grown/log/tree/stick = 1,
-				/obj/item/natural/fibers = 1)
-	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/candle
-	name = "candle (x3)"
-	result = list(/obj/item/candle/yellow,
-				/obj/item/candle/yellow,
-				/obj/item/candle/yellow)
-	reqs = list(/obj/item/reagent_containers/food/snacks/fat = 2)
-
-/datum/crafting_recipe/roguetown/stoneaxe
-	name = "stone axe"
-	result = /obj/item/rogueweapon/stoneaxe
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/stone = 1)
-
-/datum/crafting_recipe/roguetown/stonehammer
-	name = "stone hammer"
-	result = /obj/item/rogueweapon/hammer/stone
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/stone = 3)
-
-/datum/crafting_recipe/roguetown/stonetongs
-	name = "stone tongs"
-	result = /obj/item/rogueweapon/tongs/stone
-	reqs = list(/obj/item/grown/log/tree/stick = 2,
-				/obj/item/natural/stone = 1)
-
-/datum/crafting_recipe/roguetown/stonepick
-	name = "stone pick"
-	result = /obj/item/rogueweapon/pick/stone
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/stone = 2)
-
-/datum/crafting_recipe/roguetown/stoneknife
-	name = "stone knife"
-	result = /obj/item/rogueweapon/huntingknife/stoneknife
-	reqs = list(/obj/item/grown/log/tree/stick = 1,
-				/obj/item/natural/stone = 1)
-	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/stonespear
-	name = "stone spear"
-	result = /obj/item/rogueweapon/spear/stone
-	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
-				/obj/item/natural/stone = 1)
-	craftdiff = 3
-
-/datum/crafting_recipe/roguetown/woodclub
-	name = "wood club"
-	result = /obj/item/rogueweapon/mace/woodclub/crafted
-	reqs = list(/obj/item/grown/log/tree/small = 1)
+		/obj/item/natural/stone = 1)
+	req_table = TRUE
 
 /datum/crafting_recipe/roguetown/billhook
 	name = "improvised billhook"
 	result = /obj/item/rogueweapon/spear/improvisedbillhook
 	reqs = list(/obj/item/rogueweapon/sickle = 1,
-				/obj/item/rope = 1,
-				/obj/item/grown/log/tree/small = 1)
+		/obj/item/rope = 1,
+		/obj/item/grown/log/tree/small = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	craftdiff = 3
 
@@ -169,8 +420,8 @@
 	name = "goedendag"
 	result = /obj/item/rogueweapon/mace/goden
 	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/rope = 1,
-				/obj/item/rogueweapon/hoe = 1)
+		/obj/item/rope = 1,
+		/obj/item/rogueweapon/hoe = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	craftdiff = 3
 
@@ -178,76 +429,21 @@
 	name = "peasant war flail"
 	result = /obj/item/rogueweapon/flail/peasantwarflail
 	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/rope = 1,
-				/obj/item/rogueweapon/thresher = 1)
+		/obj/item/rope = 1,
+		/obj/item/rogueweapon/thresher = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	craftdiff = 3
-
-/datum/crafting_recipe/roguetown/lproesthetic
-	name = "wood arm (L)"
-	result = list(/obj/item/bodypart/l_arm/rproesthetic)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-	/obj/item/roguegear = 1)
-	skillcraft = /datum/skill/craft/carpentry
-	craftdiff = 3
-
-/datum/crafting_recipe/roguetown/rproesthetic
-	name = "wood arm (R)"
-	result = list(/obj/item/bodypart/r_arm/rproesthetic)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-	/obj/item/roguegear = 1)
-	skillcraft = /datum/skill/craft/carpentry
-	craftdiff = 3
-
-/obj/item/rogueweapon/mace/woodclub/crafted
-	sellprice = 8
-
-/datum/crafting_recipe/roguetown/woodstaff
-	name = "wood staff"
-	result = list(/obj/item/rogueweapon/woodstaff,
-	/obj/item/rogueweapon/woodstaff,
-	/obj/item/rogueweapon/woodstaff)
-	reqs = list(/obj/item/grown/log/tree = 1)
-
-/datum/crafting_recipe/roguetown/woodsword
-	name = "wood sword"
-	result = list(/obj/item/rogueweapon/mace/wsword,
-					/obj/item/rogueweapon/mace/wsword)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/fibers = 1)
-	craftdiff = 1
-
-/datum/crafting_recipe/roguetown/woodshield
-	name = "wooden shield"
-	result = /obj/item/rogueweapon/shield/wood/crafted
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/hide = 1)
-	skillcraft = /datum/skill/craft/carpentry
-
-/datum/crafting_recipe/roguetown/spoon
-	name = "spoon"
-	result = list(/obj/item/kitchen/spoon,
-				/obj/item/kitchen/spoon)
-	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /datum/crafting_recipe/roguetown/rollingpin
 	name = "rollingpin"
 	result = /obj/item/kitchen/rollingpin
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
-/obj/item/rogueweapon/shield/wood/crafted
-	sellprice = 10
-
-/datum/crafting_recipe/roguetown/woodbucket
-	name = "wooden bucket"
-	result = /obj/item/reagent_containers/glass/bucket/wooden
-	reqs = list(/obj/item/grown/log/tree/small = 1)
-
 /datum/crafting_recipe/roguetown/woodcup
 	name = "wooden cups (x3)"
 	result = list(/obj/item/reagent_containers/glass/cup/wooden/crafted,
-				/obj/item/reagent_containers/glass/cup/wooden/crafted,
-				/obj/item/reagent_containers/glass/cup/wooden/crafted)
+		/obj/item/reagent_containers/glass/cup/wooden/crafted,
+		/obj/item/reagent_containers/glass/cup/wooden/crafted)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /obj/item/reagent_containers/glass/cup/wooden/crafted
@@ -256,221 +452,137 @@
 /datum/crafting_recipe/roguetown/woodtray
 	name = "wooden trays (x2)"
 	result = list(/obj/item/storage/bag/tray,
-				/obj/item/storage/bag/tray)
+		/obj/item/storage/bag/tray)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /datum/crafting_recipe/roguetown/woodbowl
 	name = "wooden bowls (x3)"
 	result = list(/obj/item/reagent_containers/glass/bowl,
-				/obj/item/reagent_containers/glass/bowl,
-				/obj/item/reagent_containers/glass/bowl)
+		/obj/item/reagent_containers/glass/bowl,
+		/obj/item/reagent_containers/glass/bowl)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
-/datum/crafting_recipe/roguetown/pot
-	name = "stone pot"
-	result = /obj/item/reagent_containers/glass/bucket/pot
-	reqs = list(/obj/item/natural/stone = 2)
+/datum/crafting_recipe/roguetown/spoon
+	name = "spoon"
+	result = list(/obj/item/kitchen/spoon,
+		/obj/item/kitchen/spoon,
+		/obj/item/kitchen/spoon)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
 
-/datum/crafting_recipe/roguetown/stonearrow
-	name = "stone arrow"
-	result = /obj/item/ammo_casing/caseless/rogue/arrow/stone
-	reqs = list(/obj/item/grown/log/tree/stick = 1,
-				/obj/item/natural/stone = 1)
-	req_table = TRUE
-
-/datum/crafting_recipe/roguetown/stonearrow_five
-	name = "stone arrow (x5)"
-	result = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone
-				)
-	reqs = list(/obj/item/grown/log/tree/stick = 5,
-				/obj/item/natural/stone = 5)
-	req_table = TRUE
+/datum/crafting_recipe/roguetown/poisonarrow_five //Arrows and bolts can be smithed in batches of five. Makes sense for them to be dipped in batches of five, too
+	name = "poisoned arrow (x5)"
+	result = list(/obj/item/ammo_casing/caseless/rogue/arrow/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/poison)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow = 5,
+		/datum/reagent/berrypoison = 25)
+	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/poisonarrow
 	name = "poisoned arrow"
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/poison
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow = 1,
-				/datum/reagent/berrypoison = 5
-				)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow = 1,
+		/datum/reagent/berrypoison = 5)
+	req_table = FALSE
+
+/datum/crafting_recipe/roguetown/soporarrow_five
+	name = "soporific arrow (x5)"
+	result = list(/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/sopor)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow = 5,
+		/datum/reagent/medicine/soporpot = 30)
 	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/soporarrow
 	name = "soporific arrow"
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/sopor
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow = 1,
-				/datum/reagent/medicine/soporpot = 10
-				)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow = 1,
+		/datum/reagent/medicine/soporpot = 10)
+	req_table = FALSE
+
+/datum/crafting_recipe/roguetown/poisonarrow_five_stone
+	name = "poisoned stone arrow (x5)"
+	result = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
+		/datum/reagent/berrypoison = 25)
 	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/poisonarrow_stone
 	name = "poisoned stone arrow"
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/stone/poison
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 1,
-				/datum/reagent/berrypoison = 5
-				)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone = 1,
+		/datum/reagent/berrypoison = 5)
+	req_table = FALSE
+
+/datum/crafting_recipe/roguetown/soporarrow_5_stone
+	name = "soporific stone arrow (x5)"
+	result = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
+		/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
+		/datum/reagent/medicine/soporpot = 30)
 	req_table = FALSE
 
 /datum/crafting_recipe/roguetown/soporarrow_stone
 	name = "soporific stone arrow"
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 1,
-				/datum/reagent/medicine/soporpot = 6
-				)
-	req_table = FALSE
-
-/*
-/datum/crafting_recipe/roguetown/poisonbolt //Coded, but commented out pending balance discussion.
-	name = "poisoned bolt"
-	result = /obj/item/ammo_casing/caseless/rogue/bolt/poison
-	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 1,
-				/datum/reagent/berrypoison = 5)
-
-	req_table = TRUE
-*/
-/datum/crafting_recipe/roguetown/poisonarrow_five //Arrows and bolts can be smithed in batches of five. Makes sense for them to be dipped in batches of five, too
-	name = "poisoned arrow (x5)"
-	result = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/poison
-				)
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow = 5,
-				/datum/reagent/berrypoison = 25
-				)
-
-	req_table = FALSE
-
-/datum/crafting_recipe/roguetown/soporarrow_five
-	name = "soporific arrow (x5)"
-	result = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/sopor
-				)
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow = 5,
-				/datum/reagent/medicine/soporpot = 30
-				)
-
-	req_table = FALSE
-
-/datum/crafting_recipe/roguetown/tranq
-	name = "tranquilizer bolt"
-	result = /obj/item/ammo_casing/caseless/rogue/bolt/tranq
-	reqs = list(
-		/obj/item/ammo_casing/caseless/rogue/bolt = 1,
-		/datum/reagent/medicine/soporpot = 30
-		)
-
-	req_table = FALSE
-
-/datum/crafting_recipe/roguetown/tranqfive
-	name = "tranquilizer bolt (x5)"
-	result = list(
-				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
-				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
-				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
-				/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
-				/obj/item/ammo_casing/caseless/rogue/bolt/tranq
-				)
-	reqs = list(
-		/obj/item/ammo_casing/caseless/rogue/bolt = 5,
-		/datum/reagent/medicine/soporpot = 150
-		)
-
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/stone = 1,
+		/datum/reagent/medicine/soporpot = 6)
 	req_table = FALSE
 
 /*
 /datum/crafting_recipe/roguetown/poisonbolt_five //Coded, but commented out pending balance discussion.
 	name = "poisoned bolts (x5)"
-	result = list(/obj/item/ammo_casing/caseless/rogue/bolt/poison = 5)
+	result = list(/obj/item/ammo_casing/caseless/rogue/bolt/poison,
+		/obj/item/ammo_casing/caseless/rogue/bolt/poison,
+		/obj/item/ammo_casing/caseless/rogue/bolt/poison,
+		/obj/item/ammo_casing/caseless/rogue/bolt/poison,
+		/obj/item/ammo_casing/caseless/rogue/bolt/poison)
 	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 5,
-				/datum/reagent/berrypoison = 25)
+		/datum/reagent/berrypoison = 25)
+	req_table = FALSE
 
-	req_table = TRUE
+/datum/crafting_recipe/roguetown/poisonbolt //Coded, but commented out pending balance discussion.
+	name = "poisoned bolt"
+	result = /obj/item/ammo_casing/caseless/rogue/bolt/poison
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 1,
+		/datum/reagent/berrypoison = 5)
+	req_table = FALSE
 */
-/datum/crafting_recipe/roguetown/poisonarrow_five_stone
-	name = "poisoned stone arrow (x5)"
-	result = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/poison
-				)
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
-				/datum/reagent/berrypoison = 25
-				)
-
+/datum/crafting_recipe/roguetown/tranqfive
+	name = "tranquilizer bolt (x5)"
+	result = list(/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+		/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+		/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+		/obj/item/ammo_casing/caseless/rogue/bolt/tranq,
+		/obj/item/ammo_casing/caseless/rogue/bolt/tranq)
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 5,
+		/datum/reagent/medicine/soporpot = 150)
 	req_table = FALSE
 
-/datum/crafting_recipe/roguetown/soporarrow_5_stone
-	name = "soporific stone arrow (x5)"
-	result = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor,
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone/sopor
-				)
-	reqs = list(
-				/obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
-				/datum/reagent/medicine/soporpot = 30
-				)
-
+/datum/crafting_recipe/roguetown/tranq
+	name = "tranquilizer bolt"
+	result = /obj/item/ammo_casing/caseless/rogue/bolt/tranq
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 1,
+		/datum/reagent/medicine/soporpot = 30)
 	req_table = FALSE
 
-/datum/crafting_recipe/roguetown/mortar
-	name = "stone mortar"
-	result = /obj/item/reagent_containers/glass/mortar
-	reqs = list(/obj/item/natural/stone = 1)
-	craftdiff = 1
-
-/datum/crafting_recipe/roguetown/pestle
-	name = "stone pestle"
-	result = /obj/item/pestle
-	reqs = list(/obj/item/natural/stone = 1)
-	craftdiff = 1
-
-
-/datum/crafting_recipe/roguetown/bag
-	name = "bag"
-	result = /obj/item/storage/roguebag/crafted
-	reqs = list(/obj/item/natural/fibers = 1,
-				/obj/item/natural/cloth = 1)
-	tools = list(/obj/item/needle)
-	skillcraft = /datum/skill/misc/sewing
-	req_table = FALSE
-
-/datum/crafting_recipe/roguetown/bagx5
-	name = "bag x5"
-	result = list(
-				/obj/item/storage/roguebag/crafted,
-				/obj/item/storage/roguebag/crafted,
-				/obj/item/storage/roguebag/crafted,
-				/obj/item/storage/roguebag/crafted,
-				/obj/item/storage/roguebag/crafted,
-				)
-	reqs = list(/obj/item/natural/fibers = 5,
-				/obj/item/natural/cloth = 5)
-	tools = list(/obj/item/needle)
-	skillcraft = /datum/skill/misc/sewing
-	req_table = FALSE
+/datum/crafting_recipe/roguetown/woodcross
+	name = "wooden amulet"
+	result = /obj/item/clothing/neck/roguetown/psicross/wood
+	reqs = list(/obj/item/natural/fibers = 2,
+		/obj/item/grown/log/tree/stick = 2)
 
 /datum/crafting_recipe/roguetown/psydonhood
 	name = "psydon hood"
@@ -488,115 +600,39 @@
 	skillcraft = /datum/skill/misc/sewing
 	req_table = TRUE
 
-/obj/item/storage/roguebag/crafted
-	sellprice = 4
-
-
-/datum/crafting_recipe/roguetown/bait
-	name = "bait"
-	result = /obj/item/bait
-	reqs = list(/obj/item/storage/roguebag = 1,
-				/obj/item/reagent_containers/food/snacks/grown/wheat = 2)
-	req_table = TRUE
-	subtype_reqs = TRUE
-
-/datum/crafting_recipe/roguetown/sbaita
-	name = "sweetbait (apple)"
-	result = /obj/item/bait/sweet
-	reqs = list(/obj/item/storage/roguebag = 1,
-				/obj/item/reagent_containers/food/snacks/grown/apple = 2)
-	req_table = TRUE
-	subtype_reqs = TRUE
-
-/datum/crafting_recipe/roguetown/sbait
-	name = "sweetbait (berry)"
-	result = /obj/item/bait/sweet
-	reqs = list(/obj/item/storage/roguebag = 1,
-				/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2)
-	req_table = TRUE
-	subtype_reqs = TRUE
-
-/datum/crafting_recipe/roguetown/bloodbait
-	name = "bloodbait"
-	result = /obj/item/bait/bloody
-	reqs = list(/obj/item/storage/roguebag = 1,
-				/obj/item/reagent_containers/food/snacks/rogue/meat = 2)
-	req_table = TRUE
-	subtype_reqs = TRUE
-
 /datum/crafting_recipe/roguetown/pipe
 	name = "wood pipe"
 	result = /obj/item/clothing/mask/cigarette/pipe/crafted
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
-
 /obj/item/clothing/mask/cigarette/pipe/crafted
 	sellprice = 7
-
-/datum/crafting_recipe/roguetown/rod
-	name = "fishing rod"
-	result = /obj/item/fishingrod/crafted
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-		/obj/item/natural/fibers = 2)
-
-/obj/item/fishingrod/crafted
-	sellprice = 8
-
-/datum/crafting_recipe/roguetown/woodspade
-	name = "wood spade"
-	result = /obj/item/rogueweapon/shovel/small
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-			/obj/item/grown/log/tree/stick = 1)
-
-/obj/item/rogueweapon/shovel/small/crafted
-	sellprice = 6
-
-/datum/crafting_recipe/roguetown/book_crafting_kit
-	name = "book crafting kit"
-	result = /obj/item/book_crafting_kit
-	reqs = list(
-			/obj/item/natural/hide = 2,
-			/obj/item/natural/cloth = 1)
-	tools = list(/obj/item/needle = 1)
-	req_table = TRUE
-
-/datum/crafting_recipe/roguetown/woodcross
-	name = "wooden amulet"
-	result = /obj/item/clothing/neck/roguetown/psicross/wood
-	reqs = list(/obj/item/natural/fibers = 2,
-				/obj/item/grown/log/tree/stick = 2)
 
 // Gives a rusty beartrap; if you want non-rusty ones, go to smith. Prevents the dumb mass-trapping stuff.
 /datum/crafting_recipe/roguetown/mantrap
 	name = "mantrap"
 	result = list(/obj/item/restraints/legcuffs/beartrap)
 	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/fibers = 2,
-				/obj/item/ingot/iron = 1)
+		/obj/item/natural/fibers = 2,
+		/obj/item/ingot/iron = 1)
 	req_table = TRUE
 	skillcraft = /datum/skill/craft/traps
 	craftdiff = 1
 	verbage_simple = "put together"
 	verbage = "puts together"
 
-/datum/crafting_recipe/roguetown/paperscroll
-	name = "scroll of parchment (x5)"
-	result = list(/obj/item/paper/scroll,
-				  /obj/item/paper/scroll,
-				  /obj/item/paper/scroll,
-				  /obj/item/paper/scroll,
-				  /obj/item/paper/scroll)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-	/datum/reagent/water = 50)
-	tools = list(/obj/item/rogueweapon/huntingknife = 1)
-	structurecraft = /obj/structure/fluff/dryingrack
+/datum/crafting_recipe/roguetown/banner
+	name = "battle standard"
+	result = /obj/item/rogueweapon/spear/banner
+	reqs = list(/obj/item/grown/log/tree/stick = 1,
+		/obj/item/grown/log/tree/small = 1)
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/tribalrags
 	name = "tribal rags"
 	result = /obj/item/clothing/suit/roguetown/shirt/tribalrag
 	reqs = list(/obj/item/natural/hide = 1,
-				/obj/item/natural/fibers = 1)
+		/obj/item/natural/fibers = 1)
 	sellprice = 8
 	tools = list(/obj/item/needle)
 	skillcraft = /datum/skill/misc/sewing
@@ -604,97 +640,18 @@
 	verbage = "sews"
 	craftdiff = 0
 
-/datum/crafting_recipe/roguetown/skullmask
-	name = "skull mask"
-	result = /obj/item/clothing/mask/rogue/skullmask
-	reqs = list(/obj/item/natural/bone = 3,
-				/obj/item/natural/fibers = 1)
-	sellprice = 10
-	verbage_simple = "craft"
-	verbage = "crafted"
-	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/tribalskull
-	name = "wendigo helmet"
-	result = /obj/item/clothing/head/roguetown/tribalskull
-	reqs = list(/obj/item/natural/bone = 3,
-				/obj/item/natural/fibers = 1)
-	sellprice = 10
-	verbage_simple = "craft"
-	verbage = "crafted"
-	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/skullcrotch
-	name = "skull belt"
-	result = /obj/item/storage/belt/rogue/bone/skullbelt
-	reqs = list(/obj/item/natural/bone = 1,
-				/obj/item/natural/fibers = 1)
-	sellprice = 4
-	verbage_simple = "craft"
-	verbage = "crafted"
-	craftdiff = 0	
-
-/datum/crafting_recipe/roguetown/bonearmor
-	name = "bone armor"
-	result = /obj/item/clothing/suit/roguetown/armor/bone/chestplate
-	reqs = list(/obj/item/natural/bone = 3,
-				/obj/item/natural/fibers = 1)
-	sellprice = 1
-	verbage_simple = "craft"
-	verbage = "crafted"
-	craftdiff = 0	
-
-/datum/crafting_recipe/roguetown/bonegreaves
-	name = "bone greaves"
-	result = /obj/item/clothing/shoes/roguetown/boots/bonegreaves
-	reqs = list(/obj/item/natural/bone = 2,
-				/obj/item/natural/fibers = 1)
-	sellprice = 1
-	verbage_simple = "craft"
-	verbage = "crafted"
-	craftdiff = 0	
-
-/datum/crafting_recipe/roguetown/antlerhood
-	name = "antlerhood"
-	result = /obj/item/clothing/head/roguetown/antlerhood
-	reqs = list(/obj/item/natural/hide = 1,
-				/obj/item/natural/antler = 2)
-	sellprice = 12
-	tools = list(/obj/item/needle)
-	skillcraft = /datum/skill/misc/sewing
-	verbage_simple = "sew"
-	verbage = "sews"
-	craftdiff = 0
-
-/datum/crafting_recipe/roguetown/boneaxe
-	name = "bone axe"
-	result = /obj/item/rogueweapon/stoneaxe/boneaxe
+/datum/crafting_recipe/roguetown/lproesthetic
+	name = "wood arm (L)"
+	result = list(/obj/item/bodypart/l_arm/rproesthetic)
 	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/bone = 2,
-				/obj/item/natural/fibers = 1)
-	craftdiff = 2
-
-/datum/crafting_recipe/roguetown/bonespear
-	name = "bone spear"
-	result = /obj/item/rogueweapon/spear/bonespear
-	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
-				/obj/item/natural/bone = 2,
-				/obj/item/natural/fibers = 1)
+	/obj/item/roguegear = 1)
+	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 3
 
-/datum/crafting_recipe/roguetown/skullnecklace
-	name = "skull necklace"
-	result = /obj/item/clothing/neck/roguetown/psicross/skull
-	reqs = list(/obj/item/natural/bone = 1,
-				/obj/item/natural/fibers = 1)
-	sellprice = 1
-	verbage_simple = "craft"
-	verbage = "crafted"
-	craftdiff = 0		
-
-/datum/crafting_recipe/roguetown/banner
-	name = "battle standard"
-	result = /obj/item/rogueweapon/spear/banner
-	reqs = list(/obj/item/grown/log/tree/stick = 1,
-				/obj/item/grown/log/tree/small = 1)
-	craftdiff = 1
+/datum/crafting_recipe/roguetown/rproesthetic
+	name = "wood arm (R)"
+	result = list(/obj/item/bodypart/r_arm/rproesthetic)
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+	/obj/item/roguegear = 1)
+	skillcraft = /datum/skill/craft/carpentry
+	craftdiff = 3


### PR DESCRIPTION
Alright, I screwed up and merged both of these into one instead of making them separate. Go me... Anyway...

Adds two new alchemy recipes: 3 sticks into 1 coal and 1 small log into 2 coal.
Rearranges the crafting menu to be more efficient to use, updates a few recipes, and standardizes item entries.

## About The Pull Request

- Adds an alchemy that converts 3 sticks into 1 coal, and ~~1 small log into 2 coal~~ _**one small log into a single coal**_ so alchemists don't need to set up a furnace to convert logs into coal.
- Rearranges the crafting menu to be more efficient for players to use.
- The four types of bait no longer need tables to craft. (This never made any sense to me.) Now hunters can be wandering the bog and resupply bait without needing to look for a table.
- Wooden spoons now make three items per craft, the same number as wooden bowls made per craft.
- Wooden trays are now also three per craft.
- Adds a meal set craft to just directly make a tray, mug, bowl, and spoon.
- Bone spears and axes now require a stone instead of a staff or log, respectively.

## Why It's Good For The Game

Alchemists will have less prep work since they can just convert sticks and small logs directly into coal, and even get skill xp for it!
The crafting menu was an oddly arranged mess and honestly, it still kinda is but hopefully people will be able to find things more easily now and the craft items that require the oddest combination of materials (Like the book making kit and papyrus crafts.) are now higher on the list so when the specific crafting materials are around, it's easier to find and craft.