### PR TITLE
Cloak Tail fix

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -8,7 +8,7 @@
 	equip_delay_self = 10
 	bloody_icon_state = "bodyblood"
 	sewrepair = TRUE //Vrell - AFAIK, all cloaks are cloth ATM. Technically semi-less future-proof, but it removes a line of code from every subtype, which is worth it IMO.
-	flags_inv = HIDETAIL
+	//flags_inv = HIDETAIL - Edited to instead be hidden by the Hood being lifted up instead of the cloak hiding it by default, that way it can still allow for obscuring
 
 
 //////////////////////////
@@ -700,7 +700,7 @@
 	dynamic_hair_suffix = ""
 	edelay_type = 1
 	body_parts_covered = HEAD
-	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDETAIL //Edited to include Hide Tail so cloaks can keep their obscuring feature
 	block2add = FOV_BEHIND
 
 /obj/item/clothing/head/hooded/equipped(mob/user, slot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Cloaks no longer hide tails in the Astral Plane, instead they protrude out the back like they should.

But, tails are a dead giveaway for rogues, so to prevent too much meta, the tail-hiding feature has been added to the cloaks HOOD. When the hood is up, your tail will be hidden as well as the other things it hides.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gone are the days of MASSIVE tails being hidden by some dingy rain cloak, seriously, where were they hiding?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
