### PR TITLE
Tzula's Super Duper Cool Monthly Map Update

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,10 +7,14 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -497,17 +501,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/fluff/wallclock{
-	pixel_y = -30
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -988,7 +984,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "adL" = (
 /obj/item/natural/stone,
@@ -1130,29 +1126,43 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ael" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "WHEAT"
 	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4;
+	icon_state = "torchwall1"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"aen" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aev" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1237,6 +1247,10 @@
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"agV" = (
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ahH" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -1269,6 +1283,9 @@
 /area/rogue/indoors/town/church/chapel)
 "ajj" = (
 /obj/structure/statue/saints/father,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "ajo" = (
@@ -1294,6 +1311,16 @@
 	icon_state = "ice"
 	},
 /area/rogue/indoors/shelter/mountains)
+"ajD" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ajF" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe{
 	color = '#87CEFA';
@@ -1331,6 +1358,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"alQ" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "alU" = (
 /turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/under/town/basement)
@@ -1378,12 +1413,32 @@
 /obj/structure/statue/saints/knight_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"aok" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+"anO" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"anS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"aok" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1524,14 +1579,11 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "woodsmprison"
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1549,6 +1601,13 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town)
+"avN" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "avQ" = (
 /obj/structure/bars/grille,
@@ -1623,7 +1682,7 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "axs" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -1641,11 +1700,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1698,6 +1755,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"azR" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "aAe" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/guard,
@@ -1707,6 +1774,24 @@
 /obj/item/clothing/cloak/stabard/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"aAo" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "aAs" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
@@ -1792,6 +1877,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"aEG" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aEN" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/angle,
@@ -1832,8 +1923,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "aGb" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -1889,6 +1985,12 @@
 /obj/item/clothing/neck/roguetown/psicross/pestra,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"aIb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "aIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/kitchen/spoon/plastic,
@@ -1946,6 +2048,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"aIT" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aIV" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
@@ -1967,12 +2075,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
-"aJS" = (
-/obj/structure/table/wood/bar,
-/obj/item/rogueweapon/mace/stunmace,
-/obj/item/reagent_containers/glass/bottle/rogue/luckpot,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "aKd" = (
 /obj/structure/winch{
 	dir = 4;
@@ -2056,6 +2158,13 @@
 "aMH" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/tribalfort)
+"aMK" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aMV" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = 32
@@ -2083,7 +2192,7 @@
 	dir = 1;
 	pixel_y = -6
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "aNW" = (
 /obj/structure/table/wood,
@@ -2141,9 +2250,14 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/flora/roguetree/burnt,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2218,15 +2332,16 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "aSO" = (
 /obj/structure/fluff/walldeco/steward,
@@ -2247,6 +2362,12 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"aTn" = (
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "aTE" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2324,6 +2445,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"aVU" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
@@ -2397,6 +2523,10 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
+"aZu" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "aZG" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/blocks,
@@ -2424,6 +2554,11 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"baG" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "baO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -2431,6 +2566,16 @@
 "baS" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
+"baV" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "bbm" = (
 /obj/structure/flora/wildplant/wild_poppy,
 /turf/open/floor/rogue/grass,
@@ -2456,6 +2601,13 @@
 "bcN" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/church/chapel)
+"bcO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bdu" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -2494,6 +2646,16 @@
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"bez" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "beA" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -2530,6 +2692,14 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"bfE" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "bfK" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2593,6 +2763,12 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"bhR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2676,6 +2852,14 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bkF" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -2699,6 +2883,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"blT" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "blW" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -2729,11 +2917,11 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2767,7 +2955,11 @@
 	icon_state = "border"
 	},
 /obj/structure/flora/roguegrass,
-/obj/item/natural/rock,
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	icon_state = "woodrailing"
+	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "bnV" = (
@@ -2796,9 +2988,7 @@
 /area/rogue/under/cavewet/bogcaves/tomb)
 "bok" = (
 /obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "bow" = (
 /obj/structure/mineral_door/wood{
@@ -2894,11 +3084,19 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"bqu" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -2940,6 +3138,16 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"brt" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "brP" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
@@ -2964,6 +3172,10 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"bsh" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "bsm" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -2991,6 +3203,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"bsS" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3052,6 +3268,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"buB" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "buL" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -3178,7 +3403,8 @@
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "shop"
+	lockid = "shop";
+	max_integrity = 99999
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -3234,10 +3460,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/item/rogueweapon/mace/wsword,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3303,8 +3528,8 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/turf/closed/wall/mineral/rogue/wooddark/end,
-/area/rogue/outdoors/rtfield)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3328,6 +3553,14 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"bDf" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bDh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "bDl" = (
 /obj/structure/stairs{
 	dir = 1
@@ -3338,6 +3571,14 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"bDN" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16;
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "bEe" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
@@ -3421,6 +3662,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bHe" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bHt" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -3444,11 +3693,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3586,7 +3836,6 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
 /obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
@@ -3606,6 +3855,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"bON" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "bOP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "tavern"
@@ -3635,21 +3895,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
-"bPz" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"bPz" = (
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors/town/garrison)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3666,8 +3921,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "bQf" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "bQo" = (
 /obj/structure/stairs{
@@ -3787,20 +4045,29 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
+/obj/structure/stairs/stone{
+	dir = 1
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bUr" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bVa" = (
-/obj/structure/bed/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -3894,6 +4161,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"bYH" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "bYM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -3946,6 +4222,22 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cbo" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cbE" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "sheriff"
@@ -3956,14 +4248,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "cbQ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "cca" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4025,9 +4311,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4217,11 +4503,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "cjJ" = (
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 1
-	},
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4273,12 +4557,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4451,6 +4732,14 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cqU" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "crx" = (
 /obj/structure/statue/saints/noble3_l,
 /turf/open/floor/rogue/grass,
@@ -4490,6 +4779,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"csE" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4560,6 +4853,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"cvC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cvN" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road{
@@ -4567,9 +4867,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/church/chapel)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4673,6 +4972,10 @@
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"cxZ" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
@@ -4749,8 +5052,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
 "cAe" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -4763,6 +5066,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"cAj" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cAo" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -4818,7 +5127,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/fermenting_barrel/random/water,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/storage/backpack/rogue/backpack/surgery,
+/obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
@@ -4835,6 +5149,10 @@
 "cCz" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"cCC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "cCF" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/grass,
@@ -4842,7 +5160,9 @@
 "cCQ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "mason"
+	lockid = "mason";
+	max_integrity = 9999;
+	name = "The Door That Does Not Break"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -4856,10 +5176,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5020,7 +5339,7 @@
 	pixel_x = -1;
 	pixel_y = 31
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "cIy" = (
 /obj/item/chair/stool/bar/rogue,
@@ -5104,18 +5423,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5133,12 +5442,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/natural/saddle,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5182,6 +5494,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"cND" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "cNN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf{
 	faction = list("undead")
@@ -5205,10 +5524,23 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"cOL" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"cPd" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "cPe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -5233,6 +5565,20 @@
 	},
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"cPT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
@@ -5290,11 +5636,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
@@ -5319,6 +5665,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"cSi" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cSk" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
@@ -5350,6 +5700,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"cTb" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cTr" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -5433,6 +5790,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"cVu" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cVK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -5619,22 +5981,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
-"dbw" = (
-/obj/structure/roguemachine/vendor/blk4,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dbH" = (
-/obj/machinery/light/rogue/campfire,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -5761,6 +6113,10 @@
 /obj/effect/landmark/start/nightman,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"dey" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "deT" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -5775,6 +6131,22 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"dfz" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"dfH" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "dfK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -5875,6 +6247,10 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"diG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "diP" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -5893,6 +6269,17 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"djd" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "djA" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -5923,12 +6310,17 @@
 /area/rogue/outdoors/town)
 "dkf" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/tongs,
 /obj/item/rogueweapon/hammer{
 	color = gold;
 	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
 	name = "Hammer of Malum"
 	},
+/obj/item/rogueweapon/tongs,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -6012,6 +6404,12 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dmH" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "dmI" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -6053,6 +6451,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"doN" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "doW" = (
 /obj/structure/stairs{
 	dir = 4
@@ -6075,6 +6480,15 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"dpr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dpw" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -6150,6 +6564,15 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dsg" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "dsk" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/roguetown/shirt/vampire,
@@ -6177,9 +6600,20 @@
 "dsB" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
+"dsR" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "dsW" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "dth" = (
 /obj/structure/fluff/railing/border,
@@ -6195,6 +6629,15 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"dua" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "duu" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -6234,6 +6677,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"dvv" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/bath)
 "dvD" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/bed/rogue,
@@ -6268,13 +6715,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6346,10 +6791,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6370,6 +6813,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"dAE" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/bath)
 "dBk" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/grass,
@@ -6378,6 +6825,20 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"dBO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6385,10 +6846,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"dBY" = (
-/obj/structure/chair/bench/coucha/r,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6523,6 +6980,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"dHw" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dHC" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -6657,11 +7120,8 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -6774,6 +7234,13 @@
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"dQe" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "dQp" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/clinic,
@@ -6847,6 +7314,9 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dSP" = (
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "dSQ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -6878,9 +7348,8 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/ruinedwood,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
 "dTB" = (
 /obj/structure/table/wood,
@@ -6998,20 +7467,12 @@
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"dWR" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "dXw" = (
 /obj/structure/table/wood{
 	dir = 10;
 	icon_state = "tablewood2"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "dXC" = (
 /obj/structure/fluff/railing/border{
@@ -7048,12 +7509,6 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"dZh" = (
-/obj/structure/table/wood/fancy,
-/obj/item/roguekey/blk,
-/obj/item/reagent_containers/food/drinks/bottle/absinthe,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "dZu" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -7103,14 +7558,24 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
-"ebe" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/church/chapel)
+"ebe" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7146,6 +7611,14 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/bath)
+"ecb" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ecm" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -7290,8 +7763,14 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "eeO" = (
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
 "eeR" = (
 /obj/structure/window/plasma/reinforced/spawner{
@@ -7348,11 +7827,22 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"egd" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "egl" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"egu" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "egx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -7389,6 +7879,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"ehI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ehP" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road{
@@ -7434,14 +7929,23 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ejA" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ejC" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "ejJ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "ejL" = (
 /obj/structure/bed/rogue,
@@ -7472,6 +7976,12 @@
 /obj/item/dice/d6,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"eli" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "elk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -7548,7 +8058,7 @@
 	pixel_y = 7
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/town/roofs)
 "ent" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road{
@@ -7590,6 +8100,12 @@
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"eol" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eou" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -7606,10 +8122,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -7620,6 +8134,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"ept" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "epy" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -7792,13 +8313,19 @@
 /area/rogue/indoors/shelter/rtfield)
 "euo" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
+	dir = 1;
+	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
 "eur" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "euC" = (
 /obj/structure/flora/roguegrass/bush,
@@ -7852,8 +8379,10 @@
 /area/rogue/indoors/town)
 "evw" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "evJ" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
@@ -7919,7 +8448,9 @@
 "eyJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "blacksmith"
+	lockid = "blacksmith";
+	max_integrity = 9999;
+	name = "Blacksmith Door"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -7932,9 +8463,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -7949,6 +8483,11 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
+"eAm" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -7986,6 +8525,12 @@
 "eBw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"eBx" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "eBz" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8038,6 +8583,14 @@
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"eDI" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "eDN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8179,9 +8732,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "eIh" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
+/obj/structure/toilet/secret,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
 "eIj" = (
@@ -8341,6 +8892,14 @@
 "eOg" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter)
+"eOo" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "eOR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop/green{
@@ -8400,6 +8959,10 @@
 /obj/structure/statue/saints/magelady_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eRV" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eSc" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/tile{
@@ -8434,11 +8997,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8448,6 +9009,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
+"eSE" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"eTc" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 8
@@ -8576,17 +9145,26 @@
 	lockid = "priest"
 	},
 /obj/item/book/rogue/bibble,
+/obj/item/listenstone,
+/obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "eWj" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eWl" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"eWC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eWM" = (
 /obj/machinery/light/rogue/chand,
 /obj/effect/landmark/start/jester{
@@ -8622,6 +9200,9 @@
 	icon = 'icons/roguetown/misc/longsleep2.dmi';
 	icon_state = "longsleep";
 	name = "mushroom ring - Eora's Sanctuary"
+	},
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -8684,8 +9265,9 @@
 	dir = 1
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -8700,6 +9282,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fbP" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fbQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -8758,16 +9354,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "fdo" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
 "fdF" = (
 /obj/structure/table/wood{
@@ -8869,11 +9458,33 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"fgH" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"fha" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "fhg" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"fhm" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "fhu" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -8904,6 +9515,13 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"fiK" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "fiL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -8947,6 +9565,15 @@
 /obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fjW" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fjX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -8958,6 +9585,16 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"fkr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -8991,6 +9628,13 @@
 "flH" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/garrison)
+"flI" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "flK" = (
 /obj/structure/flora/shroomstump,
 /turf/open/floor/rogue/dirt,
@@ -9031,6 +9675,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fmV" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fnc" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -9133,6 +9781,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fqy" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
@@ -9161,6 +9818,11 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"fsu" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -9269,6 +9931,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fwJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fwL" = (
 /obj/item/rogueweapon/hammer{
 	color = gold;
@@ -9307,6 +9977,11 @@
 "fxx" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"fxH" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fxK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
@@ -9346,6 +10021,16 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"fyv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fyA" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -9452,7 +10137,7 @@
 /area/rogue/under/town/basement)
 "fBF" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "fBL" = (
 /obj/structure/flora/shroomstump,
@@ -9517,8 +10202,10 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
@@ -9527,6 +10214,12 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"fEc" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fEo" = (
 /obj/item/rogueweapon/woodstaff/wise{
 	color = gold;
@@ -9550,6 +10243,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"fEE" = (
+/obj/structure/closet/crate/chest{
+	name = "BREAK INCASE OF VAMPYRE EMERGENCY"
+	},
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fEF" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/church,
@@ -9567,6 +10268,18 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fFW" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"fGq" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "fGF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -9579,6 +10292,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"fGX" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fHi" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -9602,6 +10321,11 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"fHr" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fHC" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -9654,12 +10378,10 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "fID" = (
 /obj/structure/stairs{
@@ -9672,6 +10394,12 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fIK" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fIL" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9723,6 +10451,13 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"fKD" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fKI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/bog)
@@ -9738,23 +10473,30 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"fLv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fLI" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/apple,
-/obj/item/seeds/apple,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9871,11 +10613,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/effect/landmark/events/testportal{
-	aportalloc = "woodsman"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -9932,6 +10671,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"fRP" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -10042,6 +10787,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fVm" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fVE" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -10053,9 +10807,15 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/machinery/light/rogue/torchholder,
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/shelter/rtfield)
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10139,6 +10899,15 @@
 "fZe" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
+"fZg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "fZw" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobblerock,
@@ -10163,6 +10932,18 @@
 "gaC" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement)
+"gaI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gaO" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood{
@@ -10170,6 +10951,26 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gba" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"gbf" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "gbh" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/carpet/purple,
@@ -10188,11 +10989,12 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -10327,13 +11129,22 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ggG" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ggR" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/under/cavewet/bogcaves)
 "gid" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -10349,15 +11160,9 @@
 /obj/item/clothing/shoes/roguetown/boots/armor/blkknight,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
-"gii" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/silver,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "gip" = (
-/obj/structure/fluff/walldeco/stone,
-/turf/closed/wall/mineral/rogue/decostone/cand,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -10524,16 +11329,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
+"gof" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "goK" = (
 /obj/effect/decal/cobbleedge{
@@ -10578,13 +11389,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"gqo" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/bottle/blazaam,
-/obj/item/reagent_containers/food/drinks/bottle/blazaam,
-/obj/item/reagent_containers/food/drinks/bottle/blazaam,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
+"gqj" = (
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10606,13 +11414,27 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"grj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "grQ" = (
 /obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/shop)
 "grZ" = (
 /obj/structure/closet/crate/roguecloset/inn/chest,
@@ -10621,6 +11443,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gse" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "gsT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -10664,16 +11492,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"gtE" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "gtF" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut/steel,
@@ -10699,6 +11517,14 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"gum" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gut" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -10712,14 +11538,21 @@
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
-"gvi" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 4
+"guS" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
+"gvi" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/fluff/statue/tdummy2,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "gvo" = (
@@ -10730,6 +11563,10 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"gvP" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "gvT" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -10955,6 +11792,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"gDx" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -10968,6 +11809,16 @@
 "gEq" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
+"gEt" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
@@ -11036,6 +11887,16 @@
 "gGu" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
+"gGF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gGH" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -11049,7 +11910,7 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "gGN" = (
 /obj/structure/winch{
@@ -11063,6 +11924,11 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"gHd" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gHg" = (
 /obj/structure/chair/stool/rogue,
@@ -11091,6 +11957,14 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"gIo" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "gIv" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -11267,6 +12141,12 @@
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"gNz" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gOa" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/twig,
@@ -11478,11 +12358,30 @@
 /obj/structure/roguemachine/musicbox,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"gTY" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "gUx" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"gUC" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguemachine/vendor{
+	keycontrol = "blacksmith"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "gUD" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
 	max_integrity = 99999
@@ -11499,6 +12398,17 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"gUR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "gUV" = (
 /obj/structure/timeddoor,
 /turf/open/floor/rogue/dirt/road{
@@ -11531,6 +12441,10 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"gVW" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -11559,6 +12473,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"gXk" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "gXr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -11631,7 +12552,9 @@
 /area/rogue/indoors/town/manor)
 "hal" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/grass,
+/turf/open/floor/rogue/tile{
+	icon_state = "greenstone"
+	},
 /area/rogue/under/cavewet/bogcaves)
 "ham" = (
 /obj/structure/closet/crate/chest{
@@ -11681,12 +12604,9 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/machinery/light/rogue/smelter,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/metal,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -11729,9 +12649,7 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "hcq" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -11757,6 +12675,11 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"hcG" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "hcL" = (
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood,
@@ -11812,7 +12735,6 @@
 	},
 /area/rogue/indoors)
 "hdG" = (
-/obj/item/rogueweapon/sword/long/vlord,
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
@@ -11850,13 +12772,13 @@
 	pixel_x = 1;
 	pixel_y = 7
 	},
-/obj/machinery/light/rogue/smelter,
 /obj/structure/window/plasma/reinforced/spawner{
 	dir = 1;
 	icon = null;
 	max_integrity = 50000;
 	name = "RPW North"
 	},
+/obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -11864,6 +12786,14 @@
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"heK" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -12035,13 +12965,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
@@ -12115,6 +13041,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hlY" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "hme" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -12159,14 +13091,23 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "hmU" = (
-/obj/structure/fluff/statue/myth{
-	desc = "A heroic figure that seems to be in mid-wink toward the viewer.";
-	name = "The Champion"
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hmV" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/concrete,
@@ -12176,6 +13117,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/garrison)
+"hmZ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "hnd" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -12206,6 +13153,10 @@
 "hnC" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
+"hnG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "hnK" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/cup/silver,
@@ -12279,7 +13230,9 @@
 "hpJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "blacksmith"
+	lockid = "blacksmith";
+	max_integrity = 9999;
+	name = "Blacksmith Door"
 	},
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -12350,6 +13303,23 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"hrk" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"hrT" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
@@ -12381,16 +13351,9 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
@@ -12410,7 +13373,9 @@
 "htZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	desc = "Forges of Malum";
+	name = "Forges of Malum"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -12430,6 +13395,10 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
+"huL" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "hvf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -12450,6 +13419,10 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"hvo" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "hvx" = (
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/tile,
@@ -12510,6 +13483,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"hyM" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "hyR" = (
 /obj/structure/stairs/stone,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -12540,6 +13523,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hzl" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -12550,6 +13541,17 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"hzX" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"hzY" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "hAa" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
@@ -12559,6 +13561,11 @@
 /obj/item/roguekey/manor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"hAc" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hAg" = (
 /obj/item/chair/rogue/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -12615,6 +13622,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hCQ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hCS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -12654,6 +13668,18 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"hEB" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hEG" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -12694,6 +13720,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hFs" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hFM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/ravager,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12711,7 +13741,7 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/fluff/grindwheel,
+/obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -12795,6 +13825,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"hJj" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hJq" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -12830,6 +13864,18 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hKt" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"hKE" = (
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -12866,11 +13912,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"hLS" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "hLW" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12880,6 +13921,10 @@
 /obj/effect/rune,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"hMB" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "hMD" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -12902,6 +13947,12 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"hNk" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hND" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
@@ -12924,6 +13975,10 @@
 /obj/effect/landmark/start/archivist,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"hNN" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/bath)
 "hNP" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
@@ -12958,6 +14013,18 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"hOM" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hOP" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /obj/structure/spider/stickyweb,
@@ -13100,6 +14167,15 @@
 /obj/item/natural/rock,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"hTL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hTT" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/ambush,
 /turf/open/floor/rogue/blocks,
@@ -13107,10 +14183,6 @@
 "hUa" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town)
-"hUp" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/shop)
 "hUq" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
@@ -13119,7 +14191,9 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/machinery/light/rogue/lanternpost,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "hUI" = (
@@ -13173,6 +14247,10 @@
 "hWL" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -13373,9 +14451,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "idR" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -13438,13 +14514,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -13536,11 +14607,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3{
-	pixel_x = -34
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"ijW" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/bog)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -13569,11 +14645,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -13605,6 +14679,11 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"ilL" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -13691,6 +14770,9 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"iqs" = (
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -13740,11 +14822,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"irq" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/chair/bench/coucha,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "irz" = (
 /obj/structure/mineral_door/bars{
 	locked = 1
@@ -13778,21 +14855,12 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -13803,9 +14871,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving-t"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
@@ -13898,6 +14964,15 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iww" = (
+/obj/structure/rack/rogue,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -13907,6 +14982,15 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ixg" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ixt" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -14034,6 +15118,16 @@
 	dir = 10
 	},
 /area/rogue/outdoors/bog)
+"iAh" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iAi" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -14079,6 +15173,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"iCm" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "iCn" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/church,
@@ -14128,6 +15226,10 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iDV" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -14161,6 +15263,12 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
+"iEB" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -14230,6 +15338,7 @@
 	dir = 5;
 	pixel_x = -6
 	},
+/obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "iGh" = (
@@ -14266,14 +15375,16 @@
 /area/rogue/indoors/town/manor)
 "iIl" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "iIo" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"iIA" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iIG" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -14405,14 +15516,10 @@
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
 /obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
+	dir = 5
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -14483,14 +15590,8 @@
 	},
 /area/rogue/indoors)
 "iOq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	icon_state = "woodrailing"
-	},
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cleanable/generic,
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "iOI" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -14538,6 +15639,18 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iPF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
+"iPI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "iPJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -14551,7 +15664,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "iQh" = (
 /obj/structure/closet/crate/chest/crafted,
@@ -14579,23 +15692,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/indoors/town/church/chapel)
-"iRG" = (
-/obj/structure/roguemachine/vendor/blk,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "iRN" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/thresher,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -14629,12 +15729,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14696,12 +15795,29 @@
 /obj/item/kitchen/spoon/plastic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"iVA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "iVM" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"iVW" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "iWh" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/veteran{
@@ -14710,9 +15826,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14751,6 +15869,13 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"iXt" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iXK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -14799,15 +15924,23 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iYH" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/shop)
 "iYQ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "iZl" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -14844,12 +15977,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"jav" = (
-/obj/structure/table/wood/bar,
-/obj/item/rogueweapon/sword/long/vlord,
-/obj/item/reagent_containers/glass/bottle/venom,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "jaw" = (
 /obj/structure/closet/crate/chest,
 /obj/structure/feedinghole,
@@ -14928,6 +16055,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"jcT" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jcX" = (
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
@@ -14955,6 +16086,10 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
+"jdJ" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jdK" = (
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
@@ -15022,6 +16157,14 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"jfV" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15083,6 +16226,16 @@
 "jis" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jit" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jiv" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -15102,6 +16255,10 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"jjF" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -15115,13 +16272,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"jkj" = (
-/obj/structure/roguemachine/vendor/blk3,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "jkv" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -15157,6 +16307,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"jlk" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jlF" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
@@ -15175,14 +16333,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/item/roguekey/dungeon{
-	lockid = "woodsm";
-	name = "old key"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
@@ -15227,6 +16379,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"jnN" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"jnO" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "jod" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/feather,
@@ -15273,9 +16432,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -15313,6 +16473,16 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jrn" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jrs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/seeds/wheat,
@@ -15377,6 +16547,14 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"jtV" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "juc" = (
 /obj/item/rogueweapon/sickle/scythe{
 	color = gold;
@@ -15388,18 +16566,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"juf" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "juj" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"jul" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -15552,6 +16725,13 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jAJ" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jAN" = (
 /obj/effect/landmark/start/farmer{
 	dir = 4
@@ -15565,6 +16745,12 @@
 "jAY" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"jBh" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jBv" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -15580,16 +16766,20 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
 /obj/structure/roguemachine/withdraw,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "jCt" = (
@@ -15670,13 +16860,19 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"jEB" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
+"jEe" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"jEB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
@@ -15745,6 +16941,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
+"jHv" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jHz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
@@ -15781,9 +16985,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
+"jJa" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -15838,6 +17050,14 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"jMc" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jMd" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -15849,13 +17069,8 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -15869,6 +17084,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"jMs" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jMA" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
@@ -15901,6 +17121,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jNj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -15909,15 +17136,12 @@
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15946,6 +17170,12 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"jNV" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "jOn" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -15984,6 +17214,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"jPz" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jPB" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -16060,6 +17297,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
 "jRR" = (
+/obj/structure/bars,
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
@@ -16112,9 +17350,12 @@
 /area/rogue/outdoors/bog)
 "jUs" = (
 /obj/structure/stairs/stone,
-/obj/structure/mineral_door/secret/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"jUD" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jUH" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -16157,6 +17398,7 @@
 /area/rogue/under/cavewet/bogcaves)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
+/obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "jXe" = (
@@ -16183,6 +17425,10 @@
 /obj/effect/landmark/start/seelie,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"jXB" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "jXK" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/churchrough,
@@ -16197,12 +17443,30 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jXU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jXZ" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
 "jYm" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"jYn" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "jYE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/tongs,
@@ -16250,6 +17514,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"jZY" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -16311,17 +17579,15 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/church/chapel)
+"kch" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "kcj" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
 	},
 /area/rogue/indoors)
-"kck" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/adminordrazine,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "kcm" = (
 /obj/structure/fluff/statue/knightalt,
 /obj/structure/fluff/walldeco/customflag{
@@ -16334,18 +17600,42 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"kcR" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kcX" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kds" = (
-/obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
+"kdg" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"kds" = (
+/obj/structure/table/wood,
+/obj/item/dice{
+	pixel_y = 13
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"kdv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "kdM" = (
 /obj/structure/mineral_door/wood{
@@ -16356,6 +17646,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"kem" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "keq" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -16380,6 +17678,28 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"keW" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "kfe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -16398,7 +17718,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "kfr" = (
-/obj/machinery/light/rogue/forge,
+/obj/structure/rack/rogue,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "kfv" = (
@@ -16425,6 +17752,13 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"kgd" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "kgj" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
@@ -16434,6 +17768,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"kgt" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kgC" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -16455,8 +17793,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/flora/roguetree,
-/turf/open/water/swamp,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "khC" = (
 /obj/structure/flora/newtree,
@@ -16606,10 +17944,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"kpr" = (
-/obj/structure/fluff/alch,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "kpZ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -16617,15 +17951,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "kqc" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -16664,6 +17992,18 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"kqW" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "kra" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/rooftop{
@@ -16707,11 +18047,18 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"ksh" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
 	icon_state = "longtable_mid"
 	},
+/obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "kst" = (
@@ -16746,8 +18093,7 @@
 /area/rogue/outdoors/town)
 "ksK" = (
 /obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
@@ -16834,15 +18180,24 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kuV" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -16873,6 +18228,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"kwn" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "kwq" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/town/tavern)
@@ -16883,13 +18244,12 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -16963,6 +18323,16 @@
 "kzI" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
+"kzO" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kzQ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -17022,7 +18392,9 @@
 /area/rogue/outdoors/rtfield)
 "kBs" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/craftstone/window{
+	icon_state = "stonewindow"
+	},
 /area/rogue/indoors/town/garrison)
 "kBy" = (
 /obj/structure/mineral_door/wood{
@@ -17107,6 +18479,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"kEb" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "kEd" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -17145,10 +18521,15 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -17167,23 +18548,22 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"kFr" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kFD" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kFG" = (
 /obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/luckpot,
-/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,
-/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot,
-/obj/item/reagent_containers/glass/bottle/rogue/endurancepot,
-/obj/item/reagent_containers/glass/bottle/rogue/constitutionpot,
-/obj/item/reagent_containers/glass/bottle/rogue/alacritypot,
-/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot,
-/obj/item/reagent_containers/glass/bottle/rogue/virilitypot,
-/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,
-/obj/item/reagent_containers/glass/bottle/rogue/soporpot,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
 "kFS" = (
@@ -17220,6 +18600,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"kHu" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "kHA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -17241,8 +18627,13 @@
 /area/rogue/indoors/town/garrison)
 "kIf" = (
 /obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "kIu" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -17268,6 +18659,16 @@
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kIV" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "kJj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -17370,6 +18771,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kMv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "kMx" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -17412,7 +18818,7 @@
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_x = -31
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "kNv" = (
 /obj/effect/landmark/start/adventurer{
@@ -17447,6 +18853,15 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kOA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "kOB" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -17543,6 +18958,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kRI" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kRN" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
@@ -17611,6 +19032,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"kTx" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -17960,13 +19385,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -17976,6 +19397,16 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"lhy" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -18088,6 +19519,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/shelter/rtfield)
+"llo" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"llq" = (
+/obj/structure/roguemachine/scomm/l,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lls" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -18105,7 +19552,7 @@
 	lockid = "church";
 	name = "Temple of the One"
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "lmo" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -18178,16 +19625,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -18248,6 +19689,13 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"lqm" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -18257,6 +19705,16 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"lqJ" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -18266,6 +19724,12 @@
 "lqR" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
+"lrj" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
@@ -18359,6 +19823,19 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"lvF" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lvO" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobblerock,
@@ -18392,6 +19869,25 @@
 /obj/structure/mirror/fancy,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"lxN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "lxQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -18495,6 +19991,11 @@
 "lAB" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"lAK" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lAO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -18567,6 +20068,13 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
+"lEs" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "lEu" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -18637,19 +20145,35 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"lFR" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lFV" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"lGh" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "lGI" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"lGS" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "lGX" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
@@ -18727,6 +20251,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"lJJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lJO" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -18749,7 +20277,8 @@
 "lKa" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "mason"
+	lockid = "mason";
+	max_integrity = 9999
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -18786,6 +20315,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"lLl" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lLp" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
@@ -18797,7 +20333,7 @@
 /area/rogue/under/town/basement)
 "lLK" = (
 /obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -18822,9 +20358,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/obj/structure/bed/rogue/inn/hay,
-/obj/effect/landmark/start/vagrantlate,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -18948,12 +20487,6 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"lTF" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "lTZ" = (
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/tile{
@@ -18974,6 +20507,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"lUT" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lVe" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
@@ -18994,6 +20531,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"lVF" = (
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "lVS" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks{
@@ -19024,6 +20565,13 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"lXh" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lXo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -19049,14 +20597,20 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
+"lXX" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lYl" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "lYs" = (
 /obj/structure/mineral_door/wood{
@@ -19133,6 +20687,14 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"maB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "maJ" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -19201,9 +20763,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -19314,6 +20879,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"mhi" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/bath)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -19387,11 +20956,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -19466,6 +21032,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"mnW" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -19537,6 +21112,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"mpr" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mpu" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood,
@@ -19553,6 +21134,10 @@
 "mpP" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -19578,14 +21163,10 @@
 	},
 /area/rogue/indoors/town)
 "mrE" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mrN" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -19625,8 +21206,14 @@
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
+	dir = 1;
+	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
 "mtF" = (
@@ -19687,9 +21274,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "mwq" = (
-/obj/structure/well,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "mwz" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19767,6 +21354,13 @@
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mzf" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mzk" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -19814,6 +21408,15 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"mCT" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "mDe" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0
@@ -19853,10 +21456,11 @@
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
 "mDY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
+/obj/structure/ladder,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "mEg" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -19875,6 +21479,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"mEy" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "mEz" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -19932,22 +21543,18 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "mGn" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mGV" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/glass/bottle/rogue/virilitypot,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "mHb" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -19974,6 +21581,19 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"mIC" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"mJg" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -19998,6 +21618,12 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"mKz" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mKR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -20036,6 +21662,10 @@
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"mMs" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "mMv" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
@@ -20107,7 +21737,6 @@
 /area/rogue/indoors/town/manor)
 "mOT" = (
 /obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
 "mOW" = (
@@ -20163,17 +21792,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
 "mQA" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -20232,6 +21859,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"mTj" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "mTO" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -20270,10 +21903,26 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"mUC" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "mUQ" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"mUY" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mVa" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
@@ -20287,9 +21936,13 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -20311,6 +21964,17 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
+"mWn" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mWx" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -20490,16 +22154,6 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"ncp" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "nda" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/keyring,
@@ -20591,10 +22245,26 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"nfb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nfN" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -20618,14 +22288,13 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "woodsm"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -20686,12 +22355,6 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"nkV" = (
-/obj/structure/roguemachine/drugmachine,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
-	dir = 1
-	},
-/area/rogue/indoors/town/shop)
 "nkW" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -20703,10 +22366,23 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"nle" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nlf" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"nlC" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nlG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -20735,6 +22411,20 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"nmC" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"nmF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "nmR" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -20756,6 +22446,15 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"nnb" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "nnk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
@@ -20769,6 +22468,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
+"nnI" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "nnQ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -20794,11 +22497,14 @@
 	},
 /area/rogue/indoors/town/garrison)
 "npm" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4;
-	name = "Guest Room"
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/turf/closed,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "npJ" = (
 /obj/structure/table/wood{
@@ -20872,9 +22578,7 @@
 /area/rogue/indoors/town)
 "nrx" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "nrD" = (
 /obj/structure/fermenting_barrel/beer,
@@ -20952,11 +22656,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/candle,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -20966,6 +22670,14 @@
 "nvd" = (
 /turf/open/water/bath,
 /area/rogue/indoors/shelter/rtfield)
+"nvf" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
+"nvr" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nvA" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
@@ -20983,6 +22695,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nvV" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nvW" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
@@ -21099,10 +22817,11 @@
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
 "nyc" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/closed/wall/mineral/rogue/decostone/long{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "nyd" = (
 /obj/structure/glowshroom,
@@ -21165,6 +22884,9 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"nAy" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nAS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -21180,17 +22902,33 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"nBp" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "nBq" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -21211,12 +22949,37 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"nBT" = (
+/obj/structure/mineral_door/wood{
+	dir = 4;
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
+"nCA" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nCN" = (
 /obj/machinery/light/rogue/torchholder{
@@ -21294,6 +23057,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nGn" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nGw" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -21365,6 +23132,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"nIq" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nIr" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -21402,15 +23175,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/obj/structure/handcart,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -21433,6 +23205,11 @@
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
+"nKk" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nKt" = (
 /obj/structure/fluff/statue/tdummy2,
 /turf/open/floor/rogue/grass,
@@ -21441,6 +23218,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/blocks{
 	icon_state = "newstone2"
 	},
@@ -21563,9 +23341,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -21633,18 +23414,10 @@
 	},
 /area/rogue/outdoors/rtfield)
 "nRo" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nRs" = (
 /obj/structure/bed/rogue/shit,
@@ -21678,9 +23451,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nSr" = (
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -21689,6 +23466,16 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"nSy" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nSS" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -21719,9 +23506,14 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -21773,6 +23565,17 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"nVf" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nVF" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -21809,6 +23612,7 @@
 	dir = 9;
 	icon_state = "border"
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nWP" = (
@@ -21936,6 +23740,13 @@
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nZw" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nZQ" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -21946,6 +23757,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"nZV" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "oaa" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -21954,18 +23769,27 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"oaU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"obq" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+"obi" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"obq" = (
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -21984,9 +23808,7 @@
 /obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "obT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -22042,9 +23864,6 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "odo" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 34
-	},
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -22086,6 +23905,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -22134,15 +23954,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -22162,12 +23983,20 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"ohA" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+"ohw" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"ohA" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ohE" = (
 /obj/structure/bed/rogue/shit,
 /obj/structure/spider/stickyweb,
@@ -22207,20 +24036,26 @@
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"oiC" = (
-/obj/machinery/light/rogue/firebowl/stump,
+"oir" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/garrison)
+"oiC" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "oiD" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -22228,9 +24063,17 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"oiW" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ojc" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -22349,7 +24192,7 @@
 /area/rogue/under/cavewet/bogcaves/tomb)
 "onR" = (
 /obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "onT" = (
 /obj/structure/table/wood{
@@ -22371,6 +24214,12 @@
 "ooJ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"ooP" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "opc" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
@@ -22404,6 +24253,13 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"oqs" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -22411,6 +24267,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"oqH" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oqQ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/water/cleanshallow,
@@ -22432,12 +24292,26 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"orE" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "orS" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"orT" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "orY" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -22478,6 +24352,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"otr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ots" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
@@ -22529,6 +24410,16 @@
 "ous" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"ouN" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "ouQ" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -22539,11 +24430,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -22579,6 +24468,19 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"owf" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"owj" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -22637,6 +24539,18 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
+"oye" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "oyi" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -22649,6 +24563,10 @@
 /obj/item/natural/poo/horse,
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"oys" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oyE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/cloth,
@@ -22686,6 +24604,12 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ozt" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ozw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -22777,6 +24701,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"oBF" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -22970,7 +24901,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -22998,12 +24932,25 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"oJO" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
+"oJH" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"oJO" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -23031,11 +24978,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"oLg" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oLC" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"oLF" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oLO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb{
@@ -23046,10 +25005,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 1
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -23151,6 +25109,14 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"oPp" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "oPv" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23215,12 +25181,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -23294,6 +25256,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"oTE" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oUc" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -23306,10 +25276,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "oUn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "oUS" = (
 /obj/structure/roguewindow/openclose{
@@ -23479,16 +25455,6 @@
 /obj/item/seeds/pumpkin,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"oYP" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "oYV" = (
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood{
@@ -23584,6 +25550,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"pbg" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pbG" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjaill"
@@ -23652,12 +25626,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
@@ -23672,13 +25642,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -23787,16 +25753,16 @@
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"pho" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "pht" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"phD" = (
-/obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "phR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -23890,6 +25856,14 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
+"pkt" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pku" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/manor)
@@ -23921,6 +25895,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"plk" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"plR" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -23965,6 +25949,9 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pno" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "pnD" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -24186,6 +26173,12 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"put" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "pvd" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -24325,6 +26318,12 @@
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"pzi" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pzn" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -24411,6 +26410,17 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"pBC" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "pBJ" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -24435,6 +26445,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"pCH" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "pCW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -24460,11 +26483,16 @@
 /area/rogue/indoors/town/tavern)
 "pDA" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "pDF" = (
@@ -24481,6 +26509,29 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"pDM" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"pDO" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pDP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8;
@@ -24513,6 +26564,10 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pEX" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -24555,6 +26610,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"pHF" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "pHI" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile{
@@ -24594,10 +26655,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"pIV" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/grass,
-/area/rogue/under/cavewet/bogcaves)
 "pJa" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -24635,9 +26692,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/item/reagent_containers/food/snacks/smallrat/dead,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -24656,6 +26713,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pLf" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "pLh" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -24679,6 +26746,16 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"pLK" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pMi" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
@@ -24692,9 +26769,22 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -24972,6 +27062,12 @@
 /obj/item/quiver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"pUQ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pVg" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -24985,12 +27081,24 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"pVF" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pVW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"pWm" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -25097,6 +27205,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qab" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "qad" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -25262,20 +27378,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qeY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7;
@@ -25472,8 +27581,10 @@
 /turf/closed/mineral/rogue/gem,
 /area/rogue/under/cavewet/bogcaves)
 "qls" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qlt" = (
 /obj/structure/rack/rogue/shelf/big,
@@ -25560,6 +27671,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qof" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qoi" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -25581,6 +27702,21 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"qoP" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -25600,10 +27736,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qpt" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/garrison)
 "qpJ" = (
 /obj/structure/stairs/fancy/l{
 	dir = 1
@@ -25624,11 +27763,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -25734,6 +27872,11 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qsC" = (
+/obj/machinery/anvil,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qsI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -25771,6 +27914,10 @@
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"qtK" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "qtT" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -25794,6 +27941,12 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"quy" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -25808,18 +27961,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -25876,13 +28026,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck{
-	tame = 1
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -25919,9 +28064,24 @@
 /obj/item/clothing/gloves/roguetown/chain,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"qxL" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "qxN" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue,
 /area/rogue/indoors/town/manor)
+"qxO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qxZ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1;
@@ -25934,6 +28094,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qyS" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -25956,18 +28128,33 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"qzx" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qzy" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
@@ -26035,17 +28222,22 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/structure/flora/wildplant/wild_poppy,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -26065,6 +28257,18 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qEj" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"qEq" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
@@ -26094,11 +28298,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -26210,10 +28414,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
@@ -26242,8 +28447,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
 "qLF" = (
-/obj/structure/roguewindow/stained/silver,
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qLP" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -26266,6 +28476,16 @@
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"qNF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -26285,6 +28505,13 @@
 "qOx" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"qOT" = (
+/obj/structure/rack/rogue,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qOW" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
@@ -26341,6 +28568,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qQw" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -26360,16 +28593,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/metal,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "qRp" = (
+/obj/structure/chair/bench,
 /obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+	pixel_y = 5;
+	dir = 1
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
@@ -26409,6 +28643,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"qSE" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qSU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
@@ -26490,6 +28729,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"qWS" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -26534,10 +28778,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -26557,6 +28799,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"qYQ" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qZh" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
@@ -26648,12 +28894,22 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/flora/roguetree,
-/obj/structure/flora/roguetree,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
+"rcx" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
@@ -26757,6 +29013,14 @@
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"rfd" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rfl" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/bog)
@@ -26764,10 +29028,9 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -26797,14 +29060,11 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -26885,7 +29145,7 @@
 /area/rogue/under/town/basement)
 "rkf" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/water/cleanshallow,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "rkp" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -26966,8 +29226,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rmJ" = (
-/obj/structure/flora/wildplant/wild_herbs,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "rmK" = (
 /obj/structure/flora/wildplant/wild_herbs,
@@ -26991,6 +29254,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"rni" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rns" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/globe,
@@ -27006,15 +29276,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"roj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/structure/flora/wildplant/wild_herbs,
-/turf/open/floor/grass,
-/area/rogue/under/cavewet/bogcaves)
 "rou" = (
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"roG" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "roO" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -27043,6 +29314,13 @@
 "rpp" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"rps" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rpv" = (
 /obj/item/roguekey/blacksmith/town,
 /obj/item/roguekey/blacksmith/town,
@@ -27260,6 +29538,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"rwD" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "rwH" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -27286,6 +29568,16 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"rxa" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rxc" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -27301,9 +29593,12 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "rxp" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rxq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -27330,6 +29625,12 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rxS" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ryc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -27341,6 +29642,13 @@
 "ryg" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"ryE" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -27417,6 +29725,12 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"rCc" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rCL" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -27445,6 +29759,12 @@
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"rDD" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "rDU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -27480,7 +29800,7 @@
 	dir = 5;
 	icon_state = "border"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "rEA" = (
 /obj/structure/bed/rogue/shit/bier,
@@ -27540,21 +29860,16 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -27618,6 +29933,7 @@
 /area/rogue/indoors/town/dwarfin)
 "rKn" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -27717,6 +30033,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"rNT" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "rOb" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27744,11 +30064,6 @@
 "rOF" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/bog)
-"rOQ" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "rOU" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -27776,6 +30091,10 @@
 /obj/structure/crabnest,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"rPU" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "rPX" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -27821,9 +30140,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -27837,22 +30156,31 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"rRM" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church/mid{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rSn" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -27901,9 +30229,7 @@
 "rTm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "rTv" = (
 /obj/structure/fluff/traveltile/vampire{
@@ -27942,15 +30268,22 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"rUm" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
+/obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -28049,6 +30382,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"rXt" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "rXE" = (
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
@@ -28067,6 +30406,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"rYs" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rYt" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -28157,6 +30504,12 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"saP" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "saS" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -28176,12 +30529,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/roguemachine/withdraw{
-	pixel_x = -1;
-	pixel_y = 31
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -28236,7 +30586,7 @@
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "sdj" = (
 /obj/structure/fluff/railing/border{
@@ -28244,6 +30594,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/bog)
+"sdl" = (
+/obj/machinery/light/rogue/smelter,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sdo" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/rack/rogue/shelf/big,
@@ -28292,12 +30647,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -28387,6 +30741,17 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"shJ" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "shV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -28422,6 +30787,10 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"siG" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "siI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/crate/roguecloset/inn,
@@ -28549,10 +30918,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"snb" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet/bogcaves)
 "snj" = (
 /obj/structure/bars/passage{
 	redstone_id = "tourneybottom"
@@ -28697,6 +31062,13 @@
 "squ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
+"sqL" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sqW" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/mountains)
@@ -28737,6 +31109,36 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"ssD" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"ssF" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ssG" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -28777,6 +31179,15 @@
 "sue" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors)
+"sug" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sux" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -28798,9 +31209,7 @@
 /area/rogue/outdoors/beach)
 "suN" = (
 /obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "suY" = (
 /obj/structure/fluff/railing/border{
@@ -28825,6 +31234,25 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"svL" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "svX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -28865,28 +31293,24 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/structure/fluff/walldeco/painting/queen{
-	pixel_y = 32
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
 	icon_state = "barsbent";
-	layer = 2.81
+	layer = 2.81;
+	max_integrity = 99999
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -28911,6 +31335,13 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
+"syt" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "syL" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/woodturned,
@@ -28934,6 +31365,10 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"szJ" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "szM" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
@@ -28959,6 +31394,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"sAC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "sAP" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -28995,6 +31436,14 @@
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"sBJ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sBX" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -29016,10 +31465,10 @@
 /area/rogue/outdoors/town)
 "sDa" = (
 /obj/effect/decal/cobbleedge{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -29038,6 +31487,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"sDR" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sDX" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobble,
@@ -29110,6 +31566,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sGx" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sGM" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -29169,13 +31629,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -29191,11 +31649,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"sIT" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "sJZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -29210,6 +31663,10 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
+"sKs" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "sKL" = (
 /obj/structure/chair/wood/rogue{
@@ -29237,7 +31694,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "sLc" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "sLF" = (
@@ -29251,6 +31710,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"sLM" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "sMb" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/wood,
@@ -29277,6 +31740,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"sNG" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "sNY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -29287,6 +31761,13 @@
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"sOh" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sOy" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -29294,6 +31775,10 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
+"sOY" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "sPj" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt,
@@ -29332,6 +31817,22 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"sQI" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"sQV" = (
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -29345,6 +31846,14 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sRU" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -29376,6 +31885,10 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"sSL" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "sSS" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave)
@@ -29466,6 +31979,16 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"sVd" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sVB" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -29479,6 +32002,15 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"sWi" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
@@ -29506,11 +32038,25 @@
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"sXG" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "sXU" = (
 /obj/structure/fermenting_barrel/random,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"sXW" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sYa" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -29522,6 +32068,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"sYv" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sYw" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
@@ -29531,6 +32084,10 @@
 "sYA" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
@@ -29557,6 +32114,19 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"sZk" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"sZv" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -29571,10 +32141,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "tat" = (
 /obj/structure/fluff/railing/border{
@@ -29658,6 +32232,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"tcq" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "tcM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -29677,6 +32257,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tdz" = (
@@ -29690,10 +32271,15 @@
 	},
 /area/rogue/indoors)
 "tdJ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/ingot/silver,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tei" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/rogue/ruinedwood{
@@ -29745,11 +32331,11 @@
 "tfp" = (
 /obj/structure/table/wood{
 	dir = 1;
-	icon_state = "longtable"
+	icon_state = "largetable"
 	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -29763,6 +32349,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"tfW" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "tfX" = (
 /obj/structure/stairs{
 	dir = 8
@@ -29808,10 +32403,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/turf/closed/wall/mineral/rogue/decostone/end{
-	dir = 4
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -29907,14 +32501,22 @@
 /obj/structure/chair/bench/church{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "tlb" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"tlB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -29922,8 +32524,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "tlX" = (
 /obj/structure/table/wood{
@@ -29957,6 +32562,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"tnh" = (
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tnn" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/cobble,
@@ -30003,13 +32613,17 @@
 "tou" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tox" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
-"tpd" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30113,6 +32727,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ttW" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -30215,11 +32836,6 @@
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"twS" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/cyanide,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "twT" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shovel,
@@ -30228,10 +32844,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "twX" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "txa" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -30374,6 +32991,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"tAs" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tAt" = (
 /obj/structure/fluff/millstone{
 	pixel_y = 7
@@ -30386,6 +33011,18 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"tAT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tAX" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road{
@@ -30458,13 +33095,25 @@
 	},
 /area/rogue/outdoors/beach)
 "tCz" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"tCN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "tCX" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -30490,6 +33139,10 @@
 /area/rogue/outdoors/rtfield)
 "tDq" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tDJ" = (
@@ -30572,6 +33225,8 @@
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
+/obj/item/listenstone,
+/obj/item/scomstone,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tGg" = (
@@ -30659,24 +33314,55 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tJw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "tJx" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors)
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"tKf" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"tKg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tKu" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -30774,13 +33460,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town)
-"tNI" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "tNP" = (
 /obj/structure/fluff/walldeco/serpflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -30814,6 +33493,10 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"tOv" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
@@ -30878,6 +33561,11 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tSN" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tTb" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0;
@@ -30918,12 +33606,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
 	},
-/turf/open/water/swamp,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
@@ -30932,9 +33619,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/item/candle/lit,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -30956,6 +33643,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
+"tVu" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "tVx" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -31068,16 +33762,20 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
-"uaj" = (
-/obj/structure/fluff/grindwheel,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"uai" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"uaj" = (
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -31191,6 +33889,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"ueS" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ueX" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/grass,
@@ -31210,6 +33916,10 @@
 "ufJ" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
+"ufN" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "ufR" = (
 /obj/structure/chair/wood/rogue/chair3,
@@ -31274,6 +33984,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uiv" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/obj/item/listenstone,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uiN" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
@@ -31287,6 +34004,10 @@
 /obj/item/candle/lit,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"uje" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ujh" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
@@ -31347,13 +34068,34 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"ukL" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ukU" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ulj" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ulu" = (
-/obj/machinery/light/rogue/firebowl,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/seeds/sweetleaf,
+/obj/item/seeds/sweetleaf,
+/obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "ulY" = (
@@ -31441,6 +34183,14 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"upI" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "upU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/asteroid/elite/broodmother,
 /turf/open/floor/rogue/blocks,
@@ -31484,21 +34234,30 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ure" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "urr" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/machinery/light/rogue/torchholder{
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -31653,10 +34412,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "uvu" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 8
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -31671,15 +34429,14 @@
 "uvF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
+"uvI" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "uwa" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -31728,23 +34485,18 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/candle,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -31763,6 +34515,12 @@
 /obj/item/roguekey/church,
 /obj/item/paper/confession,
 /obj/item/roguekey/priest,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "uyw" = (
@@ -31793,11 +34551,20 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31868,8 +34635,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "uBv" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/alch,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "uBE" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -31916,13 +34686,21 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uDw" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uDy" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -31939,16 +34717,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"uDV" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
-/area/rogue/under/cavewet/bogcaves)
 "uEG" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -31963,16 +34731,18 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -31993,9 +34763,8 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "uGo" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -32033,6 +34802,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"uHa" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "uHb" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -32044,23 +34819,19 @@
 /area/rogue/indoors/town/church/chapel)
 "uHg" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHh" = (
 /obj/structure/feedinghole,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -32210,6 +34981,21 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"uOc" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"uOu" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -32242,10 +35028,31 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/landmark/start/druid,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"uPi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -32323,6 +35130,16 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"uRR" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "uRZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -32333,10 +35150,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/rtfield)
 "uSx" = (
-/obj/structure/rack/rogue,
-/obj/item/storage/backpack/rogue/backpack/surgery,
-/obj/item/needle,
-/obj/item/rope,
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
@@ -32345,6 +35161,14 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"uTc" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uTf" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -32372,10 +35196,8 @@
 /area/rogue/indoors/town/dwarfin)
 "uTT" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -32414,6 +35236,18 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uVj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -32421,6 +35255,14 @@
 "uVq" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/church/chapel)
+"uVs" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "uVz" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble,
@@ -32455,6 +35297,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uWj" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uWE" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
@@ -32464,7 +35312,7 @@
 	},
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "uXb" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -32492,6 +35340,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"uXS" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uXW" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -32536,6 +35388,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uYU" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uYV" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "butcher"
@@ -32562,10 +35421,6 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "uZD" = (
@@ -32614,6 +35469,10 @@
 "vaN" = (
 /turf/open/floor/rogue/dirt/snow,
 /area/rogue/indoors/shelter/mountains)
+"vaQ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "vbe" = (
 /obj/structure/stairs{
 	dir = 1
@@ -32626,10 +35485,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town/roofs)
-"vbD" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "vbM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -32659,6 +35514,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vcA" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -32666,9 +35525,27 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "vdg" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"vdj" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -32677,6 +35554,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vdm" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vdo" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -32688,6 +35569,12 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"vdZ" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "vec" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/golden,
@@ -32722,6 +35609,10 @@
 /obj/structure/plasticflaps,
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
+"veE" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "veK" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -32743,8 +35634,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/cobblerock,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/rtfield)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -32791,8 +35681,20 @@
 	dir = 1;
 	icon_state = "border"
 	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vgH" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "vgZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -32858,11 +35760,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/obj/structure/mineral_door/wood/window{
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -32916,6 +35816,13 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"vlN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vlX" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -32949,6 +35856,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"vmX" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vng" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -32967,6 +35881,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"vnu" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
@@ -32975,6 +35893,10 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"vnO" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vnX" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
@@ -33001,6 +35923,15 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vor" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "vou" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -33009,11 +35940,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -33111,9 +36040,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -33305,6 +36237,17 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"vxV" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"vyn" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -33420,6 +36363,7 @@
 /obj/item/clothing/neck/roguetown/psicross/silver,
 /obj/item/clothing/neck/roguetown/psicross,
 /obj/item/clothing/neck/roguetown/psicross,
+/obj/item/listenstone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "vBH" = (
@@ -33451,9 +36395,7 @@
 /obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "vCs" = (
 /obj/effect/decal/cobbleedge{
@@ -33543,6 +36485,10 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"vEx" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vEz" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -33573,22 +36519,23 @@
 	},
 /area/rogue/outdoors/beach)
 "vFj" = (
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
-"vFz" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
+"vFy" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
+"vFz" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -33607,15 +36554,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed,
+/area/rogue/indoors/town)
 "vGQ" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "vGT" = (
 /obj/structure/spacevine,
@@ -33627,9 +36575,20 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"vHh" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vHn" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -33643,6 +36602,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"vII" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vIJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
@@ -33653,8 +36619,8 @@
 "vIX" = (
 /obj/structure/roguemachine/scomm/r,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
 "vJb" = (
@@ -33695,8 +36661,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -33733,7 +36703,6 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "vMQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
 	dir = 4;
 	layer = 2.8;
@@ -33773,6 +36742,17 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"vND" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "vOa" = (
 /obj/structure/stairs{
 	dir = 8
@@ -33805,10 +36785,9 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/flora/roguegrass,
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -33850,9 +36829,8 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/metal,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -33896,8 +36874,13 @@
 	},
 /area/rogue/outdoors/bog)
 "vSM" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "vSQ" = (
 /obj/structure/stairs/stone{
@@ -33948,8 +36931,7 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -33966,6 +36948,12 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vVt" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "vVG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -34012,6 +37000,17 @@
 /obj/structure/table/wood/crafted,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"vWy" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "vWA" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -34026,19 +37025,28 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/town/roofs)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "vXm" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/blocks,
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	icon_state = "paving"
+	},
 /area/rogue/outdoors/town)
+"vXz" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vXF" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -34064,6 +37072,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"vYE" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vYF" = (
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34079,6 +37094,13 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"vZc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -34163,6 +37185,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"wbE" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -34173,6 +37202,12 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"wbT" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wcd" = (
 /obj/structure/stairs{
 	dir = 1
@@ -34224,9 +37259,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
 "wew" = (
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "weB" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -34261,12 +37298,18 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"wgf" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wgn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
@@ -34300,6 +37343,16 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"whz" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "whR" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves)
@@ -34311,6 +37364,26 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
+"wiH" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"wjj" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -34338,6 +37411,10 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wkw" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
@@ -34406,9 +37483,16 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "wnv" = (
+/obj/structure/roguewindow,
 /obj/structure/bars,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
+"wnE" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "wnG" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/acolyte_r,
@@ -34424,18 +37508,28 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wou" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"woV" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -34459,9 +37553,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -34478,8 +37572,16 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
-/obj/structure/flora/roguetree,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "wqE" = (
 /obj/structure/fluff/traveltile{
@@ -34503,12 +37605,13 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
@@ -34516,11 +37619,12 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "wsR" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -34531,18 +37635,20 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "wte" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "wtl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
 	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "wty" = (
 /obj/effect/decal/cobbleedge,
@@ -34624,6 +37730,15 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"wwM" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -34646,10 +37761,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "wxZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/bench,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "wyr" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -34659,16 +37772,13 @@
 	},
 /area/rogue/indoors/town/tavern)
 "wyA" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -34681,6 +37791,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"wzb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -34714,6 +37831,22 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"wAL" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "wAP" = (
 /obj/structure/rack/rogue,
 /obj/item/flint,
@@ -34775,6 +37908,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wBZ" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "wCg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -34802,6 +37941,10 @@
 "wDj" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
@@ -34831,23 +37974,40 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/well/fountain,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"wEa" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -34889,10 +38049,21 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
+"wFC" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -34915,13 +38086,6 @@
 /obj/item/natural/poo,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"wGd" = (
-/obj/structure/roguemachine/vendor/blk2,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "wGl" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -34954,6 +38118,14 @@
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
+"wIi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -34961,7 +38133,7 @@
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "wIt" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -35046,6 +38218,19 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wKF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "wKL" = (
 /obj/structure/pillory/dungeon/double,
 /turf/open/floor/rogue/cobble,
@@ -35060,6 +38245,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"wLn" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
@@ -35080,6 +38271,18 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wLT" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -35109,6 +38312,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wMo" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "wMr" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -35146,6 +38357,12 @@
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"wPd" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wPf" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/church,
@@ -35230,9 +38447,10 @@
 /area/rogue/indoors)
 "wQn" = (
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
+	lockid = "church";
+	name = "Cathedral of Enigma"
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "wQq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -35264,12 +38482,6 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wRc" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2{
-	pixel_x = 0
-	},
-/turf/open/floor/grass,
-/area/rogue/under/cavewet/bogcaves)
 "wRy" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -35278,6 +38490,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"wRE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "wSc" = (
 /obj/structure/table/wood,
 /obj/item/flint{
@@ -35288,20 +38510,17 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -35318,12 +38537,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -35345,15 +38564,13 @@
 "wTU" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
-"wUc" = (
-/obj/structure/flora/wildplant/wild_herbs,
-/turf/open/floor/grass,
-/area/rogue/under/cavewet/bogcaves)
 "wUw" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -35387,6 +38604,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"wWE" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wWK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -35441,12 +38664,17 @@
 	},
 /obj/effect/landmark/start/churchling,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
@@ -35475,6 +38703,13 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"wZr" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "wZJ" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword,
@@ -35486,12 +38721,30 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1;
-	pixel_y = -6
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"xaX" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -35505,12 +38758,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xbo" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/obj/structure/well/fountain,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xbr" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -35536,17 +38785,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -35595,28 +38840,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/structure/closet/crate/chest,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/natural/stone,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -35650,9 +38878,15 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/basement)
 "xfh" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
@@ -35661,9 +38895,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"xfP" = (
-/turf/open/floor/grass,
-/area/rogue/under/cavewet/bogcaves)
 "xgf" = (
 /obj/item/reagent_containers/food/snacks/smallrat/dead,
 /turf/open/floor/rogue/cobblerock,
@@ -35798,6 +39029,14 @@
 "xjl" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"xjp" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xjq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -35843,9 +39082,14 @@
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
 "xkF" = (
-/obj/structure/bed/rogue,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -35863,6 +39107,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"xlb" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xld" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -35928,8 +39180,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xnv" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -36034,8 +39288,8 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -36073,14 +39327,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "xrf" = (
-/obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xrg" = (
 /obj/structure/rack/rogue/shelf,
@@ -36252,15 +39502,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -36312,6 +39556,15 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
+"xxw" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "xxA" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -36391,15 +39644,20 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"xAo" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xAt" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
@@ -36454,13 +39712,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"xCv" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "xCw" = (
 /obj/item/natural/stone,
 /turf/open/water/swamp,
@@ -36588,16 +39839,11 @@
 	},
 /area/rogue/outdoors/town)
 "xET" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -36615,6 +39861,31 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"xFB" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
+"xFC" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xFD" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
@@ -36623,6 +39894,12 @@
 /obj/effect/landmark/start/barkeep,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"xFL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "xFZ" = (
 /obj/structure/spacevine,
 /turf/open/water/cleanshallow,
@@ -36668,19 +39945,22 @@
 	},
 /area/rogue/indoors/town/shop)
 "xGM" = (
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "xGW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xHe" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36718,6 +39998,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"xId" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -36736,9 +40024,18 @@
 /obj/effect/landmark/start/guardsman,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"xIK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
+"xJb" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "xJe" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/herringbone,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/town/church/chapel)
 "xJr" = (
 /obj/structure/table/wood{
@@ -36952,6 +40249,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"xQv" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xQK" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/adventurer{
@@ -37149,6 +40455,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"xWw" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xWN" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
@@ -37168,6 +40481,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"xXc" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "xXd" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/twig,
@@ -37211,23 +40533,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
 "xXN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "xXQ" = (
@@ -37365,11 +40675,18 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/roguewindow/openclose{
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"ycL" = (
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -37381,6 +40698,16 @@
 "ydm" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
+"ydJ" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ydR" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt,
@@ -37418,6 +40745,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"yeA" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "yeF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -37546,12 +40877,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -37561,6 +40889,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"yjl" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "yjp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -37578,9 +40916,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/bed/rogue/shit,
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/church/chapel)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -107677,7 +111022,7 @@ bpD
 bpD
 aAI
 aMh
-aXR
+dAE
 bgI
 bgI
 bgI
@@ -108888,7 +112233,7 @@ bqP
 baS
 baS
 aAs
-clA
+dvv
 clA
 aAs
 aAs
@@ -110094,7 +113439,7 @@ baS
 baS
 baS
 aAs
-clA
+mhi
 clA
 cHE
 bJd
@@ -111697,7 +115042,7 @@ bpD
 bpD
 aAI
 aMh
-aXR
+hNN
 bgI
 bgI
 bgI
@@ -180422,18 +183767,18 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -180824,18 +184169,18 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -181226,21 +184571,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -181628,21 +184973,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+gVW
+uaj
+uaj
+rgO
+gVW
+dNL
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -182030,21 +185375,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+uaj
+uaj
+rgO
+uaj
+bDf
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -182432,21 +185777,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+aMK
+sDR
+uaj
+uaj
+uaj
+uaj
+uaj
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -182834,21 +186179,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+qpX
+qpX
+tlB
+iME
+eRV
+uaj
+rgO
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -183236,21 +186581,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+aIT
+qpX
+qpX
+wIi
+cCC
+uaj
+sqL
+uaj
+bUi
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -183638,21 +186983,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+kHu
+qpX
+qpX
+jMc
+cCC
+pDM
+uaj
+uaj
+bUi
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -184040,21 +187385,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+qpX
+qpX
+hyM
+uaj
+eRV
+uaj
+rgO
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -184442,21 +187787,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+vII
+orT
+uaj
+uaj
+uaj
+uaj
+uaj
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -184844,21 +188189,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+uaj
+uaj
+uaj
+uaj
+bDf
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -185246,21 +188591,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+gVW
+bHe
+rgO
+rgO
+gVW
+dNL
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -185648,21 +188993,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -186050,17 +189395,17 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -186452,17 +189797,17 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -199688,15 +203033,15 @@ vRu
 vRu
 vRu
 fjw
-cEK
-ylC
-cEK
-ylC
-ylC
-ylC
-ylC
-cBf
-cBf
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 vup
 iTw
 iTw
@@ -200090,7 +203435,7 @@ vRu
 vRu
 fjw
 fjw
-ylC
+bCb
 txa
 txa
 txa
@@ -200492,7 +203837,7 @@ vRu
 vRu
 vRu
 fjw
-vRu
+sYw
 txa
 rpo
 opv
@@ -200894,7 +204239,7 @@ vRu
 vRu
 vRu
 fjw
-vRu
+sYw
 txa
 iML
 opv
@@ -201296,7 +204641,7 @@ vRu
 vRu
 fjw
 fjw
-vRu
+sYw
 txa
 yeM
 cGw
@@ -201698,7 +205043,7 @@ vRu
 fjw
 fjw
 vRu
-vRu
+sYw
 txa
 nhC
 lHK
@@ -202100,7 +205445,7 @@ vRu
 fjw
 fjw
 vRu
-vRu
+sYw
 txa
 aaI
 icc
@@ -202502,7 +205847,7 @@ vRu
 fjw
 fjw
 fjw
-vRu
+sYw
 txa
 rpo
 opv
@@ -202904,7 +206249,7 @@ vRu
 vRu
 fjw
 fjw
-fjw
+sYw
 txa
 uKD
 rpo
@@ -203306,7 +206651,7 @@ vRu
 vRu
 vRu
 vRu
-vuH
+sYw
 txa
 txa
 txa
@@ -203517,13 +206862,13 @@ dTD
 dTD
 fCU
 dRa
-wUc
-pIV
+dTD
+dTD
 dRa
 fCU
 dTD
-jul
-jul
+dTD
+dTD
 jaU
 dVO
 dVO
@@ -203702,13 +207047,13 @@ fyc
 (159,1,2) = {"
 sYw
 sYw
-vRu
-vRu
-vRu
-vRu
-vRu
-txa
-iTw
+sYw
+sYw
+sYw
+sYw
+sYw
+bCb
+bCb
 txa
 cFQ
 cBf
@@ -203915,17 +207260,17 @@ whb
 whb
 cuA
 cuA
-phD
+dTD
 dTD
 fCU
 dRa
-wRc
-xfP
+dTD
+dTD
 dRa
 fCU
 dTD
-uDV
-gtE
+dTD
+dTD
 cuA
 dVO
 dVO
@@ -204316,18 +207661,18 @@ whb
 whb
 whb
 cuA
-nkV
+cuA
 dTD
 dTD
 fCU
 dRa
-xfP
-wUc
-lTF
+dTD
+dTD
+dRa
 fCU
 dTD
-ncp
-oYP
+dTD
+dTD
 cuA
 cuA
 dVO
@@ -204723,13 +208068,13 @@ ecC
 dTD
 fCU
 dRa
-xfP
-pIV
+dTD
+dTD
 dRa
 fCU
 dTD
-dWR
-dWR
+dTD
+dTD
 cuA
 cuA
 whb
@@ -205123,12 +208468,12 @@ cuA
 cuA
 dTD
 few
-snb
+fCU
 dRa
-roj
+hal
 hal
 dRa
-snb
+fCU
 dTD
 few
 dTD
@@ -205928,10 +209273,10 @@ cIa
 ekI
 ekI
 cIa
-gGu
-hUp
-gGu
-gGu
+qBX
+qBX
+qBX
+qBX
 cIa
 ekI
 ekI
@@ -206729,7 +210074,7 @@ dSL
 dSL
 cuA
 dIo
-irq
+exG
 exG
 get
 gvn
@@ -207131,9 +210476,9 @@ dSL
 dSL
 cuA
 dIo
-dBY
 exG
-iRG
+exG
+geu
 gGu
 hxm
 gGu
@@ -207533,9 +210878,9 @@ dSL
 dSL
 cuA
 dIo
-jav
 exG
-wGd
+exG
+geu
 gGu
 hxm
 gGu
@@ -207935,9 +211280,9 @@ dSL
 dSL
 cuA
 dIo
-aJS
 exG
-jkj
+exG
+geu
 gGu
 hxm
 gGu
@@ -208337,9 +211682,9 @@ dSL
 dSL
 cuA
 dIo
-vbD
 exG
-dbw
+exG
+geu
 gGu
 hxm
 gGu
@@ -209141,7 +212486,7 @@ dSL
 dSL
 cuA
 dIo
-kpr
+exG
 exG
 get
 gUD
@@ -209543,15 +212888,15 @@ dSL
 dSL
 cuA
 dIo
-dZh
+exG
 exG
 dIo
-vbD
-mGV
-sIT
-gqo
-xCv
-tNI
+exG
+exG
+exG
+exG
+exG
+exG
 exG
 exG
 dIo
@@ -210351,13 +213696,13 @@ eIh
 exG
 gfG
 exG
-gii
-hLS
-kck
-twS
-rOQ
 exG
-tpd
+exG
+exG
+exG
+exG
+exG
+exG
 dIo
 cuA
 whb
@@ -224213,7 +227558,7 @@ eZy
 eLe
 eZy
 eZy
-eLe
+vuH
 eZy
 eZy
 fjX
@@ -224615,7 +227960,7 @@ acD
 acD
 fhw
 acD
-acD
+wRE
 acD
 acD
 acD
@@ -225013,13 +228358,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
 acD
 acD
 acD
-vRu
-vRu
-vRu
+acD
+vuH
+uDi
+vsg
 acD
 azH
 azH
@@ -225415,13 +228760,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+qgC
+vuH
+qgC
+qgC
 acD
 qgC
 qgC
@@ -225817,13 +229162,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+vsg
+qgC
+uDi
+vuH
+uDi
+vsg
 acD
 qgC
 qgC
@@ -226219,13 +229564,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+qgC
+vuH
+uDi
+vsg
 acD
 qgC
 qgC
@@ -226621,13 +229966,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+vsg
+qgC
+qgC
+vuH
+uDi
+vsg
 acD
 qgC
 qgC
@@ -227023,14 +230368,14 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+bsS
+vuH
+uDi
+qgC
+acD
 vRu
 vRu
 vRu
@@ -227424,15 +230769,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
+acD
+acD
+xxw
+acD
+acD
+acD
 vRu
 vRu
 vRu
@@ -227826,15 +231171,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+qgC
+vuH
+ffw
+qgC
+qgC
+acD
 vRu
 vRu
 vRu
@@ -228228,15 +231573,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+ogC
+vuH
+ffw
+qgC
+vsg
+acD
 vRu
 vRu
 vRu
@@ -228630,15 +231975,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+ogC
+qgC
+vuH
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -229032,15 +232377,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+qgC
+ogC
+vuH
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -229434,15 +232779,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+qgC
+qgC
+vuH
+ffw
+qgC
+acD
 vRu
 vRu
 vRu
@@ -229836,15 +233181,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+diG
+qgC
+diG
+ffw
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -230238,15 +233583,15 @@ vRu
 vRu
 vRu
 vRu
+acD
+qgC
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+ogC
+vuH
+vuH
+vuH
+vsg
+acD
 vRu
 vRu
 vRu
@@ -230640,15 +233985,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
+acD
+acD
+hcG
+hnG
+acD
+acD
 vRu
 vRu
 vRu
@@ -231047,9 +234392,9 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
 vRu
 vRu
 vRu
@@ -262525,8 +265870,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -262928,8 +266273,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -263332,9 +266677,9 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -263736,8 +267081,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -264140,8 +267485,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -264544,7 +267889,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -264947,7 +268292,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -265350,8 +268695,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 vIa
@@ -265753,8 +269098,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 vIa
 rbn
@@ -266156,8 +269501,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 aUc
 aUc
 vIa
@@ -277311,33 +280656,33 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -277713,62 +281058,62 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+mjP
+mjP
+mjP
+mjP
+mjP
+mjP
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -278115,62 +281460,62 @@ uaL
 uaL
 uaL
 uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-uaL
-hcW
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-fxx
-fxx
-uaL
-wSn
-hcW
-hcW
+veW
+qYw
+iRN
+jMf
+jMf
+nSy
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -278517,62 +281862,62 @@ wSn
 wSn
 uaL
 uaL
+veW
+qYw
+jnN
+jMf
+jMf
+jMf
+nrw
+nrw
+ydJ
+uWj
+qwp
+uwa
+uwa
+cVu
+nrw
+qxL
+jlY
+jlY
+hmZ
+kzQ
+aac
+fDB
+fDB
+dsg
+djd
+nrw
+jMf
+jMf
+uHk
 uaL
 uaL
-qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-iNT
-iNT
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-qvR
-qvR
-qvR
-uaL
-uaL
-uaL
-hcW
-uaL
-wSn
-wSn
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
+paf
 qvR
 qvR
-fxx
-fxx
-wSn
-wSn
-wSn
-hcW
+khc
+uaL
+veW
+veW
+veW
+veW
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -278919,66 +282264,66 @@ wSn
 wSn
 tzK
 uaL
+veW
+qYw
+aSD
+jMf
+tOv
+vnO
+nrw
+nrw
+pVF
+qwp
+qwp
+vnu
+vnu
+vnu
+nrw
+jlO
+jlY
+wTs
+jlY
+jlO
+aac
+fDB
+fDB
+kIV
+baV
+nrw
+jMf
+jMf
+uHk
+roG
 uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-tzK
-qvR
-uaL
-uaL
-uaL
-wSn
-uTf
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-wSn
+paf
 qvR
 qvR
-fxx
-fxx
-wSn
-wSn
-wSn
-wSn
-hcW
-hcW
-hcW
-hcW
+khc
+uaL
+uaL
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
+cWT
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -279320,67 +282665,67 @@ wSn
 wSn
 uaL
 uaL
-tzK
 uaL
-qvR
+veW
+qYw
+rwD
+jMf
+jMf
+vnO
+nrw
+nrw
+owf
+qwp
+qwp
+uWj
+qwp
+qwp
+oJO
+jlO
+jlY
+gIo
+jlY
+jlO
+evo
+cqU
+fDB
+buB
+fDB
+nrw
+jMf
+jMf
+uHk
+iWj
 uaL
-uaL
-uaL
-qvR
-uaL
-qvR
-uaL
-wSn
-wSn
-tzK
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
+paf
 qvR
 qvR
-qvR
+khc
 fxx
-fxx
+aJj
 wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-hcW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -279723,66 +283068,66 @@ wSn
 uaL
 uaL
 uaL
+veW
+qYw
+qYw
+mQr
+mQr
+nZV
+qYw
+nrw
+ksh
+nle
+qwp
+qwp
+qwp
+qwp
+oJO
+jlO
+jlY
+wFC
+jlY
+jlO
+nrw
+tKg
+fDB
+fDB
+fDB
+lGS
+jMf
+jMf
+uHk
+uaL
+uaL
+lrj
 uaL
 qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
+khc
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
 wSn
 wSn
-wSn
-uaL
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-hcW
-wSn
-qvR
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-uaL
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 hcW
@@ -280125,68 +283470,68 @@ wSn
 wSn
 uaL
 uaL
+veW
+qYw
+rwD
+mQr
+mQr
+nZV
+qYw
+nrw
+iXt
+uWj
+qwp
+aem
+aem
+aem
+nrw
+bmL
+jlY
+wEa
+jlY
+bmL
+nrw
+hlY
+fDB
+jMf
+jMf
+lGS
+jMf
+jMf
+uHk
+ykt
+ykt
+ykt
 uaL
 qvR
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
+khc
+fxx
+fxx
 wSn
-wSn
-wSn
-qvR
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-wSn
-qvR
-uaL
-vRq
-qvR
-uaL
-fxx
-fxx
-qvR
-qvR
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+aJj
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 uaL
@@ -280488,7 +283833,7 @@ cWT
 hcW
 hcW
 hcW
-uaL
+oye
 wSn
 wSn
 wSn
@@ -280527,69 +283872,69 @@ uaL
 uaL
 uaL
 uaL
+veW
+qYw
+iRN
+mQr
+hMB
+mQr
+wiH
+qwp
+qwp
+qwp
+lUT
+vnu
+vnu
+nKk
+nrw
+tJw
+jlY
+jlY
+jlY
+jlO
+nrw
+cqU
+fDB
+jMf
+jMf
+lGS
+cCS
+jMf
+uHk
+uaL
+uaL
+lrj
 uaL
 qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-wSn
-wSn
-wSn
-wSn
-uaL
+khc
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
 wSn
 uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-qvR
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-uaL
-qvR
-uaL
-tzK
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 uaL
 uaL
 wSn
@@ -280920,7 +284265,7 @@ uaL
 uaL
 uaL
 wSn
-tzK
+uaL
 uaL
 uaL
 hcW
@@ -280929,69 +284274,69 @@ hcW
 hcW
 uaL
 uaL
+veW
+qYw
+jnN
+mQr
+mQr
+mQr
+qYw
+nrw
+oJO
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+jlO
+bDh
+bmL
+jlO
+nrw
+vVt
+fDB
+jMf
+nlC
+nrw
+vdm
+jMf
+uHk
+xIK
+uaL
+paf
 uaL
 qvR
-qvR
-uaL
-uaL
-uaL
-qvR
-wSn
-wSn
-uaL
-wSn
-wSn
+khc
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-wSn
-wSn
-uaL
-fxx
-uaL
-qvR
-qvR
-qvR
-uaL
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-qvR
-qvR
-uaL
-uaL
-uaL
-fxx
-fxx
-qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-qvR
-uaL
 wSn
 uaL
-qvR
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 wSn
 wSn
@@ -281331,81 +284676,81 @@ hcW
 hcW
 uaL
 uaL
+veW
+qYw
+aSD
+xbW
+mQr
+mQr
+fFW
+jMf
+jMf
+jMs
+jMf
+jdJ
+jdJ
+jMf
+mwq
+nrw
+fyv
+nrw
+jlO
+jlO
+nrw
+xkF
+xaX
+jMf
+otr
+nrw
+cCS
+jMf
+uHk
+uHa
+uaL
+paf
 uaL
 qvR
-qvR
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
+khc
+fxx
+fxx
+fxx
 uaL
 wSn
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+qvR
+qvR
+qvR
+uaL
+uaL
+qvR
+qvR
+qvR
+qvR
+qvR
+qvR
 wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-mHb
-uaL
-uaL
-fxx
-fxx
-qvR
-qvR
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lcg
-oMa
-bdN
-bdN
-bdN
-bCb
-lcg
-fxx
-fxx
-qvR
-qvR
-qvR
-uaL
-pPy
-uaL
-qvR
-qvR
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
-uTf
 spp
 nzw
 qvR
@@ -281733,68 +285078,68 @@ hcW
 hcW
 hcW
 uaL
-tzK
-qvR
-qvR
-uaL
-qvR
-qvR
-uaL
+veW
+qYw
+qYw
+qYw
+qYw
+nrw
+nrw
 mwq
-uaL
-wSn
-uaL
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-wSn
-uTf
-wSn
-wSn
-uaL
-gvi
-uaL
-uaL
-jlY
-uaL
-uaL
-lcg
-fxx
-fxx
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
+jMf
+tOv
+jMf
+tOv
+jMf
+jMf
+jMf
+jMf
+jMf
+nrw
+wzb
+nrw
+nrw
+nrw
+nrw
+wZr
+nrw
+nrw
+jMf
+jMf
+uHk
+lsD
+lsD
+jJa
 uaL
 qvR
-qvR
-iNT
+khc
+fxx
+fxx
+fxx
+fxx
+wSn
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
 uaL
 uaL
 uaL
@@ -282135,66 +285480,66 @@ hcW
 hcW
 uaL
 uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-wSn
-uaL
-wSn
-wSn
-uaL
-uaL
+veW
+veW
+veW
+veW
+veW
+evo
+nrw
+nrw
+pHF
+pHF
+wbE
+gip
+rxp
+rxp
+rxp
+gip
+jMf
+nrw
+qwp
+eol
+fIK
+nrw
+cSi
+cCS
+vdm
+cCS
+jMf
+jMf
+uHk
+rhD
+rhD
+rhD
+rhD
+rhD
+khc
+rZt
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
 uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fTe
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uvu
-uaL
-uaL
-uaL
-uaL
-uaL
-uwa
-fxx
-fxx
-qvR
-qvR
-uaL
-uaL
-uaL
-uaL
-aPF
-uaL
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
 uaL
 uaL
@@ -282520,7 +285865,7 @@ uaL
 wSn
 uaL
 uaL
-uTf
+wSn
 wSn
 wSn
 wSn
@@ -282540,63 +285885,63 @@ uaL
 uaL
 uaL
 qvR
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
 qvR
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-gvi
-tev
+veW
+evo
+pEX
+vdm
+cbG
+cbG
+uPa
+gip
+gum
+avN
+lFR
+sKs
+jMf
+nrw
 qwp
-uaL
-tev
-uaL
-lcg
+dHw
+qwp
+jPz
+jMf
+jMf
+cCS
+jMf
+jMf
+jMf
+owj
 fxx
 fxx
-qvR
-qvR
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+aJj
 wSn
-uaL
-wSn
-uaL
-uaL
-uaL
+veW
+veW
+kVc
+kVc
+veW
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
 uaL
 uaL
@@ -282943,14 +286288,34 @@ uaL
 uaL
 qvR
 qvR
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
+fQq
+evo
+gDx
+vdm
+cbG
+cbG
+rYs
+gip
+tfp
+ohw
+ure
+gip
+jMf
+fLv
+qwp
+tUR
+qwp
+wzb
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+owj
+fxx
+fxx
+rXt
 fxx
 fxx
 fxx
@@ -282958,48 +286323,28 @@ fxx
 fxx
 fxx
 fxx
-fxx
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-pPy
-uaL
-qvR
-qvR
-uaL
-uaL
-lVe
-lVe
-cQY
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-fxx
-fxx
-qvR
 uaL
 wSn
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
-uaL
-uaL
-wSn
-uaL
-tzK
 wSn
 uaL
 tzK
@@ -283345,62 +286690,62 @@ uaL
 uaL
 qvR
 qvR
+fQq
+evo
+yiI
+vdm
+cbG
+cbG
+wbE
+gip
+bkF
+rni
+llo
+gip
+jMf
+nrw
+fEc
+fEc
+tUR
+wzb
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+owj
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
 uaL
 uaL
-uaL
-wSn
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-wSn
-wSn
-uTf
-wSn
-uaL
-uaL
-qvR
-lyL
-qvR
-uaL
-lVe
-jyE
-ooJ
-xHe
-lVe
-jCh
-jCh
-jCh
-gvx
-jCh
-jCh
-lVe
-fxx
-fxx
-qvR
-qvR
-wSn
-wSn
-wSn
-wSn
-wSn
-qvR
+kVc
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 uaL
 uaL
@@ -283711,7 +287056,7 @@ uaL
 uaL
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -283747,62 +287092,62 @@ uaL
 uaL
 qvR
 qvR
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
+fQq
+evo
+nrw
+nrw
+xFB
+xFB
+wbE
+sKs
+nPQ
+nPQ
+nPQ
+gip
+jMf
+nrw
+fRP
+wsR
+qwp
+jPz
+jMf
+jMf
+cCS
+jMf
+jMf
+jMf
+uHk
+rhD
+rhD
+rhD
+rhD
+rhD
+khc
+rZt
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-qvR
-qvR
-uaL
-lVe
-upY
-ooJ
-azl
-lVe
-jCh
-jCh
-jCh
-gvx
-jCh
-jCh
-lVe
-fxx
-fxx
-uaL
-qvR
-qvR
-qvR
-iNT
-qvR
-qvR
-qvR
+aJj
+kVc
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 uaL
 uaL
@@ -284149,62 +287494,62 @@ uaL
 uaL
 qvR
 qvR
+veW
+evo
+nrw
+mwq
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+tOv
+jMf
+nrw
+nrw
+nrw
+sVd
+nrw
+cSi
+cCS
+vdm
+cCS
+jMf
+jMf
+uHk
+orE
 qvR
 qvR
 qvR
-uaL
-tzK
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
 qvR
-rBC
-uaL
-uaL
+khc
 fxx
 fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-qvR
-lyL
-qvR
-lVe
-til
-ooJ
-ooJ
-lVe
-ifg
-ifg
-rgO
-vox
-jCh
-jCh
-lVe
 fxx
 fxx
-wSn
-qvR
-qvR
+fxx
 uaL
-uaL
-qvR
-qvR
-uaL
+aJj
+veW
+veW
+veW
+kVc
+kVc
+veW
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+veW
+kVc
 qvR
 qvR
 qvR
@@ -284551,62 +287896,62 @@ uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-qvR
-qvR
-qvR
+veW
+evo
+nrw
+ulj
+iCm
+sQV
+jMf
+iCm
+iCm
+jMf
+mwq
+nrw
+nrw
+nrw
+nrw
+rRA
+qwp
+nrw
+nrw
+vGN
+nrw
+nrw
+cCS
+jMf
+uHk
 uaL
 uaL
 uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
 uaL
 qvR
-qvR
-qvR
-uaL
+khc
 fxx
 fxx
-uaL
-wSn
-uaL
-wSn
-wSn
-wSn
-rCL
-qvR
-qvR
-qvR
-lVe
-lLp
-ooJ
-tuw
-lVe
-kwN
-dAf
-auL
-vox
-jCh
-jCh
-lVe
+fxx
 fxx
 fxx
 wSn
-qvR
-qvR
-qvR
-wSn
-qvR
-qvR
-uaL
+aJj
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
 wSn
 uaL
@@ -284922,7 +288267,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -284951,64 +288296,64 @@ uaL
 uaL
 uaL
 hcW
+veW
+veW
+veW
+evo
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+iPF
+iPF
+nrw
+rRA
+qwp
+rRA
+pWm
+aym
+uwa
+nrw
+vdm
+jMf
+uHk
+uaL
+uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-wSn
-qvR
-uaL
-uaL
-rcr
-rcr
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
+khc
 fxx
 fxx
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
-uaL
-lVe
-lVe
-vjs
-lVe
-lVe
-lVe
-nhR
-lVe
-lVe
-lVe
-lVe
-lVe
 fxx
 fxx
-uaL
-qvR
-vRq
-qvR
-lyL
-qvR
-qvR
-uaL
+fxx
+wSn
+aJj
+kVc
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+aZu
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
 uaL
 uaL
 qvR
@@ -285354,63 +288699,63 @@ hcW
 hcW
 hcW
 hcW
-uaL
-uaL
-uaL
-uaL
+cWT
+mjP
+mjP
+mjP
+mjP
+rRA
+rRA
+rRA
+iPF
+iPF
+rRA
+rRA
+rRA
+qwp
+cjJ
+nrw
+bhR
+qwp
+tUR
+qwp
+dHw
+qwp
+vYE
+cCS
+jMf
+uHk
+qvR
+qvR
+qvR
+qvR
+qvR
+khc
+fxx
+fxx
+fxx
+fxx
+fxx
 wSn
 wSn
-wSn
-uaL
-tzK
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uTf
-qvR
-uaL
-fxx
-fxx
-fxx
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
-uTf
-uaL
-uaL
-lVe
-afA
-ddv
-ddv
-lVe
-bqt
-wlD
-lVe
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-qvR
-uaL
-qvR
-qvR
-qvR
-qvR
+kVc
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
 qvR
 qvR
 qvR
@@ -285443,7 +288788,7 @@ uaL
 uaL
 uaL
 qvR
-vHd
+qvR
 qvR
 qvR
 qvR
@@ -285754,64 +289099,64 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+cWT
+mjP
+iJR
+ikM
+qNF
+qwp
+rRD
+cjJ
+ijU
+rRD
+rRD
+cjJ
+rRD
+oaU
+qwp
+gDx
+aym
+qwp
+qwp
+qwp
+tUR
+qwp
+jPz
+jMf
+jMf
+uHk
 uaL
 uaL
 uaL
 uaL
 qvR
-uaL
-uaL
-qvR
-uaL
+khc
 fxx
-fxx
-fxx
-qvR
-qzy
-wSn
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-cQY
-wlD
-ddv
-ddv
-wlD
-wlD
-wlD
-cQY
-fxx
-fQq
 fxx
 fxx
 fxx
 fxx
 wSn
 wSn
-oZH
-qvR
-qvR
-qvR
-qvR
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 lyL
 aPF
@@ -286120,6 +289465,22 @@ uaL
 uaL
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -286131,89 +289492,73 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+mjP
+iJR
+blT
+qNF
+qwp
+rRD
+cjJ
+cvC
+rRD
+cjJ
+ijU
+cjJ
+cjJ
+qwp
+nrw
+qwp
+qwp
+aem
+aem
+qwp
+qwp
+jPz
+jMf
+jMf
+uHk
 uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-wSn
 uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-qvR
-lyL
+khc
 fxx
 fxx
-qvR
-qvR
-wSn
-wSn
-uaL
-uaL
-uTf
-uaL
-wSn
-uaL
-lVe
-wlD
-iim
-wlD
-wlD
-ddv
-wlD
-lVe
-gwN
 fxx
 fxx
+fxx
+uaL
+wSn
 veW
-fxx
-fxx
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-tzK
+kVc
+kVc
+kVc
+veW
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 qvR
 qvR
@@ -286556,66 +289901,66 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
+cWT
+mjP
+mjP
+mjP
+mjP
+rRA
+rRA
+rRA
+nhR
+nhR
+rRA
+rRA
+rRA
+ijU
+qwp
+aev
+qwp
+qwp
+vHd
+uvu
+vEx
+rRA
+nrw
+jMf
+jMf
+uHk
+fZg
 qvR
-uaL
-tzK
-uaL
 qvR
+qvR
+qvR
+khc
 fxx
 fxx
-qvR
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-cQY
-wlD
-izm
-psH
-czI
-ddv
-wlD
-pdm
-jlY
-uaL
-uaL
-uaL
 fxx
 fxx
-uaL
-qvR
-iNT
-qvR
-qvR
-qvR
-uaL
+fxx
+fxx
+wSn
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 qvR
 qvR
@@ -286625,7 +289970,7 @@ uaL
 uaL
 wSn
 wSn
-qzy
+qvR
 qvR
 qvR
 spp
@@ -286951,6 +290296,7 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -286961,63 +290307,62 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-fuA
-uaL
-uaL
-wSn
-uaL
-tzK
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-qvR
-qvR
+cWT
+cWT
+cWT
+cWT
+mjP
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+evo
+evo
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
 fxx
 fxx
-wSn
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-lVe
-sFE
-mzk
-nQE
-wKh
-ddv
-wlD
-lVe
-uaL
-uaL
-vLS
-uaL
+fxx
+fxx
 fxx
 fxx
 uaL
-qvR
-qvR
-xis
-qvR
-qvR
-uaL
+kVc
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 uaL
 uaL
@@ -287335,6 +290680,7 @@ qvR
 uaL
 uaL
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -287352,6 +290698,14 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -287359,67 +290713,58 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-fuA
+cWT
+fQq
+fQq
+pno
+pno
+evo
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+qvR
+qvR
+qvR
 uaL
 uaL
 uaL
-tzK
-tzK
-uaL
-wSn
-mHb
-wSn
-wSn
-wSn
-lyL
-xis
+qvR
 fxx
 fxx
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-cQY
-wlD
-dlx
-dlx
-wlD
-ddv
-wlD
-cQY
-uaL
-vLS
-glM
-uaL
+fxx
+fxx
 fxx
 fxx
 uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
+aJj
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
 qvR
 qvR
 uaL
@@ -287738,7 +291083,7 @@ qvR
 qvR
 hcW
 hcW
-hcW
+dbH
 hcW
 kYc
 kYS
@@ -287747,6 +291092,7 @@ mzx
 kYc
 mzx
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -287770,57 +291116,56 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-lcg
-bdN
-oZE
-lcg
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
+pno
+fQq
+evo
+evo
+evo
+dpZ
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+qvR
+qvR
+qvR
 qvR
 qvR
 fxx
 fxx
-uaL
-wSn
-uaL
-aPF
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lVe
-rGY
-wlD
-wlD
-uhe
-ddv
-afA
-lVe
-aok
-uaL
-uaL
-vLS
+fxx
+fxx
 fxx
 fxx
 uaL
-qvR
-qvR
-qvR
-qvR
-iNT
+uaL
+uaL
+veW
+uaL
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 qvR
 qvR
@@ -287844,7 +291189,7 @@ qvR
 qvR
 ptV
 qvR
-wpm
+qvR
 qvR
 wSn
 rhD
@@ -288152,6 +291497,16 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -288164,21 +291519,10 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 hLK
 vra
 fxx
-dpZ
 fxx
 fxx
 fxx
@@ -288193,35 +291537,36 @@ fxx
 fxx
 fxx
 fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fTe
 uaL
+aJj
 uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lVe
-lVe
-dbH
-lVe
-lVe
-cQY
-lVe
-lVe
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-uaL
-wSn
-rBC
-qvR
-qvR
+fTe
+kVc
+ykt
+xKz
+bOK
+xKz
+bOK
+xKz
+bOK
+xKz
+ykt
 uaL
 qvR
 qvR
@@ -288552,6 +291897,18 @@ msk
 ntQ
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -288564,19 +291921,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 hLK
 vra
 fxx
@@ -288588,15 +291933,6 @@ fxx
 fxx
 fxx
 fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
 fxx
 fxx
 fxx
@@ -288606,23 +291942,32 @@ fxx
 fxx
 fxx
 fxx
-lVe
-lVe
-lVe
-uaL
-uaL
-uaL
-uaL
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
 uaL
 uaL
 uaL
 fxx
 fxx
-fxx
-uaL
-wSn
-wSn
-wSn
+jNF
+goz
+goz
+goz
+goz
+goz
+jNF
 wSn
 uaL
 uaL
@@ -288943,7 +292288,7 @@ sJZ
 sJZ
 qvR
 hcW
-hcW
+dbH
 hcW
 hcW
 ldI
@@ -288978,7 +292323,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+cWT
 lcg
 bdN
 oZE
@@ -289018,13 +292363,13 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+lEs
+peN
+peN
+peN
+peN
+peN
+kgd
 fxx
 fxx
 fxx
@@ -289333,7 +292678,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 qvR
@@ -289365,6 +292710,13 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+dbH
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289373,30 +292725,23 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-fuA
-fuA
-fuA
-fuA
+cWT
+cWT
+cWT
+cWT
+cWT
 uaL
-fuA
-uaL
-fuA
-fuA
-fDB
-fDB
-uaL
+ykt
+ykt
+ykt
+ykt
+ykt
+xKz
+xKz
+xKz
+jeb
+jeb
+xKz
 fxx
 fxx
 fxx
@@ -289420,13 +292765,13 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+goz
+peN
+peN
+peN
+hzY
+peN
+goz
 fxx
 fxx
 fxx
@@ -289770,6 +293115,10 @@ hcW
 hcW
 hcW
 hcW
+dbH
+dbH
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289783,45 +293132,26 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uTf
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-fuA
-mjP
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
 uaL
 wSn
 wSn
 wSn
 wSn
 wSn
+xKz
+upI
+nTR
+lLa
+xKz
+xKz
+jXU
+uai
+mnW
+xKz
+jeb
+jeb
+xKz
+xKz
 uaL
 uaL
 uaL
@@ -289831,7 +293161,22 @@ uaL
 uaL
 uaL
 uaL
-uTf
+uaL
+wSn
+wSn
+wSn
+wSn
+wSn
+peN
+peN
+peN
+peN
+peN
+peN
+peN
+uaL
+uaL
+wSn
 uaL
 uaL
 uaL
@@ -290167,8 +293512,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+dbH
+dbH
 hcW
 hcW
 hcW
@@ -290191,24 +293536,24 @@ hcW
 hcW
 uaL
 wSn
-uTf
 wSn
 wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fTe
-uaL
-uaL
-uaL
+wSn
+wSn
+xKz
+bUr
+iYQ
+fVQ
+nZw
+qpt
+sDa
+peN
+rUr
+quL
+nZw
+fVQ
+sNG
+xKz
 qvR
 qvR
 qvR
@@ -290224,13 +293569,13 @@ wSn
 uaL
 fTe
 wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+xHe
+dQe
+aIb
+aIb
+aIb
+dQe
+xHe
 uaL
 uaL
 uaL
@@ -290571,7 +293916,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -290592,28 +293937,28 @@ hcW
 hcW
 hcW
 uaL
-uTf
+wSn
 bHL
 wSn
-uaL
+wSn
+wSn
+xKz
+qWS
+nTR
+fVQ
+lLa
+qpt
+sDa
+peN
+rUr
+quL
+lLa
+fVQ
+seC
+xKz
 qvR
-uaL
-uaL
-uaL
-qvR
-aPR
-uaL
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-lyL
 qvR
 qvR
-uaL
-uaL
 vRq
 qvR
 qvR
@@ -290626,14 +293971,14 @@ uaL
 uaL
 uaL
 uaL
+xKz
+bOK
+jeb
+sRU
+jeb
+bOK
+xKz
 uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-xqL
 uaL
 uaL
 uaL
@@ -290966,14 +294311,14 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
 hcW
 hcW
 hcW
+dbH
 hcW
-hcW
-hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -290997,26 +294342,26 @@ uaL
 wSn
 wSn
 wSn
-qvR
-qvR
-tzK
-uaL
 wSn
 wSn
-qvR
-tAf
-fxx
-fxx
-fxx
-uaL
+xKz
+bUr
+iYQ
+fVQ
+xaD
+qpt
+sDa
+peN
+rUr
+quL
 hmU
-wSn
-wSn
-wSn
+fVQ
+seC
+xKz
 qvR
 qvR
-uaL
-uTf
+qvR
+wSn
 lyL
 qvR
 uaL
@@ -291025,16 +294370,16 @@ uTf
 uaL
 uaL
 uaL
-tzK
 uaL
 uaL
 uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
+bOK
+tYP
+tYP
+ozt
+tYP
+tYP
+xKz
 uaL
 uaL
 wSn
@@ -291344,7 +294689,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 qvR
 qvR
@@ -291366,7 +294711,7 @@ ndD
 kYc
 msk
 nxV
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -291399,25 +294744,25 @@ uaL
 wSn
 uTf
 wSn
-qvR
-uaL
-uaL
-uaL
-uaL
 wSn
-qvR
-qvR
+wSn
+xKz
+qWS
+nTR
+fVQ
+jeb
+jeb
 sDa
-xxp
+peN
 rUr
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
+jeb
+jeb
+fVQ
+jNj
+xKz
 qvR
 qvR
+uaL
 uaL
 xis
 qvR
@@ -291430,13 +294775,13 @@ uaL
 qvR
 qvR
 uaL
-wSn
-uaL
-xqL
-wSn
-wSn
-uaL
-uaL
+uOu
+tYP
+gTY
+tYP
+bHX
+tYP
+xKz
 qvR
 qvR
 uaL
@@ -291800,26 +295145,26 @@ uaL
 wSn
 wSn
 wSn
-uTf
-qvR
-uaL
-uaL
-uaL
 wSn
 wSn
-tAf
-qvR
+wSn
+xKz
+ycL
+iYQ
+fVQ
+fVQ
+jeb
 wgn
-jXZ
-kIf
+peN
+rUr
+jeb
+fVQ
+tYP
+kdv
+xKz
+qvR
+qvR
 uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-lyL
 qvR
 qvR
 qvR
@@ -291832,13 +295177,13 @@ qvR
 qvR
 uaL
 wSn
-wSn
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
+xKz
+wDz
+tYP
+tYP
+tYP
+tYP
+xKz
 qvR
 qvR
 qvR
@@ -292158,7 +295503,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -292203,28 +295548,28 @@ wSn
 wSn
 wSn
 wSn
+wSn
+wSn
+xKz
+dwO
+lLa
+fVQ
+fVQ
+nBT
+sDa
+peN
+rUr
+nBT
+fVQ
+sCg
+mrE
+xKz
 qvR
 uaL
 uaL
-efg
-wSn
-wSn
-xqL
-tAf
-wgn
-jXZ
-kIf
-aJj
-wSn
-wSn
-uTf
-wSn
-wSn
-wSn
-wSn
 qvR
 qvR
-qzy
+qvR
 qvR
 wSn
 wSn
@@ -292234,14 +295579,14 @@ qvR
 aPF
 uaL
 wSn
-wSn
-wSn
-uaL
+bOK
+tYP
+szJ
+tYP
+sCg
+jUD
+xKz
 qvR
-uaL
-qvR
-qvR
-iNT
 qvR
 qvR
 qvR
@@ -292567,7 +295912,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -292604,26 +295949,26 @@ uaL
 wSn
 jct
 wSn
-wSn
 xKz
 xKz
+xKz
+xKz
+dwO
+lLa
+kMi
+gXk
 jeb
-jeb
-jeb
-xKz
-xKz
-tUp
 wgn
-jXZ
-kIf
-aJj
-wSn
-wSn
-wSn
-wSn
-oxc
-wSn
-wSn
+peN
+rUr
+jeb
+fVQ
+sCg
+mrE
+xKz
+qvR
+uaL
+qvR
 uaL
 qvR
 qvR
@@ -292636,18 +295981,18 @@ uaL
 uaL
 wSn
 wSn
-wSn
-wSn
-iNT
-qvR
-qvR
-qvR
-qvR
+xKz
+xKz
+xKz
+nnI
+sCg
+mrE
+xKz
 qvR
 qvR
 qvR
 uaL
-tzK
+uaL
 uTf
 uaL
 qvR
@@ -292999,52 +296344,52 @@ uaL
 uaL
 uaL
 uaL
-tzK
-tzK
 uaL
 uaL
-wSn
+uaL
+uaL
 wSn
 wSn
 wSn
 xKz
-peN
-qGh
+xKz
 mDY
-qeY
+fVQ
+fVQ
+fVQ
+kMi
+ycL
+jeb
+sDa
 peN
+rUr
+jeb
+fVQ
+tYP
+mrE
 xKz
-kIf
-wgn
-jXZ
-kIf
-aJj
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
 qvR
 qvR
-lyL
 qvR
-rCL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+wSn
+wSn
+xKz
+xKz
+xKz
+tYP
+sCg
+mrE
+xKz
 qvR
 qvR
 uaL
@@ -293353,7 +296698,7 @@ hcW
 wSn
 uaL
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -293408,26 +296753,26 @@ uaL
 wSn
 wSn
 wSn
-wSn
-jeb
+xKz
+xKz
 mDY
-goz
-cRP
+fVQ
+fVQ
 fIB
-qeY
-jeb
-kIf
-wgn
-jXZ
-kIf
-aJj
-bmL
-wSn
+fVQ
+fVQ
+qpt
+sDa
+peN
+rUr
+quL
+lLa
+fVQ
+ohA
+xKz
+qvR
 uaL
-wSn
-uaL
-wSn
-uaL
+qvR
 uaL
 uaL
 wSn
@@ -293440,13 +296785,13 @@ uaL
 wSn
 uTf
 wSn
-wSn
-wSn
-qvR
-qvR
-qvR
-qvR
-qvR
+xKz
+xKz
+xKz
+nnI
+sCg
+jUD
+xKz
 qvR
 uaL
 uaL
@@ -293468,7 +296813,7 @@ wOD
 qvR
 qvR
 qvR
-qzy
+qvR
 qvR
 fxx
 fxx
@@ -293755,6 +297100,7 @@ wSn
 wSn
 uaL
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -293763,8 +297109,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+dbH
 wSn
 wSn
 qvR
@@ -293810,26 +297155,26 @@ uaL
 xqL
 wSn
 wSn
-wSn
 xKz
-xNo
-jpw
-eoz
-itC
-xNo
+gXk
+gqa
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+qpt
+sDa
+peN
+rUr
+quL
+lLa
+fVQ
+hrT
 xKz
-iaX
-jXZ
-jXZ
-jXZ
-ykt
-ykt
-uTf
-wSn
-wSn
-uaL
-uaL
-uaL
+qvR
+qvR
+qvR
 uaL
 uaL
 tzK
@@ -293842,10 +297187,10 @@ uaL
 wSn
 wSn
 uaL
-uaL
-uaL
 xKz
 xKz
+xKz
+jit
 xKz
 xKz
 xKz
@@ -294154,19 +297499,19 @@ fyc
 cWT
 cWT
 wSn
+dbH
+dbH
+dbH
+dbH
+hcW
+dbH
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+dbH
+dbH
+dbH
+dbH
 wSn
 wSn
 qvR
@@ -294201,7 +297546,7 @@ aJj
 aJj
 aJj
 aJj
-khc
+aJj
 aJj
 aJj
 aJj
@@ -294212,27 +297557,27 @@ aJj
 aJj
 uaL
 qvR
-qvR
-jeb
+xKz
+bUr
 iYQ
-iME
-oRp
-lhd
-uxV
-jeb
+lLa
+fVQ
+fIB
+fVQ
+fVQ
 qpt
-wgn
-jXZ
-kIf
-wgn
-ykt
-wSn
-aJj
-aJj
+sDa
+peN
+rUr
+quL
+xFC
+fVQ
+mGn
+xKz
+uaL
 uaL
 qvR
 qvR
-qvR
 uaL
 aJj
 aJj
@@ -294244,8 +297589,8 @@ uaL
 aJj
 aJj
 aJj
-aJj
-aJj
+xKz
+xKz
 xKz
 waI
 kyo
@@ -294556,9 +297901,9 @@ fyc
 cWT
 cWT
 uaL
-hcW
-hcW
-hcW
+dbH
+dbH
+dbH
 hcW
 hcW
 hcW
@@ -294614,40 +297959,40 @@ evo
 evo
 evo
 evo
-evo
 xKz
-bOK
+ycL
+nTR
 kds
-szV
-uxV
-peN
-vFz
+sOh
+xKz
+xaD
+fVQ
+xKz
+gUR
+nmC
 kIf
-wgn
-jXZ
-kIf
-wgn
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
+fhm
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
 xKz
 cWG
 bOK
@@ -294972,7 +298317,7 @@ uaL
 wSn
 wSn
 wSn
-iNT
+qvR
 qvR
 qvR
 wSn
@@ -295024,31 +298369,31 @@ xKz
 xKz
 xKz
 xKz
-oAn
+xKz
 uWL
-wjB
-wjB
-oAn
-evo
-xAi
-xAi
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-cVN
-cVN
-dCV
-dCV
-xAi
-xAi
-xAi
-xAi
-dCV
-dCV
-dCV
+egd
+egd
+xKz
+xKz
+uGf
+uGf
+bPz
+bPz
+bPz
+bPz
+bPz
+bPz
+lGh
+lGh
+bPz
+bPz
+uGf
+uGf
+uGf
+uGf
+bPz
+bPz
+bPz
 axq
 dnx
 axl
@@ -295374,7 +298719,7 @@ qvR
 uaL
 uaL
 wSn
-iNT
+qvR
 qvR
 qvR
 iNT
@@ -296264,7 +299609,7 @@ uaL
 uaL
 uaL
 qvR
-iNT
+qvR
 qvR
 uaL
 uaL
@@ -297887,7 +301232,7 @@ trG
 ryI
 ryI
 fxx
-oiE
+qvR
 qvR
 qvR
 fxx
@@ -301492,7 +304837,7 @@ uaL
 uaL
 wSn
 wSn
-uDi
+wSn
 rCL
 qvR
 qvR
@@ -301509,7 +304854,7 @@ mcm
 qvR
 fxx
 fxx
-qvR
+wBx
 okF
 okF
 okF
@@ -301912,7 +305257,7 @@ qvR
 fxx
 fxx
 qvR
-qzy
+qvR
 gex
 qvR
 rhD
@@ -302263,7 +305608,7 @@ xKz
 wVI
 wbg
 wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -302619,7 +305964,7 @@ mcK
 nBW
 mOY
 nBW
-nBW
+jXB
 nBW
 wtF
 wbg
@@ -302701,7 +306046,7 @@ uaL
 uaL
 qvR
 qvR
-iNT
+qvR
 qvR
 jJx
 sTr
@@ -304233,7 +307578,7 @@ wtF
 wbg
 wbg
 wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -304711,12 +308056,12 @@ uaL
 uaL
 qvR
 qvR
-iNT
+qvR
 qvR
 eOg
 uAZ
 xzN
-rNg
+xzN
 lOo
 rNg
 nuD
@@ -305585,7 +308930,7 @@ wGD
 iae
 wGD
 sYx
-ijU
+odi
 odi
 wGD
 wGD
@@ -305918,7 +309263,7 @@ qvR
 qvR
 qvR
 qvR
-vHd
+qvR
 qvR
 eXH
 efS
@@ -306240,7 +309585,7 @@ jDm
 uOL
 lbC
 hOh
-aev
+hOh
 aHx
 aHx
 lbC
@@ -306316,7 +309661,7 @@ olN
 uaL
 qvR
 uaL
-iNT
+qvR
 qvR
 qvR
 qvR
@@ -306356,9 +309701,9 @@ bwS
 lVe
 bwS
 lVe
-hHF
+kwn
 goK
-wlD
+nvf
 sux
 pYf
 pYf
@@ -306743,7 +310088,7 @@ uaL
 uaL
 qvR
 xis
-qvR
+wBx
 fxx
 wSn
 wSn
@@ -307492,14 +310837,14 @@ wbg
 wbg
 wbg
 wVI
-wVI
-wVI
+rDD
+plk
 nHz
 wVI
 wVI
 wVI
-nHz
-wVI
+fVM
+rDD
 wVI
 tUw
 wVI
@@ -307535,7 +310880,7 @@ fxx
 fxx
 fxx
 fxx
-fxx
+kch
 fxx
 boU
 fxx
@@ -307553,13 +310898,13 @@ qvR
 wSn
 cyr
 hHF
-enD
+fiK
 wlD
 sIG
 wlD
 wlD
 wlD
-wlD
+nvf
 wlD
 sIG
 wlD
@@ -307833,7 +311178,7 @@ sqd
 miX
 wxB
 wxB
-wxB
+miX
 wxB
 wxB
 wxB
@@ -307860,7 +311205,7 @@ wbg
 xXq
 yhZ
 yhZ
-yhZ
+qtK
 yhZ
 yhZ
 xXq
@@ -308273,13 +311618,13 @@ xez
 wbg
 wbg
 wbg
+ovj
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -308327,7 +311672,7 @@ fxx
 fxx
 fxx
 fxx
-fxx
+kch
 fxx
 fxx
 fxx
@@ -308352,7 +311697,7 @@ mHb
 wSn
 wSn
 wSn
-dNL
+qvR
 wSn
 wSn
 cyr
@@ -308652,7 +311997,7 @@ uYE
 sHm
 mwE
 mwE
-nPQ
+mwE
 mwE
 lpq
 mwE
@@ -308695,6 +312040,7 @@ wbg
 wbg
 wbg
 wbg
+ovj
 wbg
 wbg
 wbg
@@ -308702,8 +312048,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -308741,7 +312086,7 @@ fxx
 fxx
 fxx
 wxd
-tCz
+iDD
 wmj
 cyr
 cyr
@@ -309086,7 +312431,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 qcm
 cZg
 fRa
@@ -309488,7 +312833,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 heo
 rJX
 pUl
@@ -309890,7 +313235,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 urH
 pUl
 pUl
@@ -309902,17 +313247,17 @@ wbg
 wbg
 wbg
 wbg
-wbg
+qzH
 hUt
 vFj
 qzH
 wbg
-jIP
-mwE
-mwE
+wbg
+wbg
 xGM
-rfO
-wsR
+xGM
+qzH
+adK
 ukb
 wvE
 rLt
@@ -309933,7 +313278,7 @@ uaL
 uaL
 uaL
 uaL
-tzK
+uaL
 qvR
 qvR
 qvR
@@ -309953,7 +313298,7 @@ trG
 ryI
 fZw
 fxx
-fxx
+kch
 rhD
 qvR
 qvR
@@ -310292,7 +313637,7 @@ tJx
 wVI
 wbg
 wbg
-wVI
+wbg
 jbj
 pUl
 dkf
@@ -310303,18 +313648,18 @@ guP
 vce
 wbg
 wbg
-wbg
 qtV
-wJq
-vPA
+iPY
+iPY
+iPY
 wew
-aOv
+wxZ
 nRo
 bQf
-mwE
-qDn
-mwE
-wsR
+bez
+iPY
+vdZ
+adK
 ukb
 wvE
 wvE
@@ -310337,7 +313682,7 @@ wSn
 wSn
 uaL
 uaL
-uEX
+wSn
 wSn
 wSn
 uaL
@@ -310668,7 +314013,7 @@ aOn
 aOn
 lpa
 nCh
-wbg
+ovj
 wbg
 wbg
 hOh
@@ -310694,28 +314039,28 @@ xdq
 vka
 qqW
 wbg
-wVI
+wbg
 tnv
 pUl
 pUl
 rJX
 tCr
 guP
-guP
-guP
-teR
-wbg
+wte
+jjF
+vlN
 wbg
 qtV
+iPY
+iPY
 mwE
-yjP
+qeY
 wVI
+weX
 wVI
-wSl
-bQf
-mwE
-pKQ
-mwE
+dua
+hRv
+vdZ
 adK
 xMr
 yho
@@ -311096,28 +314441,28 @@ xdq
 vka
 qqW
 wbg
-wVI
+wbg
 hmk
 pUl
 rJX
 eai
 tCr
 guP
-guP
-guP
+grj
+vmX
 iGf
 viq
-wbg
 qtV
-uFp
-vWY
-weX
+iPY
+iPY
+iPY
+hCQ
 wxZ
-wYv
-mwE
-ueX
-mwE
-mwE
+wVI
+bQf
+wKF
+nXd
+whz
 adK
 dHZ
 xww
@@ -311137,7 +314482,6 @@ qvR
 qvR
 spp
 qvR
-qzy
 qvR
 qvR
 qvR
@@ -311146,7 +314490,8 @@ qvR
 qvR
 qvR
 qvR
-wpm
+qvR
+qvR
 bzI
 fxx
 fxx
@@ -311498,7 +314843,7 @@ wan
 xdq
 oAn
 wbg
-wVI
+wbg
 ufu
 pUl
 pUl
@@ -311507,18 +314852,18 @@ fQm
 guP
 guP
 guP
-guP
+jjF
 uTQ
-wbg
-wbg
-wbg
-wbg
-ybh
-wDZ
-utL
-jEB
-aOn
-mwE
+qtV
+nXd
+kwN
+cND
+wYv
+wVI
+wVI
+wVI
+wVI
+wVI
 rmJ
 adK
 pht
@@ -311577,7 +314922,7 @@ lVe
 uxL
 sZI
 xlx
-usw
+dTa
 iTv
 cXU
 iTv
@@ -311855,7 +315200,7 @@ uOL
 jxy
 vbO
 oif
-oif
+uvI
 oif
 uJk
 tOz
@@ -311900,28 +315245,28 @@ iqY
 tYm
 oAn
 wbg
-wVI
+wbg
 wKT
 wKT
 hpJ
 wKT
 wKT
+gUC
 sxR
 sxR
 sxR
-sxR
-wKT
+abh
 wbg
-wbg
-wbg
+jCr
+jCr
 aSH
-fRN
-pkK
-mwE
-jEB
-mwE
-qKU
-mwE
+jCr
+wVI
+wVI
+wVI
+wVI
+wVI
+aEG
 oUn
 xMr
 vwQ
@@ -312302,28 +315647,28 @@ iqY
 tYm
 oAn
 wbg
-wVI
-wKT
+wbg
+dsR
 dTB
 tVP
 tVP
 jLX
-tVP
+tCG
 tVP
 tVP
 tCG
-wKT
+rUm
 wbg
-wbg
-fRN
-aOn
-mwE
-mwE
-mwE
-nPQ
-auT
-qRp
-mwE
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+rZY
 ejJ
 xMr
 wCE
@@ -312704,7 +316049,7 @@ dWG
 xdq
 xAu
 wbg
-wVI
+wbg
 wKT
 sSW
 tVP
@@ -312714,19 +316059,19 @@ tVP
 tVP
 tVP
 tVP
-wKT
-wbg
+nnb
 qtV
-mwE
-eSt
-aOn
-pKQ
+fKD
+rZY
+wVI
+wxZ
+wVI
 xbo
-aOn
-auT
-qKU
-uHk
-uHk
+wVI
+bQf
+wVI
+wVI
+rZY
 dHZ
 xMr
 xMr
@@ -313104,31 +316449,31 @@ pAS
 sZN
 sZN
 xdq
-wVI
+sIE
 wbg
-wVI
-wKT
+wbg
+dsR
 rJC
 tVP
+wnE
+iYH
+tVP
+kEb
 tVP
 tVP
-tZZ
-tZZ
-tZZ
-tVP
-wKT
-wVI
+nnb
 qtV
-hOh
-aOn
-aOn
-mwE
-mwE
-mwE
-mwE
-xEB
-wJq
-gaq
+fKD
+rZY
+wVI
+wxZ
+wVI
+wVI
+wVI
+bQf
+wVI
+rZY
+qKU
 kjH
 kjH
 kjH
@@ -313158,7 +316503,7 @@ vLS
 uaL
 sjP
 wSn
-fxx
+kch
 fxx
 lcg
 fQg
@@ -313506,31 +316851,31 @@ sZN
 sZN
 sZN
 xdq
-wVI
+qeY
 wbg
-wVI
+wbg
 wKT
 kFS
 tVP
+veE
+lqJ
+keW
+wgf
 tVP
-tVP
-tVP
-tVP
-tVP
-xaD
-abh
-wVI
+tCG
+nnb
 wbg
-xEB
-gDe
-aOn
-uFp
-mwE
-gSp
-nZQ
-mwE
-mwE
-aOn
+wbg
+wVI
+uEX
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
 oVI
 bmi
 hyR
@@ -313858,7 +317203,7 @@ oif
 oif
 oif
 oif
-eUJ
+rNT
 eUJ
 eUJ
 jxy
@@ -313908,31 +317253,31 @@ sZN
 sZN
 lzC
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 wKT
 eWj
 yfY
-yfY
-tVP
+ijS
+mmb
 tZZ
 vGQ
-vGQ
-tVP
+yfY
+yfY
 wKT
 onR
-wbg
-hOh
+qEa
 vXm
-wjB
-wjB
-wjB
-quL
-mwE
-mwE
-mwE
-aOn
+vXm
+vXm
+nCA
+mUY
+wVI
+wVI
+wVI
+rZY
+wVI
 kjH
 bmi
 bmi
@@ -314310,7 +317655,7 @@ sZN
 sZN
 lzC
 xdq
-wVI
+qls
 wbg
 aNQ
 wKT
@@ -314325,16 +317670,16 @@ yfY
 wKT
 eur
 wbg
-ddH
-wVI
 uqe
 ewM
 uqe
-wra
-auT
-aOn
-mwE
-mwE
+lxN
+qeY
+wVI
+wVI
+rZY
+fbP
+rZY
 jXw
 xgi
 rYE
@@ -314712,9 +318057,9 @@ pDy
 sZN
 sZN
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 cCQ
 yfY
 yfY
@@ -314724,19 +318069,19 @@ yfY
 yfY
 yfY
 yfY
-wKT
+fha
+wbg
+mMs
+uqe
+uqe
+uqe
+tCN
+wew
+weX
 wVI
-wbg
-wbg
-pMn
-uqe
-uqe
-uqe
-wra
-mwE
-mwE
-mwE
-mwE
+rZY
+uzT
+rZY
 jXw
 xgi
 rYE
@@ -314777,7 +318122,7 @@ gkv
 hLK
 njv
 fxx
-fxx
+kch
 wxd
 wxd
 wSn
@@ -315083,7 +318428,7 @@ wrj
 jDm
 jDm
 mwE
-mwE
+sLM
 mwE
 wbg
 wbg
@@ -315114,31 +318459,31 @@ pAS
 sZN
 sZN
 xdq
-wVI
+qeY
 wbg
-wVI
+wbg
 cJz
 yfY
+dfH
 ijS
+eBx
+vGQ
+tZZ
 kfr
-mmb
-uaj
-mmb
-kfr
-ijS
+nBp
 wKT
 cIh
 wbg
-wbg
-wVI
 uqe
 ewM
 uqe
-wra
-mwE
-mwE
-aOn
-mwE
+tCN
+wew
+wVI
+wVI
+wVI
+rZY
+wVI
 kjH
 gDi
 bmi
@@ -315516,12 +318861,11 @@ ygF
 ygF
 uDv
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 wKT
 eyJ
-cJz
 wKT
 wKT
 wKT
@@ -315529,17 +318873,18 @@ wKT
 wKT
 wKT
 wKT
-haB
-wbg
-wbg
-vXm
+wKT
+asE
+qEa
 gGZ
 gGZ
 gGZ
-xdw
-mwE
-mwE
-aOn
+ssF
+kzO
+wqq
+wqq
+wqq
+wqq
 wqq
 kjH
 kjH
@@ -315918,32 +319263,32 @@ ygF
 ygF
 uDv
 xdq
-wVI
+qls
 wbg
-wVI
+wbg
 wKT
-viq
-viq
+wBZ
+mTj
 ksK
 qRm
-hbc
-vQV
-bPv
-xbW
+ksK
+qRm
+ksK
+qRm
 wKT
-wVI
 wbg
 wbg
 wbg
 wbg
-aOn
-mwE
-qEa
-mwE
-mwE
-aOn
-auT
-wVI
+wbg
+wbg
+wbg
+wbg
+vJU
+wbg
+vJU
+vJU
+qPD
 wVI
 wVI
 wVI
@@ -316320,9 +319665,9 @@ kaA
 wan
 vka
 xdq
-wVI
+qls
 wbg
-wVI
+wbg
 wKT
 iov
 viq
@@ -316333,18 +319678,18 @@ viq
 viq
 viq
 wKT
-wVI
+wbg
 wbg
 wbg
 wbg
 wbg
 rEo
-aOn
-mwE
-qCT
-mwE
-gaq
-mwE
+wbg
+wbg
+wbg
+wbg
+wbg
+wbg
 wbg
 wbg
 wbg
@@ -316722,31 +320067,31 @@ pMj
 pPI
 xdq
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 wKT
 rRB
 iQe
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+viq
+viq
+viq
+viq
+viq
+viq
 wKT
-wVI
+wbg
 wbg
 usR
 ncb
 ncb
-vgA
+kem
 wbg
-mwE
-mwE
-mwE
-mwE
-gaq
+wVI
+wVI
+wVI
+wVI
+lJJ
 wVI
 wVI
 wbg
@@ -317124,20 +320469,20 @@ pOs
 pRW
 xdq
 qls
+jEe
 wbg
 wbg
-wVI
 wKT
 wKT
 jCs
-ovj
-rHj
-urF
+ksK
 wFp
-wTs
-xwi
+ksK
+wFp
+ksK
+wFp
 wKT
-wVI
+wbg
 wbg
 usR
 xAt
@@ -317525,10 +320870,10 @@ xdq
 xdq
 xdq
 xdq
+xWw
 wbg
 wbg
 wbg
-wVI
 wKT
 wKT
 wKT
@@ -317539,11 +320884,11 @@ wKT
 wKT
 wKT
 wKT
-wVI
+wbg
 wbg
 vAB
 bnQ
-ihW
+heK
 nWM
 wbg
 kjH
@@ -317927,21 +321272,21 @@ xMr
 xMr
 xMr
 xMr
+qeY
 wbg
 wbg
 wbg
-wVI
-wVI
+wbg
 fBF
-wVI
-wVI
-wVI
-wVI
-wVI
-wVI
+wbg
+wbg
+wbg
+wbg
+wbg
+wbg
 fBF
-wVI
-wVI
+wbg
+wbg
 wbg
 wbg
 iOq
@@ -318329,6 +321674,7 @@ dCV
 csA
 dCV
 hXf
+sIE
 wbg
 wbg
 wbg
@@ -318344,8 +321690,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
-aoD
+wEd
 wEd
 wEd
 wbg
@@ -318731,7 +322076,7 @@ dCV
 dCV
 dCV
 qee
-wbg
+jEe
 wbg
 wbg
 wbg
@@ -319133,7 +322478,7 @@ oTD
 csA
 dCV
 hXf
-wbg
+jHc
 wbg
 wbg
 wbg
@@ -319519,7 +322864,7 @@ wSn
 nZj
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -319537,11 +322882,11 @@ xMr
 xMr
 gGZ
 qCy
-wbg
-wbg
-wbg
-wbg
-wbg
+bfE
+wVI
+weX
+wVI
+tJC
 wbg
 ekQ
 qDx
@@ -319921,7 +323266,7 @@ wSn
 nZj
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -319938,12 +323283,12 @@ bmi
 mgx
 xMr
 xAt
-qCy
+wjj
 wbg
-wbg
-wbg
-wbg
-wbg
+wVI
+wVI
+wVI
+wVI
 wbg
 hOh
 qDx
@@ -320323,7 +323668,7 @@ uaL
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -320341,11 +323686,11 @@ oVp
 xMr
 qnO
 oZC
-wbg
-wbg
-wbg
-wbg
-wbg
+qRp
+wVI
+xbo
+wVI
+tJC
 wbg
 hOh
 qDx
@@ -320725,7 +324070,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -320743,11 +324088,11 @@ nTe
 qhC
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+qRp
+wVI
+wVI
+wVI
+tJC
 wbg
 hOh
 qDx
@@ -321127,7 +324472,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -321143,13 +324488,13 @@ oXn
 oXn
 oXn
 xMr
-asE
+bqu
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
+wVI
+wVI
+wVI
+wVI
 wbg
 ekQ
 qDx
@@ -321529,7 +324874,7 @@ uaL
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 xMr
@@ -321545,13 +324890,13 @@ paz
 bmi
 bmi
 xMr
+xWw
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+bfE
+wVI
+weX
+wVI
+tJC
 wbg
 lHf
 rfx
@@ -321931,7 +325276,7 @@ lgA
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 hcm
@@ -321947,7 +325292,7 @@ gVS
 gVS
 bmi
 xMr
-wbg
+sIE
 wbg
 wbg
 wbg
@@ -321972,7 +325317,7 @@ wbg
 ltk
 rSS
 lpq
-mwE
+nCh
 xEB
 axk
 wbg
@@ -322333,7 +325678,7 @@ nBq
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 jZn
@@ -322349,7 +325694,7 @@ poR
 pPs
 bmi
 qhR
-wbg
+xWw
 wbg
 wbg
 wbg
@@ -322735,7 +326080,7 @@ qvR
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 cwN
@@ -322751,7 +326096,7 @@ ppo
 ssG
 bmi
 qkl
-wbg
+qls
 wbg
 wbg
 wbg
@@ -322775,7 +326120,7 @@ bJG
 wbg
 jpZ
 aOv
-cOV
+kMv
 aOv
 aOv
 aOv
@@ -323137,7 +326482,7 @@ uaL
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 cwN
@@ -323153,7 +326498,7 @@ orY
 orY
 bmi
 xMr
-wbg
+sIE
 wbg
 wbg
 wbg
@@ -323176,7 +326521,7 @@ ewt
 cEF
 wbg
 xll
-utL
+gHd
 aOn
 jHc
 mwE
@@ -323539,7 +326884,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 hRy
@@ -323555,7 +326900,7 @@ bmi
 mou
 bmi
 xMr
-wbg
+sIE
 wbg
 wbg
 wbg
@@ -323941,8 +327286,8 @@ uaL
 paf
 xAt
 xAt
+rfx
 wbg
-wbg
 xMr
 xMr
 xMr
@@ -323957,7 +327302,7 @@ xMr
 xMr
 xMr
 xMr
-wbg
+qeY
 wbg
 wbg
 wbg
@@ -324036,8 +327381,8 @@ wxd
 wxd
 wxd
 hcW
-hcW
-hcW
+cWT
+cWT
 tUO
 hcW
 tUO
@@ -324438,8 +327783,8 @@ wxd
 kVc
 kVc
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -324752,7 +328097,7 @@ xAt
 xAt
 xAt
 xAt
-fXg
+xAt
 xAt
 xAt
 xrd
@@ -324840,8 +328185,8 @@ kVc
 kVc
 kVc
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -325242,8 +328587,8 @@ kVc
 kVc
 kVc
 hcW
-hcW
-kVc
+cWT
+veW
 hcW
 hcW
 hcW
@@ -325644,8 +328989,8 @@ kVc
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -325952,24 +329297,24 @@ ujh
 xAt
 xAt
 vtw
-wOR
-wOR
-wOR
-wOR
 vtw
 vtw
 vtw
 vtw
 vtw
 vtw
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
 vtw
 wOR
 wOR
@@ -326046,8 +329391,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -326359,17 +329704,17 @@ vtw
 vtw
 vtw
 vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 vtw
 vtw
 vtw
@@ -326448,8 +329793,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -326755,20 +330100,20 @@ qvR
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+oqs
+oys
+hbc
+xKF
+xKF
+xKF
+xKF
 xKF
 xKF
 xKF
@@ -326850,8 +330195,8 @@ xqL
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -327157,19 +330502,19 @@ qvR
 uaL
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-iSJ
-iuo
-mGn
+xKF
+ueS
+oRp
+oRp
+rHj
+xKF
+xKF
+eBN
+eBN
+eBN
 iug
-ejY
+iug
+gse
 trI
 uHj
 uHj
@@ -327252,8 +330597,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -327559,21 +330904,21 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-obq
+xKF
+xAh
+oRp
+oRp
+rHj
+xKF
+xKF
+ejY
+eBN
+eBN
+iug
+iug
+ejY
+trI
+uHj
 rTm
 uHj
 obL
@@ -327654,8 +330999,8 @@ sJZ
 wxd
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -327961,20 +331306,20 @@ uTf
 afX
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-ogC
-yiI
+xKF
+uiv
+oRp
+oRp
+rHj
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 uHj
 uHj
 uHj
@@ -328001,7 +331346,7 @@ uJF
 mzZ
 gGe
 ddH
-aOv
+beQ
 mwE
 nZQ
 oXE
@@ -328056,8 +331401,8 @@ sJZ
 sJZ
 feP
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -328363,20 +331708,20 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-iuo
+xKF
+gvP
+oRp
+oRp
+rxS
+xKF
+ofq
+ofq
+xKF
+quy
+ofq
+eBN
 uHj
-uHj
+suN
 uHj
 bok
 uHj
@@ -328458,8 +331803,8 @@ sJZ
 sJZ
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -328765,18 +332110,18 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-iuo
+xKF
+nGn
+oRp
+oRp
+wLT
+xKF
+ofq
+ofq
 wVy
 ofq
 ofq
-iuo
+eBN
 bok
 suN
 uHj
@@ -328785,12 +332130,12 @@ idG
 obL
 xKF
 vtw
-wOR
+hKE
 wOR
 vtw
-ofq
+eEC
 iPY
-hRv
+aOv
 aOv
 xEB
 rfx
@@ -328860,8 +332205,8 @@ qet
 sJZ
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -329167,20 +332512,20 @@ aJj
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-iuo
+xKF
+bqt
+oRp
+sZk
+wLn
+xKF
+ofq
+ofq
 wVy
 ofq
 ofq
-iuo
+eBN
 uHj
-uHj
+suN
 uHj
 iIl
 xKF
@@ -329262,8 +332607,8 @@ qet
 qet
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -329569,32 +332914,32 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
+mdB
+mdB
+xKF
+xFL
 xKF
 xKF
 xKF
 xKF
 xKF
 ofq
-ofq
-iuo
+eBN
 bok
 suN
 uHj
 tkZ
 xKF
-xKF
 vtw
 vtw
-wOR
+vtw
+hKE
 gLx
 vtw
 rkf
 mOT
-iPY
+aOv
 kJX
 jHc
 jHc
@@ -329664,8 +333009,8 @@ qet
 qet
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -329971,20 +333316,20 @@ uaL
 afX
 xAt
 xAt
-vtw
-lAs
-lAs
-xKF
+eTc
+fCM
+fCM
+cNo
 twX
-dsW
-oIv
+cNo
+uVj
 eeO
-xKF
-ccY
-iuo
-iuo
+sKd
+vdj
+eBN
+eBN
 uHj
-uHj
+suN
 uHj
 vCr
 xKF
@@ -330066,8 +333411,8 @@ sJZ
 sJZ
 xSK
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -330373,21 +333718,21 @@ uaL
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-xKF
+eTc
+fCM
+fCM
+fCM
+fCM
+sOY
+cPd
 dsW
-oIv
-oIv
-dsW
-vSM
-oIv
-oIv
-aem
-oIv
-cdn
-dsW
+sKd
+xgL
+uHj
+uHj
+uHj
+uHj
+nrx
 obL
 xKF
 vtw
@@ -330468,8 +333813,8 @@ sJZ
 sJZ
 wxd
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -330775,21 +334120,21 @@ afX
 uaL
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-oIv
-oIv
-oIv
-oIv
+bsh
+iuo
+iuo
+iuo
+sOY
+wPC
+dsW
+sKd
 xgL
-rRA
-oIv
-oIv
-oIv
-oIv
-oIv
+huL
+uHj
+uHj
+uHj
+uHj
 uHj
 xKF
 vtw
@@ -330870,8 +334215,8 @@ sJZ
 sJZ
 sJZ
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -330916,7 +334261,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 ovn
@@ -331177,22 +334522,22 @@ afX
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-oIv
-oIv
-oIv
-oIv
+auL
+auL
+auL
+iuo
+fCM
+sKd
+sKd
 vSM
-oIv
-oIv
-wDz
+pBC
+uHj
+uHj
 wIl
 dXw
 uHg
-oIv
+uHj
 xKF
 vtw
 vWe
@@ -331203,7 +334548,7 @@ vtw
 qZh
 ltk
 mwE
-mwE
+sLM
 mwE
 mwE
 aOv
@@ -331272,8 +334617,8 @@ sJZ
 sJZ
 sJZ
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -331319,7 +334664,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 ovn
@@ -331579,23 +334924,23 @@ tzK
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-bzl
+gof
+bON
+vLA
+iuo
 oIv
-dsW
-oIv
+sKd
+sKd
 xKF
 xKF
+lma
 lma
 xKF
 xKF
 xKF
+hnd
 xKF
-jMf
-vtw
 vtw
 vtw
 feY
@@ -331674,14 +335019,14 @@ sJZ
 qet
 sJZ
 kVc
+cWT
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
-gdC
-gdC
-gdC
-gdC
-gdC
-gdC
-hcW
 whb
 whb
 whb
@@ -331721,7 +335066,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -331981,9 +335326,6 @@ uaL
 pOO
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
 xKF
 xKF
@@ -331991,13 +335333,16 @@ xKF
 xKF
 xKF
 xKF
+xKF
+xKF
+pkt
 eCn
-xKF
+eCn
 xKF
 wWK
 iuo
 iuo
-vtw
+xKF
 vtw
 vtw
 vtw
@@ -332076,8 +335421,8 @@ sJZ
 sJZ
 sJZ
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -332125,12 +335470,12 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
 whb
-whb
-whb
+qli
 whb
 whb
 whb
@@ -332374,11 +335719,11 @@ hcW
 uaL
 hcW
 hcW
+hcW
 uaL
 uaL
 uaL
-wSn
-wSn
+uaL
 uaL
 paf
 xAt
@@ -332394,12 +335739,12 @@ afz
 aHN
 sLc
 eCn
-xKF
+eCn
 xKF
 awJ
 iuo
 iuo
-vtw
+xKF
 iuo
 iuo
 vtw
@@ -332478,8 +335823,8 @@ sJZ
 qet
 sJZ
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -332529,13 +335874,13 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
-whb
-whb
-whb
-whb
+qli
+qli
+qli
 whb
 whb
 whb
@@ -332776,13 +336121,13 @@ hcW
 hcW
 hcW
 hcW
-sjP
-sjP
+hcW
 hcW
 uaL
-wSn
 uaL
 uaL
+uaL
+paf
 xAt
 xAt
 vtw
@@ -332796,12 +336141,12 @@ eCn
 eCn
 eCn
 eCn
-xKF
+eCn
 xKF
 gqN
 iuo
 iuo
-vtw
+xKF
 iuo
 iuo
 vtw
@@ -332880,8 +336225,8 @@ sJZ
 sJZ
 sJZ
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -333177,13 +336522,13 @@ hcW
 hcW
 hcW
 hcW
-fVM
-sjP
-jXZ
+hcW
+hcW
 hcW
 uaL
-wSn
-wSn
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -333198,18 +336543,18 @@ eCn
 vxf
 xSG
 eCn
+eCn
 xKF
 xKF
 xKF
+hnd
 xKF
-jNF
-vtw
 kPZ
-vtw
-vtw
-jMf
+xKF
+xKF
+hnd
 ofb
-vtw
+xKF
 vtw
 oAn
 wbg
@@ -333282,8 +336627,8 @@ sJZ
 sJZ
 wxd
 kVc
-gdC
-gdC
+sue
+sue
 gdC
 gdC
 gdC
@@ -333580,12 +336925,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
-wSn
-wSn
+uaL
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -333600,18 +336945,18 @@ eCn
 eCn
 eCn
 eCn
-xKF
+eCn
 euo
-oOU
+smO
 oOU
 smO
 buj
 smO
-vtw
-vtw
+hnd
+kSh
 sKd
 uHb
-vtw
+xKF
 vtw
 oAn
 swu
@@ -333684,8 +337029,8 @@ kVc
 kVc
 wxd
 kVc
-hcW
-gdC
+cWT
+sue
 gdC
 gdC
 gdC
@@ -333982,12 +337327,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-sjP
 hcW
 hcW
-wSn
-wSn
+hcW
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -334002,18 +337347,18 @@ kAT
 aee
 sLc
 eCn
-lma
+eCn
 mty
-smO
 smO
 smO
 nXv
 smO
+smO
 hnd
-kSh
 sKd
 sKd
-vtw
+sKd
+xKF
 vtw
 oAn
 nvS
@@ -334086,8 +337431,8 @@ kVc
 kVc
 wxd
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -334384,13 +337729,13 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
-wSn
-nZj
+uaL
+uaL
+uaL
+paf
 xAt
 xAt
 vtw
@@ -334403,19 +337748,19 @@ xKF
 xKF
 xKF
 xKF
-jMf
+hnd
 xKF
-vtw
+xKF
 wnv
-tlQ
-vtw
-vtw
-jMf
-vtw
+xKF
+xKF
+hnd
+hnd
+xKF
 bJs
 sKd
 aqj
-vtw
+xKF
 vtw
 oAn
 xgy
@@ -334488,8 +337833,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -334786,11 +338131,11 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
+uaL
+uaL
 uaL
 paf
 xAt
@@ -334806,18 +338151,18 @@ oSY
 szN
 szN
 sKd
-abZ
-vtw
+xKF
 iuo
 iuo
 fXv
-vtw
+xKF
+bSm
 wOR
-vtw
+xKF
 alk
 alk
-vtw
-vtw
+xKF
+xKF
 vtw
 oAn
 vzm
@@ -334890,14 +338235,14 @@ kVc
 kVc
 kVc
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -334957,9 +338302,9 @@ whb
 whb
 whb
 whb
+qli
 whb
-whb
-whb
+qli
 dVO
 dVO
 ovn
@@ -335188,13 +338533,13 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
-hcW
-hcW
+uaL
+uaL
+uaL
+uaL
 xAt
 xAt
 vtw
@@ -335208,18 +338553,18 @@ bau
 sKd
 sKd
 sKd
-sKd
-clr
+hnd
 iuo
 aFS
 iuo
-clr
+hnd
+wOR
 wOR
 rKn
 sKd
 tkq
-vtw
-lAs
+xKF
+xKF
 vtw
 rfx
 pwQ
@@ -335292,8 +338637,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -335590,8 +338935,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -335610,17 +338955,17 @@ lel
 szN
 szN
 sKd
-wPC
-vtw
+xKF
 bEo
 iuo
 iuo
-vtw
+xKF
+bSm
 wOR
 rKn
 sKd
 sKd
-vtw
+xKF
 vtw
 vtw
 rfx
@@ -335694,8 +339039,8 @@ wxd
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -335992,8 +339337,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -336012,17 +339357,17 @@ iuo
 iuo
 iuo
 sKd
-mQA
-vtw
-vtw
-clr
-vtw
-vtw
+xKF
+xKF
+hnd
+xKF
+xKF
 wOR
-vtw
+wOR
+xKF
 mfd
 sKd
-vtw
+xKF
 lAs
 lAs
 pQd
@@ -336096,14 +339441,14 @@ wxd
 wxd
 kVc
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -336162,7 +339507,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -336394,8 +339739,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -336415,16 +339760,16 @@ oHg
 iuo
 sKd
 wPC
-vtw
-qHe
+xKF
 wOR
 azQ
 qHe
 wOR
+wOR
 hnd
 sKd
-vtw
-vtw
+xKF
+xKF
 lAs
 lAs
 pQd
@@ -336498,14 +339843,14 @@ wxd
 wxd
 wxd
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -336565,7 +339910,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -336795,9 +340140,9 @@ hcW
 hcW
 hcW
 hcW
-fVM
-jXZ
-jXZ
+hcW
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -336817,15 +340162,15 @@ bXB
 iuo
 sKd
 sKd
-vtw
+xKF
 wOR
 wOR
 wOR
 wOR
 lds
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -336900,14 +340245,14 @@ wxd
 wxd
 wxd
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -336967,7 +340312,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -337198,12 +340543,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
-jXZ
-jXZ
-btl
-qbG
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 hcW
 xAt
 xAt
@@ -337219,14 +340564,14 @@ pDa
 iuo
 krp
 sBX
-jMf
+hnd
 wlI
 pHa
 odo
 oBB
 aTg
-vtw
-lAs
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -337302,8 +340647,8 @@ wxd
 wxd
 wxd
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -337600,12 +340945,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
-jXZ
-cwO
-btl
-qbG
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 hcW
 xAt
 xAt
@@ -337618,17 +340963,17 @@ xKF
 xKF
 xKF
 xKF
-hjD
+clr
 xKF
 xKF
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-lAs
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -337704,8 +341049,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -337770,6 +341115,10 @@ whb
 whb
 whb
 whb
+qli
+whb
+whb
+qli
 whb
 whb
 whb
@@ -337778,11 +341127,7 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+qli
 whb
 whb
 whb
@@ -338106,8 +341451,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -338174,17 +341519,17 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
+qli
 whb
+qli
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+qli
+qli
+qli
 whb
 whb
 whb
@@ -338508,8 +341853,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -338910,8 +342255,8 @@ wxd
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -339312,8 +342657,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -339714,8 +343059,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340116,8 +343461,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340518,8 +343863,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340920,8 +344265,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -341322,8 +344667,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -341724,8 +345069,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342126,8 +345471,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342528,8 +345873,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342930,8 +346275,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -343332,8 +346677,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -343734,8 +347079,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344136,8 +347481,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -346241,8 +349586,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -346643,8 +349988,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -347045,8 +350390,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -347447,8 +350792,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -347849,8 +351194,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -348251,8 +351596,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -348653,8 +351998,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349055,8 +352400,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349457,8 +352802,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349859,8 +353204,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -350261,8 +353606,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -350663,8 +354008,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351065,8 +354410,8 @@ uuE
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351467,8 +354812,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351869,8 +355214,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -352271,8 +355616,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -352673,8 +356018,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353075,8 +356420,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353477,8 +356822,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353879,8 +357224,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -354281,8 +357626,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -354683,8 +358028,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355085,8 +358430,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355487,8 +358832,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355889,9 +359234,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -356291,9 +359636,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -356693,9 +360038,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357095,9 +360440,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357497,9 +360842,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357899,9 +361244,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -358301,9 +361646,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -358703,9 +362048,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359105,9 +362450,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359507,9 +362852,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359909,9 +363254,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -360311,9 +363656,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -360713,9 +364058,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361115,9 +364460,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361517,9 +364862,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361919,9 +365264,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -362321,9 +365666,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -362724,7 +366069,7 @@ uuE
 uuE
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -363126,7 +366471,7 @@ uuE
 uuE
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -363528,7 +366873,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -363930,7 +367275,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -364332,7 +367677,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -364734,7 +368079,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -365136,7 +368481,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -365538,7 +368883,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -365940,7 +369285,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -366342,7 +369687,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -366744,7 +370089,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367146,7 +370491,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367548,7 +370893,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367950,7 +371295,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -368348,11 +371693,11 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -368746,15 +372091,15 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -369147,12 +372492,12 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -369549,7 +372894,7 @@ uuE
 uuE
 uuE
 uuE
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -369951,7 +373296,7 @@ uuE
 uuE
 uuE
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -370353,7 +373698,7 @@ uuE
 uuE
 uuE
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -370755,7 +374100,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371157,7 +374502,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371559,7 +374904,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371961,7 +375306,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -372363,7 +375708,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -372765,7 +376110,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373167,7 +376512,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373569,7 +376914,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373971,7 +377316,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374373,7 +377718,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374775,7 +378120,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375177,7 +378522,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375579,7 +378924,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375981,7 +379326,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376383,7 +379728,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376785,7 +380130,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377187,7 +380532,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377589,7 +380934,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377991,7 +381336,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378393,7 +381738,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378795,7 +382140,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379197,7 +382542,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379599,7 +382944,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379884,53 +383229,53 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
 uuE
 uuE
 uuE
@@ -380001,7 +383346,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -380182,6 +383527,111 @@ fyc
 (88,1,4) = {"
 aUc
 aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -380221,119 +383671,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -380400,10 +383745,10 @@ uuE
 uuE
 uuE
 uuE
-vIa
 vIa
 vIa
 vIa
+aUc
 vIa
 vIa
 vIa
@@ -380627,6 +383972,31 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -380640,6 +384010,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -380653,42 +384025,15 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -380728,14 +384073,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -380805,7 +384150,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381029,6 +384374,46 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+nvV
+gNz
+oiE
+uFp
+xpM
+oiE
+oiE
+xpM
+fxH
+dAf
+hJj
+dAf
+lhy
+hJj
+hJj
+woV
+dAf
+dAf
+hJj
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -381043,54 +384428,14 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -381130,14 +384475,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -381207,7 +384552,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381431,6 +384776,31 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+nvV
+wra
+oiE
+uFp
+xpM
+oiE
+oiE
+xpM
+abZ
+wou
+wou
+abZ
+xpM
+doN
+ijW
+xpM
+lhd
+dAf
+nvr
+pzi
 erZ
 erZ
 erZ
@@ -381445,6 +384815,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -381458,63 +384830,18 @@ erZ
 erZ
 erZ
 erZ
+erZ
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
 erZ
 erZ
 erZ
@@ -381532,6 +384859,15 @@ vIa
 vIa
 vIa
 vIa
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 vIa
 vIa
 vIa
@@ -381540,6 +384876,15 @@ vIa
 vIa
 vIa
 vIa
+vIa
+aUc
+aUc
+vIa
+vIa
+vIa
+vIa
+vIa
+vIa
 uuE
 uuE
 uuE
@@ -381609,7 +384954,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381833,6 +385178,47 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+dbt
+oiE
+xpM
+oiE
+oiE
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+qDn
+qDn
+xpM
+wUw
+ukL
+cld
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -381850,69 +385236,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
 vIa
 erZ
 erZ
@@ -381932,6 +385259,18 @@ vIa
 vIa
 vIa
 vIa
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 vIa
 vIa
 vIa
@@ -381940,6 +385279,12 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
+vIa
+vIa
+vIa
+vIa
 vIa
 vIa
 vIa
@@ -382011,7 +385356,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -382235,6 +385580,31 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+dbt
+uFp
+xpM
+oiE
+oiE
+xpM
+wbT
+dAf
+dAf
+sbF
+xpM
+eWC
+eWC
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -382245,6 +385615,48 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+aUc
+aUc
+aUc
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+vIa
+vIa
 erZ
 erZ
 erZ
@@ -382269,75 +385681,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -382413,7 +385758,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -382637,6 +385982,72 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+egu
+oiE
+xpM
+oiE
+oiE
+xpM
+ehI
+dAf
+dAf
+sbF
+xpM
+lGI
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+aUc
+vIa
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -382671,75 +386082,9 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
 vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -382815,7 +386160,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383039,6 +386384,47 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+nfb
+xpM
+xpM
+xpM
+xpM
+kFr
+kvj
+dAf
+gbf
+xpM
+wou
+wou
+woV
+dAf
+nvr
+hJj
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383057,50 +386443,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383140,8 +386485,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -383217,7 +386562,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383441,6 +386786,47 @@ vIa
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+gvi
+oiE
+dey
+oiE
+oiE
+sXG
+xpM
+hAc
+dAf
+dAf
+dAf
+wou
+abZ
+xpM
+dAf
+dAf
+xpM
+dAf
+dAf
+dAf
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383458,51 +386844,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383542,8 +386887,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -383619,7 +386964,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383843,6 +387188,47 @@ vIa
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+gba
+oiE
+oiE
+oiE
+uFp
+uXS
+xpM
+hAc
+dAf
+fqy
+dAf
+csE
+abZ
+xpM
+lGI
+dAf
+xpM
+loE
+tAs
+cld
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383859,52 +387245,11 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383944,8 +387289,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -384021,7 +387366,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -384245,6 +387590,47 @@ vIa
 vIa
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+jcT
+oiE
+oiE
+uFp
+oiE
+uXS
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ajD
+ajD
+xpM
+xpM
+xpM
+xpM
+xpM
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
 erZ
 erZ
 erZ
@@ -384261,51 +387647,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384346,8 +387691,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -384423,7 +387768,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -384650,6 +387995,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+iIA
+oiE
+oiE
+oiE
+oiE
+sXG
+xpM
+hjD
+lAK
+qzy
+dey
+qzy
+lAK
+mKz
+oiE
+pUQ
+htf
 erZ
 erZ
 erZ
@@ -384669,6 +388032,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -384684,28 +388048,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384748,14 +388093,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -384825,7 +388170,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385052,6 +388397,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+vHh
+uFp
+oiE
+rGY
+oiE
+kTx
+xpM
+oiE
+xdw
+xdw
+oiE
+xAo
+xAo
+oiE
+uFp
+oiE
+htf
 erZ
 erZ
 erZ
@@ -385071,6 +388434,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -385086,28 +388450,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385150,13 +388495,13 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -385227,7 +388572,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385454,6 +388799,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+qSE
+oiE
+hjD
+fHr
+oiE
+vQV
+gGF
+oiE
+uFp
+oiE
+uFp
+oiE
+oiE
+oiE
+oiE
+oiE
+htf
 erZ
 erZ
 erZ
@@ -385473,6 +388836,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -385488,28 +388852,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ryI
-nqU
-oJO
-nqU
-nqU
-ryI
-nqU
-oJO
-nqU
-nqU
-cjJ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385552,8 +388897,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -385629,7 +388974,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385856,6 +389201,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+pdm
+oiE
+hjD
+tnh
+oiE
+kTx
+xpM
+oiE
+iSJ
+iSJ
+oiE
+oiE
+nIq
+nIq
+oiE
+uFp
+htf
 erZ
 erZ
 erZ
@@ -385875,6 +389238,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -385890,28 +389254,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-nqU
-bUi
-xbD
-xbD
-dwO
-nqU
-dTa
-xbD
-bUi
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385954,8 +389299,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -386031,7 +389376,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -386258,6 +389603,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+tSN
+oiE
+oiE
+oiE
+oiE
+tKf
+xpM
+hjD
+qzy
+qzy
+mKz
+pUQ
+oiE
+gNz
+nuH
+oiE
+htf
 erZ
 erZ
 erZ
@@ -386277,6 +389640,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386290,30 +389655,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-ikM
-xbD
-xbD
-nBf
-nqU
-kvj
-xbD
-ikM
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386356,8 +389701,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -386433,7 +389778,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -386660,6 +390005,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+uje
+oiE
+hjD
+fHr
+oiE
+tKf
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+pLK
+pLK
+xpM
 erZ
 erZ
 erZ
@@ -386679,6 +390042,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386692,30 +390057,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-cwd
-xbD
-xbD
-xkF
-nqU
-bVa
-xbD
-xbD
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386758,7 +390103,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -386835,7 +390180,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -387062,52 +390407,28 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
+xpM
+pdm
+oiE
+hjD
+tnh
+oiE
+uDw
+xpM
+vor
+rcr
+uVs
+fLK
+uVs
+rcr
+fLK
 nuH
-xbD
-xbD
-vdg
-nqU
-vdg
-xbD
-xbD
-nqU
-ebb
+oiE
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -387118,6 +390439,30 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387160,7 +390505,7 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -387237,7 +390582,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -387461,7 +390806,31 @@ erZ
 erZ
 erZ
 erZ
-vIa
+aUc
+erZ
+xpM
+xpM
+dbt
+oiE
+oiE
+hzX
+oiE
+xwi
+xpM
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+vjs
+oiE
+woV
+dAf
+dAf
+hJj
+pzi
 erZ
 erZ
 erZ
@@ -387478,6 +390847,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -387491,35 +390861,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-ryI
-cld
-skP
-kHC
-nqU
-nqU
-nqU
-cld
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387562,7 +390907,7 @@ erZ
 erZ
 erZ
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -387637,9 +390982,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
+aUc
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -387863,8 +391208,31 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
+xpM
+xpM
+dbt
+uFp
+oiE
+oiE
+oiE
+vQV
+xpM
+pKQ
+oiE
+oiE
+lXh
+oiE
+vjs
+oiE
+oiE
+oiE
+xpM
+hNk
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -387881,6 +391249,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -387894,34 +391263,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-woq
-xbD
-bqt
-jCh
-nqU
-xbD
-xbD
-xbD
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388038,8 +391383,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -388265,10 +391610,31 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+eoz
+eoz
+dbt
+rfd
+vQV
+oiE
+uFp
+oiE
+iAh
+oiE
+vjs
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+xpM
+lhd
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -388285,6 +391651,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -388298,31 +391665,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-jCr
-xbD
 ebe
 ebe
-xbD
-xbD
-jCr
-xbD
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
 erZ
 erZ
 erZ
@@ -388440,7 +391785,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 gxt
@@ -388669,10 +392014,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+eoz
+eoz
+eoz
+vQV
+vQV
+oiE
+oiE
+yjl
+xId
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+vjs
+oiE
+xpM
+lGI
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -388689,6 +392053,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -388702,29 +392067,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-ryI
-cld
-skP
-kHC
-nqU
-nqU
-nqU
-nqU
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388841,8 +392186,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -389072,10 +392417,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+eoz
+eoz
+hvo
+vQV
+vQV
+xpM
+xpM
+nJy
+nJy
+kOA
+nJy
+nuH
+oiE
+oiE
+oiE
+xpM
+ejA
+cld
+fsu
+pzi
 erZ
 erZ
 erZ
@@ -389092,6 +392455,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -389105,28 +392469,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-ebb
-nqU
-xbD
-xbD
-xbD
-cMs
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389242,8 +392587,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -389475,11 +392820,27 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+eoz
+eoz
+eoz
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+yeA
+yeA
+yeA
+yeA
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -389496,6 +392857,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389508,27 +392871,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-nqU
-qYw
-kFh
-mVz
-xbD
-lGI
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389643,8 +392988,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -389878,11 +393223,12 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+ebe
 erZ
 erZ
 erZ
@@ -389910,14 +393256,12 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ryI
-nqU
-nqU
-nqU
-nqU
-ryI
-ebb
+erZ
+erZ
+erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389928,9 +393272,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390045,7 +393390,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 uuE
@@ -390312,26 +393657,26 @@ erZ
 erZ
 erZ
 erZ
-ebb
-vLA
-vLA
-vLA
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390446,8 +393791,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -390714,14 +394059,6 @@ erZ
 erZ
 erZ
 erZ
-ebb
-vLA
-erZ
-vLA
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -390732,7 +394069,15 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390847,8 +394192,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -391117,9 +394462,6 @@ erZ
 erZ
 erZ
 erZ
-vLA
-vLA
-vLA
 erZ
 erZ
 erZ
@@ -391130,10 +394472,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -391248,8 +394593,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -391504,6 +394849,14 @@ erZ
 erZ
 erZ
 erZ
+jeb
+jeb
+jeb
+jeb
+jeb
+jeb
+jeb
+xKz
 erZ
 erZ
 erZ
@@ -391521,21 +394874,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -391647,10 +394992,10 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
-gxt
+aUc
+aUc
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -391899,6 +395244,21 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+lqm
+aen
+qof
+sXW
+maB
+qxO
+xKz
 erZ
 erZ
 erZ
@@ -391916,28 +395276,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -392048,7 +395393,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -392301,6 +395646,26 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+tdJ
+tCz
+tCz
+qzx
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+jeb
+jeb
+jeb
+jeb
+jeb
 erZ
 erZ
 erZ
@@ -392313,33 +395678,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+eza
+eSt
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -392449,8 +395794,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -392703,6 +396048,26 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+lLa
+lLa
+lLa
+lLa
+xKz
+fVQ
+fVQ
+jeb
+mVz
+fVQ
+xlb
+xKz
+fVQ
+bvN
+tYP
+kgt
+jeb
 erZ
 erZ
 erZ
@@ -392715,33 +396080,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -392851,7 +396196,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -393105,6 +396450,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+xKz
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+oir
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+oir
+fVQ
+bvN
+tYP
+cRP
+jeb
 erZ
 erZ
 erZ
@@ -393117,33 +396482,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -393252,7 +396597,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -393507,6 +396852,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+pLf
+cAj
+fVQ
+fVQ
+lLa
+dfz
+jeb
+dpr
+fkr
+oJH
+xQv
+fVQ
+lLa
+xKz
+fVQ
+tYP
+tYP
+bcO
+jeb
 erZ
 erZ
 erZ
@@ -393519,33 +396884,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -393653,8 +396998,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -393909,6 +397254,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+oLF
+cAj
+fVQ
+fVQ
+lLa
+dfz
+jeb
+xKz
+xKz
+xKz
+xKz
+nGw
+xKz
+xKz
+fVQ
+tYP
+tYP
+jlk
+jeb
 erZ
 erZ
 erZ
@@ -393921,33 +397286,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394054,8 +397399,8 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -394311,6 +397656,26 @@ erZ
 erZ
 erZ
 erZ
+xKz
+vXz
+cAj
+fVQ
+fVQ
+fVQ
+fVQ
+oir
+fVQ
+xjp
+rxa
+uOc
+fVQ
+sBJ
+xKz
+fVQ
+bvN
+tYP
+kgt
+jeb
 erZ
 erZ
 erZ
@@ -394323,33 +397688,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+eza
+eSt
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394455,8 +397800,8 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -394713,6 +398058,26 @@ erZ
 erZ
 erZ
 erZ
+xKz
+oTE
+cAj
+fVQ
+fGX
+fVQ
+fVQ
+jeb
+qEj
+fVQ
+fVQ
+fVQ
+fVQ
+guS
+xKz
+fVQ
+bvN
+tYP
+cRP
+jeb
 erZ
 erZ
 erZ
@@ -394725,33 +398090,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394857,7 +398202,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -395115,14 +398460,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
 xKz
-jeb
-jeb
 xKz
-jeb
-jeb
 xKz
+xKz
+xKz
+mWn
+xKz
+xKz
+wPd
+fVQ
+jeb
+mVz
+fVQ
+fjW
+xKz
+fVQ
+tYP
+tYP
+bcO
+jeb
 erZ
 erZ
 erZ
@@ -395135,25 +398492,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395258,7 +398603,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -395517,13 +398862,25 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
+utx
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+rRM
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
+xKz
+fVQ
+tYP
+tYP
+jlk
 jeb
 erZ
 erZ
@@ -395537,25 +398894,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395660,7 +399005,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -395919,13 +399264,25 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
-fVQ
+utx
 lLa
 vZP
 lLa
 fVQ
+xKz
+brt
+hrk
+hOM
+cbo
+fVQ
+tAT
+xKz
+fVQ
+fIB
+tYP
+kgt
 jeb
 erZ
 erZ
@@ -395939,25 +399296,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -396061,7 +399406,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -396321,42 +399666,42 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 xKz
 fVQ
 lLa
 noC
 lLa
+xlb
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
 fVQ
+fIB
+fVQ
+fVQ
+jeb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+cxZ
+jIP
 xKz
-jeb
-jeb
-xKz
-jeb
-jeb
-xKz
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-xKz
-jeb
+jrn
 bOK
 jeb
 xKz
@@ -396462,8 +399807,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -396723,20 +400068,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
 kHs
 tat
 xAL
 tat
 nIo
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+xKz
+mWn
+xKz
+xKz
+xKz
 jeb
-ufd
-ufd
-ufd
-ufd
-ufd
-jeb
 erZ
 erZ
 erZ
@@ -396749,14 +400100,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
 jeb
 fVQ
 ugK
@@ -396863,7 +400208,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -397133,12 +400478,18 @@ bOK
 rOt
 fVQ
 kdM
-ufd
-ufd
-ufd
-ufd
-ufd
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 kdM
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 pty
 pty
 pty
@@ -397152,13 +400503,7 @@ pty
 pty
 pty
 pty
-pty
-pty
-pty
-pty
-pty
-pty
-pty
+rsd
 bOK
 kHs
 gGH
@@ -397264,7 +400609,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -397537,16 +400882,16 @@ vES
 xKz
 xKz
 kBs
-peN
-peN
+jeb
+jeb
 xKz
 xKz
 evw
-rsd
-rsd
-rsd
-rsd
-rsd
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 rsd
 rsd
 rsd
@@ -397666,7 +401011,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -398067,7 +401412,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -398468,7 +401813,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -399270,8 +402615,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -399670,8 +403015,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -400071,8 +403416,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -400473,7 +403818,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -402708,7 +406053,7 @@ wtF
 wtF
 wtF
 wtF
-cBj
+npm
 wtF
 wtF
 wtF
@@ -405121,7 +408466,7 @@ cUW
 xlm
 oPy
 xlm
-tmE
+ouN
 pqw
 iur
 twQ
@@ -407133,14 +410478,14 @@ nBW
 nBW
 dEA
 wtF
-cBj
+npm
 wtF
 wtF
 cpf
-cBj
+npm
 cpf
 wtF
-cBj
+npm
 cpf
 jTP
 fZJ
@@ -409316,7 +412661,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -409717,8 +413062,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -409955,7 +413300,7 @@ ohU
 wKq
 duQ
 ohU
-tmE
+ouN
 fZJ
 fZJ
 fZJ
@@ -410119,7 +413464,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -410521,7 +413866,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -410759,7 +414104,7 @@ omr
 sFy
 pNf
 omr
-tmE
+ouN
 fZJ
 fZJ
 fZJ
@@ -410920,9 +414265,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -411321,7 +414666,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -411722,7 +415067,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -412123,7 +415468,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -412524,7 +415869,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -412924,8 +416269,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -413324,9 +416669,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
+aUc
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -413725,8 +417070,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -414126,8 +417471,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -414526,8 +417871,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -414927,8 +418272,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -415329,7 +418674,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 uuE
@@ -415730,8 +419075,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 uuE
 uuE
@@ -416011,7 +419356,7 @@ ygF
 ygF
 ygF
 ygF
-ygF
+rfO
 jYR
 lHe
 lHe
@@ -416132,7 +419477,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 uuE
 uuE
@@ -428871,8 +432216,8 @@ wAm
 wAm
 wAm
 wAm
-wAm
-qLF
+hTL
+hTL
 wAm
 wAm
 wAm
@@ -428884,12 +432229,12 @@ wAm
 wAm
 wAm
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -429270,28 +432615,28 @@ teW
 kwf
 nRx
 rwH
-uSx
+lMZ
 teW
 kqc
-wAm
-wAm
-wAm
+hEB
+jjS
+svL
 vMQ
 vsf
-sIE
+rwH
 nKu
-nSr
-sIE
+jiv
+rwH
 teW
-hqI
-fUr
-wte
+yjP
+dBO
+vMQ
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -429674,26 +433019,26 @@ jiv
 jiv
 uSx
 teW
-nSr
+obi
+vgH
 jiv
-jjS
 jiv
-nSr
-nSr
-nSr
+jiv
+jiv
+jiv
 bEL
 jiv
 jjS
 teW
 hqI
+cwd
 hqI
-uGf
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+vZc
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430074,28 +433419,28 @@ teW
 yhF
 jiv
 jiv
-uSx
 teW
-nSr
+teW
+vMQ
+vgH
 jiv
 jiv
 jiv
-nSr
-nSr
-nSr
+jiv
+jiv
 nKu
-nSr
+jiv
 vIX
 teW
-fUr
 hqI
-wUw
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+cwd
+hqI
+cwd
+sAC
+qab
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430473,31 +433818,31 @@ erZ
 fZJ
 fZJ
 teW
-yhF
+cBG
 jiv
 jiv
-teW
-teW
-sxM
+hcx
+cfw
+jiv
 jiv
 jiv
 jiv
 qfh
-nSr
+uYU
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
+cwd
 hqI
-bPz
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+cwd
+cwd
+eAm
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430880,26 +434225,26 @@ jiv
 jiv
 hcx
 cfw
-nSr
-nSr
+xSI
+jiv
+jiv
 jiv
 nSr
-nSr
-nSr
-nSr
+ojc
+htU
 teW
 ael
-cLL
-iRN
-fUr
 hqI
-uGf
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+hqI
+hqI
+cwd
+hqI
+lVF
+cwd
+mCT
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431277,31 +434622,31 @@ erZ
 fZJ
 fZJ
 teW
-mrE
+cBG
 vAK
 xSI
 tML
+wAm
+wAm
+kdg
+kdg
+wAm
+vND
 tML
-qpX
-teW
-fnF
-teW
-teW
-uzT
-fnF
-teW
+vND
+tML
 pDA
 hqI
-aac
 hqI
-gdJ
-uGf
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+hqI
+cwd
+hqI
+cwd
+cwd
+mCT
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431683,27 +435028,27 @@ wAm
 wAm
 wAm
 wAm
+wAm
 tML
-teW
 nyc
-swm
+ntK
 gbA
 cAe
-ybm
-swm
-teW
+cAe
+bPv
+kqW
 ulu
 hqI
 fVE
 hqI
+lLK
 hqI
-wUw
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+cwd
+nfN
+wSl
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432083,29 +435428,29 @@ fZJ
 teW
 tML
 sdb
-ntK
+aur
 swm
 lPt
-ntK
-bkD
-vUf
-tak
-tak
-tak
 swm
+nyc
+ntK
+tak
+qGh
+qGh
+qGh
 teW
 uNz
 hqI
 hqI
-hqI
-hqI
+cwd
+wAL
 ojc
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+itC
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432488,26 +435833,26 @@ tsB
 aur
 swm
 pLs
-ntK
-bkD
-vUf
-rSg
-rSg
-rSg
 swm
-teW
+nyc
+ntK
+rSg
+jNV
+jNV
+jNV
+tML
 ajj
 lLK
-hqI
-uPa
+lLK
+lLK
 tML
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432891,25 +436236,25 @@ aur
 rVB
 vrG
 wtl
-wtl
-vUf
-lYl
+ntK
+ntK
 lYl
 xrf
-swm
-ohA
+xrf
+xrf
+wQn
 bcN
 bcN
 bcN
 vWe
+put
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433292,12 +436637,12 @@ uKB
 oBU
 sUQ
 xXs
+ntK
+vFy
+ntK
+uTT
 swm
 swm
-swm
-uTT
-uTT
-uTT
 swm
 wQn
 bcN
@@ -433306,12 +436651,12 @@ bcN
 vWe
 ffv
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433694,26 +437039,26 @@ uKB
 aur
 uZa
 cPw
+pho
+ntK
+ntK
+azR
 ybm
 ybm
-vUf
-tak
-tak
-tak
-swm
-ohA
+ybm
+wQn
 bcN
 bcN
 bcN
 vWe
+siG
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434096,26 +437441,26 @@ sUb
 aur
 swm
 pLs
-ntK
-bkD
-vUf
-rSg
-rSg
-rSg
 swm
-teW
+nyc
+ntK
+gbA
+bPv
+bPv
+bPv
+tML
 eYI
 uZC
-vGN
-tML
-tML
+uZC
+wAm
+wAm
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434288,7 +437633,7 @@ uuE
 uuE
 uuE
 nqU
-tJC
+xkK
 lAB
 mKZ
 edk
@@ -434495,29 +437840,29 @@ fZJ
 teW
 gGI
 wYt
-ntK
+aur
 swm
 oyP
-ntK
-bkD
-vUf
-lYl
-lYl
-xrf
 swm
+nyc
+ntK
+tak
+qGh
+qGh
+qGh
+teW
+vWy
+vWy
+vWy
 tML
-wAm
-wAm
-wAm
-wAm
 tML
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434897,29 +438242,29 @@ fZJ
 teW
 ePd
 wAm
-tML
 wAm
-tML
-rRD
+wAm
+wAm
 aXE
-swm
-swm
-lDq
-swm
-swm
-tML
-rMM
-rMM
+nyc
+ntK
+pCH
+uRR
+uRR
+cMs
+teW
+wpm
+wpm
+wpm
 wAm
 wAm
-hKU
-hKU
-lug
-tML
-tWY
-tWY
-tWY
-tWY
+wAm
+wAm
+wAm
+wAm
+squ
+squ
+squ
 squ
 squ
 squ
@@ -434927,7 +438272,7 @@ squ
 squ
 squ
 rTC
-rTC
+jnO
 squ
 squ
 squ
@@ -435289,7 +438634,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -435303,33 +438648,33 @@ tML
 teW
 tML
 tML
-tML
+tox
 fnF
+wAm
+aGb
 tML
-tML
-ycz
 aGb
 tML
 cfY
 cfY
 cfY
 wpe
-eCn
+fQd
 eCn
 sNY
+ggG
 teW
 teW
 teW
 teW
 teW
-squ
 squ
 squ
 squ
 squ
 squ
 rTC
-rTC
+jnO
 rTC
 rTC
 rTC
@@ -435691,7 +439036,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -435704,34 +439049,34 @@ tML
 tML
 teW
 btc
-tUR
 bkD
 swm
-owz
-rMM
+swm
+fbf
+cfY
 cfY
 cfY
 vTd
 cfY
 cfY
 cfY
-teW
-aTF
+alk
 eCn
-sNY
-teW
+eCn
+eCn
+eCn
 teW
 aor
 xfh
+ebb
 teW
-squ
 squ
 squ
 squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -436093,8 +439438,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -436106,24 +439451,25 @@ tML
 tML
 teW
 wVs
-ntK
 ujc
+swm
 swm
 fbf
 cfY
 cfY
-uZy
-uZy
-uZy
-uZy
 cfY
-alk
-eCn
-eCn
-eCn
-fQd
+cfY
+cfY
+cfY
+cfY
 teW
-htf
+aTF
+sQI
+jAJ
+eCn
+mYi
+gbX
+gbX
 gbX
 teW
 squ
@@ -436131,9 +439477,8 @@ squ
 squ
 squ
 squ
-squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -436496,36 +439841,37 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
 fZJ
-fZJ
+eQa
 teW
 wAm
 wAm
 wAm
-teW
+tML
 btc
-tUR
 bkD
+swm
 swm
 owz
 rMM
 cfY
-idu
-xAh
-lIc
-sNp
 cfY
-teW
+uZy
+uZy
+uZy
+cfY
+alk
 eCn
+pbg
+shJ
 eCn
-eCn
-eCn
-teW
-xET
+mYi
+gbX
+gbX
 gbX
 teW
 squ
@@ -436533,9 +439879,8 @@ squ
 squ
 squ
 squ
-squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -436898,46 +440243,46 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
+vWY
+hIC
+jBh
 uKB
-nTR
 uBv
 tML
 tML
 tML
 xnv
-fnF
+hKt
 tML
 rMM
 cfY
-fPg
-pcQ
-nJX
-cpY
 cfY
-alk
+idu
+lIc
+sNp
+cfY
+teW
+aTF
 eCn
 eCn
-fLK
 eCn
-mYi
-gbX
-gbX
+teW
+aAo
+iVW
+wwM
 teW
 squ
 squ
 squ
 squ
 squ
-squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -437300,17 +440645,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
+vWY
 uKB
-nTR
-ntK
-bHX
+kcR
+uKB
+uKB
+uKB
 kNs
 htZ
 swm
@@ -437318,28 +440663,28 @@ swm
 tML
 tML
 lQT
-tcW
-tcW
-tcW
-tcW
 cfY
-teW
-sbF
+fPg
+nJX
+cpY
+cfY
+wpe
+qcC
+qcC
 eCn
-uxZ
 eCn
 teW
-wyA
-seC
 teW
-squ
+teW
+teW
+teW
 squ
 squ
 squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -437702,18 +441047,18 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+erZ
+erZ
+erZ
+erZ
 fZJ
-fZJ
-rxp
+vWY
 uKB
-nTR
-ntK
-ntK
-ntK
+agV
+uKB
+vox
+iDV
+uKB
 nIr
 swm
 swm
@@ -437721,18 +441066,18 @@ jlM
 pzU
 cfY
 cfY
+tcW
+tcW
+tcW
 cfY
-cfY
-cfY
-cfY
-alk
+teW
 eCn
 eCn
-loE
-aym
 teW
+mYi
 teW
-teW
+xJe
+xJe
 teW
 squ
 squ
@@ -437741,7 +441086,7 @@ squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -438106,35 +441451,35 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+lIW
+teW
+teW
 teW
 rou
-nTR
-cCS
-nJy
-ntK
+uKB
+uKB
+uKB
+uKB
+uKB
 nIr
 swm
 swm
 swm
 pzU
 cfY
-uZy
-uZy
-uZy
-uZy
+cfY
+cfY
+cfY
+cfY
 cfY
 teW
-aTF
-eCn
-tfp
+teW
+teW
+teW
 eCn
 teW
-lAs
-lAs
+xJe
+xJe
 teW
 squ
 squ
@@ -438143,7 +441488,7 @@ squ
 squ
 squ
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -438508,35 +441853,35 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-pur
+jfV
+teW
+fgH
+uKB
+wkw
+sdl
+xJb
+qsC
 tML
-tML
-ydR
-tML
-cbQ
 swm
 swm
 lDq
 pzU
 cfY
-idu
-lIc
-sct
-sNp
 cfY
-alk
+uZy
+uZy
+uZy
+cfY
+mYi
 eCn
 eCn
+fQd
 eCn
-grk
 teW
-lAs
-lAs
+xJe
+xJe
 teW
 eQa
 rTC
@@ -438545,7 +441890,7 @@ rTC
 rTC
 rTC
 rTC
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -438910,44 +442255,44 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-uKB
-cgD
+vyn
+teW
+eOo
+eOo
 tML
-gdJ
 tML
-pjB
+ydR
+tML
+tML
 swm
 swm
 tML
 tML
 lQT
-bWq
-iMA
-iMA
-pxR
 cfY
-wpe
-qcC
-qcC
-qcC
-tiH
+idu
+sct
+sNp
+cfY
+kuV
+tlQ
+oPp
+ecb
+eCn
 teW
-lAs
-lAs
-lAs
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+xJe
+xJe
+xJe
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -439312,34 +442657,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
 uKB
-tdJ
+hIC
+uKB
+uKB
+cgD
 tML
-gdJ
+bDN
+hqI
+pjB
+swm
+swm
 tML
-vaa
-lDq
-iWj
-tML
-rMM
+qQw
 cfY
-tcW
-tcW
-tcW
-tcW
 cfY
+bWq
+iMA
+pxR
+cfY
+kuV
+qYQ
+ilL
+tVu
+eCn
 teW
-eCn
-eCn
-eCn
-tiH
-teW
-lAs
+xJe
 lAs
 lAs
 vIa
@@ -439714,34 +443059,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-nMd
-xeO
+aTn
+uKB
+uKB
+uKB
+fEE
 tML
+gdJ
+hqI
+vaa
+swm
+lDq
 tML
-tML
-wAm
-wAm
-wAm
-wAm
-teW
+rMM
 eVa
-cfY
-cfY
-cfY
-cfY
+xXc
+tcW
+tcW
+tcW
 eVa
+alQ
+lLl
+hzl
+wMo
+eCn
 teW
-teW
-teW
-teW
-teW
-lAs
-lAs
+xJe
 lAs
 lAs
 vIa
@@ -440116,34 +443461,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-tML
-tML
-tML
-tML
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
 teW
+pcQ
+nMd
+uKB
+uKB
+xeO
+tML
+tML
+tML
+wAm
+hKt
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
 teW
-wAm
-wAm
-aSD
-wAm
-wAm
+aTF
+eCn
+grk
+eCn
 teW
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 lAs
 lAs
 vIa
@@ -440518,34 +443863,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
 teW
-vsg
-xJe
-eBN
-xJe
-wAm
-wAm
-wAm
 teW
-lAs
-lAs
-lAs
-lAs
+teW
+iww
+uKB
+uKB
+ept
+iYx
+fGq
+vUf
+vUf
+iYx
+iYx
+iYx
+iYx
+iYx
+xJe
+xJe
+xJe
+teW
+teW
+teW
+teW
+teW
+teW
+teW
+xJe
 lAs
 lAs
 vIa
@@ -440920,34 +444265,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
+xJe
+xJe
 teW
-lMZ
-eBN
-eBN
-eBN
-eBN
-eBN
-lMZ
-teW
-lAs
-lAs
-lAs
-lAs
+iDV
+uKB
+uKB
+syt
+iYx
+vaa
+vUf
+dmH
+iYx
+fVm
+eli
+llq
+iYx
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
 lAs
 lAs
 vIa
@@ -441323,29 +444668,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-fZJ
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 teW
-mQr
-eBN
-eBN
-eBN
-eBN
-eBN
-dbt
-teW
+qOT
+uKB
+uKB
+sZv
+iYx
+tcq
+vUf
+vUf
+iYx
+cOL
+vUf
+vUf
+iYx
+xJe
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -441725,29 +445070,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 teW
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
+anO
+uKB
+uKB
+pMn
+iYx
+aVU
+vUf
+vUf
+jHv
+vUf
+vUf
+vUf
+iYx
+xJe
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -442127,29 +445472,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 teW
-dbt
-eBN
-dbt
-eza
-dbt
-eBN
-dbt
 teW
+teW
+teW
+teW
+iYx
+baG
+vUf
+oqH
+iYx
+lXX
+jZY
+oLg
+iYx
+xJe
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -442529,29 +445874,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+xJe
+xJe
+xJe
+iYx
+iYx
+iYx
+iYx
+fGq
+vUf
+rCc
+iYx
+iYx
+iYx
+iYx
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-gip
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
 lAs
 lAs
 lAs
@@ -442931,29 +446276,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+rCc
+mJg
+iYx
+iYx
+vUf
+oqH
+iYx
+fVm
+eli
+llq
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-mQr
-eBN
-dbt
-eBN
-dbt
-eBN
-dbt
-teW
 lAs
 lAs
 lAs
@@ -443333,29 +446678,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+cOL
+vUf
+jHv
+vUf
+vUf
+vUf
+iYx
+cOL
+vUf
+vUf
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
 lAs
 lAs
 lAs
@@ -443735,29 +447080,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+vUf
+vUf
+iYx
+vUf
+vUf
+vUf
+jHv
+vUf
+vUf
+vUf
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-dbt
-ejY
-dbt
-ejY
-dbt
-wou
-dbt
-teW
 lAs
 lAs
 lAs
@@ -444137,29 +447482,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+fmV
+oLg
+iYx
+vUf
+hFs
+cPT
+iYx
+lXX
+jZY
+oLg
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-teW
 lAs
 lAs
 lAs
@@ -444542,20 +447887,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+juf
+iYx
+iYx
+iYx
+eDI
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
+juf
+aUc
 vIa
 vIa
 vIa
@@ -444944,20 +448289,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+iYx
+iYx
+sSL
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+xJe
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -445347,17 +448692,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+eSE
+iqs
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+xJe
 vIa
 vIa
 vIa
@@ -445749,17 +449094,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+qEq
+iqs
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+xJe
 vIa
 vIa
 vIa
@@ -446151,17 +449496,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+iEB
+rPU
+uZC
+uZC
+uZC
+iYx
+iYx
+iYx
+xJe
 vIa
 vIa
 vIa
@@ -446553,17 +449898,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+iYx
+iYx
+vcA
+vcA
+ufN
+iYx
+xJe
+xJe
+xJe
 vIa
 vIa
 vIa
@@ -446956,13 +450301,13 @@ aUc
 aUc
 aUc
 aUc
-aUc
-aUc
-aUc
-aUc
-aUc
-aUc
-aUc
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
 aUc
 aUc
 aUc
@@ -448555,6 +451900,16 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -448658,17 +452013,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -448956,6 +452301,17 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -449059,18 +452415,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -449359,6 +452704,16 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -449462,17 +452817,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -449761,6 +453106,16 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -449864,17 +453219,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -450276,7 +453621,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -450678,7 +454023,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -451080,7 +454425,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -451482,7 +454827,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -451884,7 +455229,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452286,7 +455631,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452688,7 +456033,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453090,7 +456435,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453492,7 +456837,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453894,7 +457239,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -454296,7 +457641,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -454698,7 +458043,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455100,7 +458445,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455502,7 +458847,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455904,7 +459249,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -456306,7 +459651,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -456708,7 +460053,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457110,7 +460455,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457512,7 +460857,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457914,7 +461259,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -458316,7 +461661,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -458718,7 +462063,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459120,7 +462465,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459522,7 +462867,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459924,7 +463269,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -460326,7 +463671,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -460728,7 +464073,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461130,7 +464475,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461532,7 +464877,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461934,7 +465279,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -462336,7 +465681,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -462738,7 +466083,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463140,7 +466485,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463542,7 +466887,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463944,7 +467289,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464346,7 +467691,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464748,7 +468093,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465150,7 +468495,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465552,7 +468897,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465954,7 +469299,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466356,7 +469701,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466758,7 +470103,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467160,7 +470505,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467562,7 +470907,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467964,7 +471309,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468366,7 +471711,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468768,7 +472113,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469170,7 +472515,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469572,7 +472917,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469974,7 +473319,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470376,7 +473721,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470778,7 +474123,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471180,7 +474525,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471582,7 +474927,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471984,7 +475329,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472386,7 +475731,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472788,7 +476133,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473190,7 +476535,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473592,7 +476937,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473994,7 +477339,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474396,7 +477741,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474798,7 +478143,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475200,7 +478545,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475602,7 +478947,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -476004,7 +479349,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -476406,7 +479751,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -476808,7 +480153,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -477210,7 +480555,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -477612,7 +480957,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -478014,7 +481359,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -478416,7 +481761,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -478818,7 +482163,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -479220,7 +482565,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -479622,7 +482967,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -480024,7 +483369,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -480426,7 +483771,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -480828,7 +484173,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -481230,7 +484575,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -481632,7 +484977,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482034,7 +485379,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482436,7 +485781,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482728,89 +486073,89 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 eSw
 wQD
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+vIa
+vIa
+vIa
+vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -483130,9 +486475,39 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+obq
 erZ
 erZ
 erZ
@@ -483161,38 +486536,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -483212,6 +486557,7 @@ vIa
 vIa
 vIa
 vIa
+aUc
 vIa
 vIa
 vIa
@@ -483222,24 +486568,23 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 aUc
 vIa
 vIa
@@ -483532,9 +486877,39 @@ vIa
 vIa
 vIa
 vIa
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+aok
+xpM
+xpM
+xpM
+hJj
+dAf
+dAf
+dAf
+hJj
+woV
+dAf
+xpM
+rps
+rcx
+bYH
+kRI
+uxV
+kRI
+aPR
 erZ
 erZ
 erZ
@@ -483564,55 +486939,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
 vIa
 vIa
 vIa
@@ -483625,7 +486952,25 @@ vIa
 vIa
 vIa
 vIa
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 vIa
+aUc
+vIa
+vIa
+vIa
+vIa
+vIa
+vIa
+vIa
+aUc
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -483934,11 +487279,39 @@ vIa
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+nmF
+xpM
+xpM
+xpM
+dAf
+dAf
+gEt
+flI
+flI
+xpM
+dAf
+ixg
+uxV
+mpr
+uxV
+mpr
+uxV
+uxV
+kFh
 erZ
 erZ
 erZ
@@ -483974,34 +487347,6 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 vIa
 vIa
 vIa
@@ -484016,15 +487361,15 @@ erZ
 erZ
 erZ
 erZ
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -484336,9 +487681,40 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+sbF
+xpM
+nBf
+sYv
+uxZ
+oiW
+xpM
+xpM
+xpM
+woV
+xpM
+ooP
+uxV
+uxV
+uxV
+uxV
+uxV
+sWi
+erZ
 erZ
 erZ
 erZ
@@ -484376,17 +487752,6 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -484399,32 +487764,12 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -484738,9 +488083,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+sbF
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+lGI
+ycz
+dAf
+xpM
+uTc
+sug
+fwJ
+uxV
+uxV
+uxV
+aPR
 erZ
 erZ
 erZ
@@ -484759,36 +488134,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -485140,9 +488485,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+woV
+xpM
+xpM
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+ycz
+dAf
+dAf
+obq
+mQA
+mzf
+tfW
+qoP
+uxV
+mpr
+kFh
 erZ
 erZ
 erZ
@@ -485161,36 +488536,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -485542,9 +488887,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+sGx
+sGx
+jtV
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+dAf
+uxZ
+ycz
+obq
+wQI
+plR
+wQI
+anS
+uxV
+uxV
+sWi
 erZ
 erZ
 erZ
@@ -485553,36 +488928,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -485944,11 +489289,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 fIL
 wQD
-vIa
-vIa
+aUc
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nBf
+kvj
+dAf
+oiW
+xpM
+jpw
+uxZ
+uxZ
+tiH
+xpM
+dAf
+dAf
+dAf
+obq
+wQI
+wQI
+iPI
+sxM
+uxV
+uxV
+aPR
 erZ
 erZ
 erZ
@@ -485956,34 +489329,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -486346,39 +489691,39 @@ erZ
 erZ
 erZ
 vIa
-vIa
+aUc
 eNY
 hby
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+dAf
+ycz
+dAf
+obq
+vaQ
+wQI
+vaQ
+gaI
+uxV
+uxV
+kFh
 erZ
 erZ
 erZ
@@ -486748,39 +490093,39 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 eDN
 twI
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+aUc
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ehI
+dAf
+sGx
+sbF
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+lGI
+dAf
+uxZ
+xpM
+xpM
+xpM
+xpM
+iVA
+iVA
+iVA
+qyS
 erZ
 erZ
 erZ
@@ -487150,35 +490495,35 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 twI
 twI
 twI
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ryE
+kvj
+dAf
+gEt
+xpM
+ehI
+dAf
+dAf
+sbF
+xpM
+dAf
+uxZ
+dAf
+dAf
+dAf
+uPi
+bzl
 erZ
 erZ
 erZ
@@ -487552,35 +490897,35 @@ erZ
 erZ
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 xGC
 oWI
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jEB
+kvj
+dAf
+oiW
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+dAf
+dAf
+dAf
+dAf
+wDZ
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -487955,9 +491300,34 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ehI
+sGx
+dAf
+tiH
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+dAf
+dAf
+uxZ
+dAf
+uPi
+saP
+bVa
 erZ
 erZ
 erZ
@@ -487981,31 +491351,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -488356,10 +491701,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+dAf
+sbF
+xpM
+sbF
+uxZ
+uxZ
+tiH
+xpM
+lGI
+dAf
+dAf
+dAf
+uPi
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -488383,31 +491753,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -488758,10 +492103,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nBf
+kvj
+dAf
+mUC
+mUC
+mUC
+dAf
+dAf
+mUC
+mUC
+uxZ
+dAf
+dAf
+wWE
+vdg
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -488785,31 +492155,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -489160,10 +492505,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+sGx
+dAf
+lvF
+xpM
+kFr
+kvj
+dAf
+gbf
+xpM
+lGI
+uxZ
+dAf
+dAf
+dAf
+vdg
+bzl
 erZ
 erZ
 erZ
@@ -489187,31 +492557,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -489562,10 +492907,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+sGx
+dAf
+woV
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+cTb
+dAf
+dAf
+uLh
+uLh
+vFz
+gqj
+uLh
 erZ
 erZ
 erZ
@@ -489585,35 +492959,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -489964,45 +493309,40 @@ erZ
 erZ
 erZ
 erZ
-erZ
-lgg
+bQB
+ebe
 uXW
 oRe
-erZ
-erZ
-erZ
-erZ
-sri
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nVf
+kvj
+dAf
+pDO
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ebe
+ebe
+xpM
+dAf
+ycz
+ycz
+uLh
+ssD
+dSP
+oBF
+uLh
+oMa
 erZ
 erZ
 erZ
@@ -490010,12 +493350,17 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -490361,21 +493706,46 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-lgg
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 hqA
 pCW
-lgg
-lgg
-lgg
-lgg
-lgg
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+dAf
+vxV
+dSP
+dSP
+tUp
+gqj
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -490393,31 +493763,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -490758,13 +494103,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 lgg
 lgg
 lgg
@@ -490776,12 +494121,33 @@ lgg
 lgg
 lgg
 lgg
-lgg
-sri
-sri
-sri
-sri
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+dAf
+vxV
+dSP
+dSP
+dSP
+vxV
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -490799,27 +494165,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -491156,13 +494501,13 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 lgg
 lgg
 lgg
@@ -491182,10 +494527,29 @@ lgg
 lgg
 vIa
 vIa
-sri
-sri
-sri
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+lGI
+ycz
+dAf
+vxV
+dSP
+dSP
+dSP
+gqj
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -491203,25 +494567,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -491561,7 +494906,7 @@ vIa
 erZ
 erZ
 erZ
-erZ
+ebe
 lgg
 lgg
 lgg
@@ -491587,8 +494932,25 @@ vIa
 vIa
 vIa
 vIa
-sri
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+wyA
+ttW
+dAf
+uLh
+vPA
+dSP
+dSP
+uLh
+oMa
 erZ
 erZ
 erZ
@@ -491607,23 +494969,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -491990,8 +495335,23 @@ vIa
 vIa
 vIa
 vIa
-vIa
-sri
+aUc
+ebe
+xpM
+xET
+xET
+xET
+xET
+xET
+xET
+xET
+woq
+woq
+uLh
+uLh
+mIC
+mIC
+mEy
 erZ
 erZ
 erZ
@@ -492011,21 +495371,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -492393,8 +495738,8 @@ vIa
 vIa
 vIa
 vIa
-sri
-sri
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -492422,12 +495767,12 @@ erZ
 erZ
 erZ
 erZ
-ebb
-mdB
-ebb
-ebb
-ebb
-ebb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -494015,14 +497360,14 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -494412,19 +497757,19 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -494814,24 +498159,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -495216,24 +498561,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -495616,26 +498961,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -496018,26 +499363,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -496420,26 +499765,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -496822,26 +500167,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -497224,26 +500569,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -497626,7 +500971,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 iJC
 bOK
 nEd
@@ -497634,18 +500979,18 @@ nEd
 nEd
 bOK
 iJC
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498028,7 +501373,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 bOK
 fVQ
 fVQ
@@ -498036,18 +501381,18 @@ bmG
 fVQ
 fVQ
 bOK
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498430,7 +501775,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 nEd
 fVQ
 lgN
@@ -498438,18 +501783,18 @@ jJC
 lgN
 fVQ
 nEd
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498832,7 +502177,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 nEd
 fVQ
 qxZ
@@ -498846,12 +502191,12 @@ vxC
 vxC
 vxC
 ppx
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -499234,7 +502579,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 nEd
 fVQ
 fVQ
@@ -499248,12 +502593,12 @@ fZJ
 fZJ
 fZJ
 kZS
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -500486,7 +503831,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bQB
 erZ
 erZ
 erZ
@@ -516470,11 +519815,11 @@ dST
 naI
 naI
 naI
-npm
+dST
 naI
 naI
 naI
-npm
+dST
 naI
 naI
 wtF
@@ -533808,7 +537153,7 @@ eZN
 rFc
 hjt
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -534211,7 +537556,7 @@ pur
 udS
 udS
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -534612,7 +537957,7 @@ miM
 rFc
 hjt
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -538605,7 +541950,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+rbn
 erZ
 erZ
 erZ
@@ -539826,11 +543171,11 @@ qzV
 nLH
 pil
 aqS
-qTb
+jYn
 fCM
 fCM
 fCM
-pur
+mdB
 fCM
 nQU
 cGD
@@ -540219,7 +543564,7 @@ vIa
 vIa
 fZJ
 fZJ
-uwn
+lAs
 woj
 qPA
 qPA
@@ -540619,9 +543964,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 woj
 qPA
 qPA
@@ -541021,9 +544366,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 woj
 qPA
 qPA
@@ -541423,9 +544768,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 woj
 qPA
 qPA
@@ -541825,9 +545170,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 eJN
 bHY
 bHY
@@ -542227,27 +545572,27 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
+cbQ
+cbQ
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 pYj
 pYj
 pYj
@@ -542629,7 +545974,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cbQ
 vIa
 vIa
 vIa
@@ -543031,7 +546376,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cbQ
 vIa
 vIa
 vIa
@@ -543433,7 +546778,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cbQ
 vIa
 vIa
 vIa
@@ -543835,7 +547180,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+pYj
 vIa
 vIa
 vIa


### PR DESCRIPTION
## About The Pull Request

The following PR adds as followed for the server and fixes a number of issues.
>Fixes the voids in the Keep reported by Elizabeths player
>Adds a number of anti grief and QoL features to the keep (Hand gets an gemerald ring and choker. There are now bar'd windows in the Stewards area.
>Removes secretly mapped in items that gave certain people an advantage 
>Adds anti gref measures to the Smithy.
>Adds the Grandmasters chambers to the Church & revamps part of it.
>Adds a feeding line for the poor. 
>Adjusts around the beggar spawn.
>Adds a new segment of Rockhill known as "The Estate" which is guarded by the town watch utilizing a shutter gate system.
>Adds a mini dungeon crypt that has one dungeon chest but is surrounded by running water. Gl.
>Added anti tunneling measures and things like that in the map. If you wanna break in, find the statue or tunnel in from the undersea.
> Some other things I might have forgotten to mention besides some mining ore spots.
> Also adds a new dungeon that advs can clear out and claim as home.

## Why It's Good For The Game

Mentioned above. 

## Pictures in game:

![image](https://github.com/user-attachments/assets/4bbd96d5-bd80-4af1-922f-5c6169b63393)
![image](https://github.com/user-attachments/assets/0921ad70-f4d2-4bbb-bed8-5a41a327f29f)
![image](https://github.com/user-attachments/assets/085b8236-d982-4e51-bb91-3d46cbce8a61)
![image](https://github.com/user-attachments/assets/e8d3878b-6dd5-45ff-9837-79808148f516)
![image](https://github.com/user-attachments/assets/31aa7f02-de27-4782-94bd-7294346c59e9)
![image](https://github.com/user-attachments/assets/bf8aca72-a204-4c73-9f6d-fbd4030a9ba1)
