### PR TITLE
take three | Tzula's super duper cool map update

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7,10 +7,14 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
 "aac" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aad" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -497,17 +501,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "abZ" = (
-/obj/structure/fluff/wallclock{
-	pixel_y = -30
-	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "wooden_floor2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "aca" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -988,7 +984,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "adL" = (
 /obj/item/natural/stone,
@@ -1130,29 +1126,43 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ael" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "WHEAT"
 	},
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4;
+	icon_state = "torchwall1"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "aem" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"aen" = (
+/obj/item/quiver/bolts,
+/obj/item/quiver/bolts,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "aev" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/obj/structure/flora/roguegrass/bush/wall/tall,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "aex" = (
 /obj/structure/flora/wildplant/wild_herbs,
 /turf/open/floor/rogue/grass,
@@ -1170,13 +1180,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"afc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/border/ruinedwood{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "afp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/library{
@@ -1244,6 +1247,10 @@
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"agV" = (
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "ahH" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -1276,6 +1283,9 @@
 /area/rogue/indoors/town/church/chapel)
 "ajj" = (
 /obj/structure/statue/saints/father,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "ajo" = (
@@ -1301,6 +1311,16 @@
 	icon_state = "ice"
 	},
 /area/rogue/indoors/shelter/mountains)
+"ajD" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "ajF" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe{
 	color = '#87CEFA';
@@ -1338,13 +1358,17 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"alQ" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "alU" = (
 /turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/under/town/basement)
-"alX" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors)
 "alY" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1389,18 +1413,32 @@
 /obj/structure/statue/saints/knight_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"aoa" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
+"anO" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"anS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"aok" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/bog)
-"aok" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
 "aor" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1464,12 +1502,6 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
-"arx" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/bog)
 "arL" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/twig,
@@ -1497,11 +1529,6 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"att" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "atx" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/church,
@@ -1530,15 +1557,6 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"atT" = (
-/obj/structure/fluff/nest,
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 1
-	},
-/turf/open/floor/rogue/rooftop/green{
-	dir = 1
-	},
-/area/rogue/outdoors/mountains)
 "auq" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -1561,14 +1579,11 @@
 	icon_state = "wiz"
 	})
 "auL" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "woodsmprison"
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "auQ" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile{
@@ -1586,13 +1601,14 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
-"avF" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
+/area/rogue/indoors/town)
+"avN" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "avQ" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/border{
@@ -1666,17 +1682,13 @@
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/indoors/town)
+/area/rogue/indoors/town/garrison)
 "axs" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"axR" = (
-/obj/structure/stairs,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "axW" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
@@ -1688,11 +1700,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
 "aym" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -33
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ayt" = (
 /obj/effect/landmark/start/adventurer{
 	dir = 1
@@ -1745,6 +1755,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"azR" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "aAe" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/cloak/stabard/guard,
@@ -1754,6 +1774,24 @@
 /obj/item/clothing/cloak/stabard/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"aAo" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "aAs" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
@@ -1765,19 +1803,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"aAO" = (
-/obj/structure/bars/pipe,
-/obj/effect/decal/wood/ruinedwood{
-	dir = 1
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 4
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "aAV" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -1792,13 +1817,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
-"aCE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "aCS" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -1819,13 +1837,6 @@
 /obj/effect/landmark/start/ladylate,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"aDk" = (
-/obj/structure/bed/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "aDE" = (
 /obj/structure/stairs{
 	dir = 4
@@ -1866,6 +1877,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
+"aEG" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "aEN" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/angle,
@@ -1906,8 +1923,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "aGb" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -1963,6 +1985,12 @@
 /obj/item/clothing/neck/roguetown/psicross/pestra,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"aIb" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "aIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/kitchen/spoon/plastic,
@@ -2020,6 +2048,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"aIT" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CE"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aIV" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
@@ -2041,12 +2075,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
-"aJS" = (
-/obj/structure/table/wood/bar,
-/obj/item/reagent_containers/glass/bottle/rogue/luckpot,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "aKd" = (
 /obj/structure/winch{
 	dir = 4;
@@ -2130,6 +2158,13 @@
 "aMH" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/tribalfort)
+"aMK" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "aMV" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = 32
@@ -2157,7 +2192,7 @@
 	dir = 1;
 	pixel_y = -6
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "aNW" = (
 /obj/structure/table/wood,
@@ -2168,7 +2203,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "aOn" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -2177,10 +2212,6 @@
 "aOv" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"aOE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "aOT" = (
 /obj/structure/roguemachine/stockpile{
 	pixel_x = 32;
@@ -2219,9 +2250,14 @@
 	},
 /area/rogue/outdoors/rtfield)
 "aPR" = (
-/obj/structure/flora/roguetree/burnt,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "aPX" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -2266,11 +2302,6 @@
 /obj/structure/roguemachine/steward,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"aRt" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/shoes/roguetown/boots/leather,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "aRA" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
@@ -2301,15 +2332,16 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "aSD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/roguebin/water/gross,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "aSH" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "aSO" = (
 /obj/structure/fluff/walldeco/steward,
@@ -2330,6 +2362,12 @@
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"aTn" = (
+/obj/structure/fluff/walldeco/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "aTE" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -2407,6 +2445,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"aVU" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "aWs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/hexstone,
@@ -2453,14 +2496,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs)
-"aXQ" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/effect/holodeck_effect/cards,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "aXR" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
@@ -2488,14 +2523,10 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor)
-"aZo" = (
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+"aZu" = (
+/obj/structure/flora/roguegrass/fungus_bush,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/rtfield)
 "aZG" = (
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/blocks,
@@ -2510,14 +2541,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "aZZ" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
+/obj/structure/rack/rogue,
+/obj/item/clothing/gloves/roguetown/leather,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/natural/bone,
-/obj/item/reagent_containers/powder/salt,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet/bogcaves)
+/area/rogue/indoors/town)
 "bau" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/church/chapel)
@@ -2525,6 +2554,11 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"baG" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "baO" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -2532,6 +2566,16 @@
 "baS" = (
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
+"baV" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "bbm" = (
 /obj/structure/flora/wildplant/wild_poppy,
 /turf/open/floor/rogue/grass,
@@ -2557,6 +2601,13 @@
 "bcN" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/church/chapel)
+"bcO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/obj/item/rogueweapon/woodstaff,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bdu" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -2595,6 +2646,16 @@
 /obj/structure/statue/saints/martyr,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"bez" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "beA" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -2631,6 +2692,14 @@
 	dir = 8
 	},
 /area/rogue/indoors)
+"bfE" = (
+/obj/structure/chair/bench,
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = 5;
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "bfK" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -2671,10 +2740,6 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"bhp" = (
-/obj/structure/bars/pipe,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "bht" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -2698,6 +2763,12 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"bhR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "bix" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2712,11 +2783,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"biZ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "bjd" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -2786,10 +2852,18 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bkF" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/golden,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "bkW" = (
 /obj/structure/roguewindow/openclose,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "bkZ" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
@@ -2809,6 +2883,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"blT" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "blW" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -2839,11 +2917,11 @@
 	},
 /area/rogue/indoors/town/garrison)
 "bmL" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "bmV" = (
 /obj/item/burial_shroud,
 /obj/structure/table/wood{
@@ -2877,7 +2955,11 @@
 	icon_state = "border"
 	},
 /obj/structure/flora/roguegrass,
-/obj/item/natural/rock,
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	icon_state = "woodrailing"
+	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "bnV" = (
@@ -2906,9 +2988,7 @@
 /area/rogue/under/cavewet/bogcaves/tomb)
 "bok" = (
 /obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "bow" = (
 /obj/structure/mineral_door/wood{
@@ -2950,21 +3030,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"bpt" = (
-/obj/structure/bars/pipe{
-	dir = 4;
-	icon_state = "pipe"
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -12
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "bpx" = (
 /obj/structure/table/vtable/v2,
 /obj/item/reagent_containers/glass/mortar,
@@ -2989,14 +3054,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "bpT" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/obj/item/natural/bone,
+/obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/cloak/raincloak/mortus,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet/bogcaves)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town)
 "bqf" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
@@ -3021,11 +3084,19 @@
 	},
 /area/rogue/indoors)
 "bqt" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"bqu" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "bqD" = (
 /obj/item/rogueweapon/shield/tower/metal{
 	desc = "A kite-shaped iron shield. Reliable and sturdy. This shield glows with the divine grace of Astrata.";
@@ -3067,6 +3138,16 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"brt" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "brP" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "wooden_floort"
@@ -3091,6 +3172,10 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"bsh" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "bsm" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -3118,6 +3203,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"bsS" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "btc" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/churchrough,
@@ -3179,6 +3268,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"buB" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "buL" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -3306,7 +3404,7 @@
 	icon_state = "wcv";
 	locked = 1;
 	lockid = "shop";
-	max_integrity = 1000000
+	max_integrity = 99999
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -3362,10 +3460,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "bzl" = (
-/obj/item/rogueweapon/mace/wsword,
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bzD" = (
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -3431,8 +3528,8 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
 "bCb" = (
-/turf/closed/wall/mineral/rogue/wooddark/end,
-/area/rogue/outdoors/rtfield)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/town/basement)
 "bCk" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -3456,6 +3553,14 @@
 /area/rogue/indoors/town/library{
 	icon_state = "wiz"
 	})
+"bDf" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bDh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "bDl" = (
 /obj/structure/stairs{
 	dir = 1
@@ -3466,6 +3571,14 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"bDN" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16;
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "bEe" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/blocks,
@@ -3475,12 +3588,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
-"bEs" = (
-/obj/structure/bars/pipe{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "bEC" = (
 /obj/structure/lever/wall{
 	dir = 4;
@@ -3555,6 +3662,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"bHe" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "bHt" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -3578,11 +3693,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bHX" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32
+/obj/structure/winch{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "bHY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 4
@@ -3663,16 +3779,12 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"bKj" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/under/cavewet/bogcaves)
 "bKk" = (
 /obj/structure/table/wood{
 	dir = 5;
 	icon_state = "largetable"
 	},
-/obj/item/reagent_containers/food/snacks/rogue/pumpkincandy,
-/obj/item/reagent_containers/food/snacks/rogue/pumpkincandy,
+/obj/item/roguekey/roomhunt,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
 "bLf" = (
@@ -3724,7 +3836,6 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
 /obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/mercury,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
@@ -3744,6 +3855,17 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"bON" = (
+/obj/item/candle/skull,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "bOP" = (
 /obj/structure/mineral_door/wood/window{
 	lockid = "tavern"
@@ -3773,21 +3895,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "bPv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
-"bPz" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"bPz" = (
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors/town/garrison)
 "bPP" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
@@ -3804,8 +3921,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "bQf" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/grass,
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "bQo" = (
 /obj/structure/stairs{
@@ -3888,8 +4008,6 @@
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/food/snacks/rogue/ratonastick,
-/obj/item/reagent_containers/glass/bottle/rogue/luckpot,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "bSW" = (
@@ -3927,20 +4045,29 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "bUi" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
+/obj/structure/stairs/stone{
+	dir = 1
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"bUr" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "bVa" = (
-/obj/structure/bed/rogue,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border,
+/obj/structure/closet/crate/coffin/vampire{
+	name = "CASKET OF DOUGH";
+	pixel_x = 19
+	},
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh2";
+	aportalid = "wh1";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = 18
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "bVw" = (
 /turf/open/water/river{
 	dir = 1;
@@ -4034,6 +4161,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"bYH" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "bYM" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -4074,9 +4210,6 @@
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"bZF" = (
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "bZO" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
@@ -4089,6 +4222,22 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cbo" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cbE" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "sheriff"
@@ -4099,14 +4248,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "cbQ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/mineral/rogue,
+/area/rogue/outdoors/town/roofs)
 "cca" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4168,9 +4311,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "cdn" = (
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "cdA" = (
 /obj/structure/bars/passage{
 	redstone_id = "gobcell1"
@@ -4360,11 +4503,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "cjJ" = (
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 1
-	},
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cka" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/flashlight/flare/torch/lantern,
@@ -4416,12 +4557,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cld" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "clr" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -4487,7 +4625,7 @@
 /area/rogue/outdoors/town)
 "cnp" = (
 /turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cnD" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/tile{
@@ -4518,10 +4656,6 @@
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"cpb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "cpf" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -4598,16 +4732,23 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cqU" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "crx" = (
 /obj/structure/statue/saints/noble3_l,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "crz" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/bed/rogue/shit,
+/obj/effect/landmark/start/servant{
+	dir = 8
 	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/manor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "crG" = (
@@ -4638,6 +4779,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"csE" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "csU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -4708,6 +4853,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"cvC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cvN" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road{
@@ -4715,9 +4867,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
 "cwd" = (
-/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/church/chapel)
 "cwh" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4821,19 +4972,13 @@
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"cxZ" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "cyr" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
-"cyB" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
-"cyU" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/indoors/town)
 "czb" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
@@ -4907,8 +5052,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
 "cAe" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -4921,14 +5066,16 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"cAj" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "cAo" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet/bogcaves)
-"cAu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "cAv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -4980,7 +5127,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "cBG" = (
-/obj/structure/fermenting_barrel/random/water,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/storage/backpack/rogue/backpack/surgery,
+/obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
@@ -4997,6 +5149,10 @@
 "cCz" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"cCC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "cCF" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/grass,
@@ -5005,7 +5161,8 @@
 /obj/structure/mineral_door/wood{
 	locked = 1;
 	lockid = "mason";
-	max_integrity = 1000000
+	max_integrity = 9999;
+	name = "The Door That Does Not Break"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -5019,10 +5176,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cCS" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cDC" = (
 /obj/structure/rack/rogue,
 /obj/item/roguekey/garrison,
@@ -5118,13 +5274,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"cGk" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "cGw" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "glyph1"
@@ -5190,7 +5339,7 @@
 	pixel_x = -1;
 	pixel_y = 31
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "cIy" = (
 /obj/item/chair/stool/bar/rogue,
@@ -5230,8 +5379,10 @@
 "cKr" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/leather,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet/bogcaves)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town)
 "cKt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -5272,18 +5423,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "cLL" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/nest,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/mountains)
 "cLW" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass,
@@ -5301,12 +5442,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "cMs" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/obj/item/natural/saddle,
-/obj/item/quiver/arrows,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/walldeco/church/line,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "cMO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -5318,7 +5462,7 @@
 "cMU" = (
 /obj/structure/roguewindow,
 /turf/open/transparent/openspace,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "cNd" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -5350,6 +5494,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"cND" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "cNN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf{
 	faction = list("undead")
@@ -5373,10 +5524,23 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"cOL" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "cOV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"cPd" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "cPe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -5401,6 +5565,20 @@
 	},
 /obj/effect/landmark/start/monk,
 /turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"cPT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "cQf" = (
 /obj/machinery/light/rogue/forge,
@@ -5458,11 +5636,11 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "cRP" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/obj/item/rogueweapon/mace/woodclub,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "cRQ" = (
 /obj/machinery/light/rogue/torchholder{
@@ -5487,6 +5665,10 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"cSi" = (
+/obj/structure/fluff/statue/gargoyle/moss,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "cSk" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/rogue/grass,
@@ -5518,6 +5700,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"cTb" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "cTr" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -5601,6 +5790,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"cVu" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "cVK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -5649,13 +5843,6 @@
 "cWT" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/rtfield)
-"cWU" = (
-/obj/effect/decal/stone/mossy,
-/obj/effect/decal/dirt,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "cXk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -5794,22 +5981,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dbt" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
-"dbw" = (
-/obj/structure/roguemachine/vendor/blk4,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "dbH" = (
-/obj/machinery/light/rogue/campfire,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/rtfield)
 "dbV" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/grass,
@@ -5852,6 +6029,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dcH" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/under/cavewet/bogcaves)
 "dcN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -5914,7 +6097,6 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/item/reagent_containers/food/snacks/rogue/cheesebun,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "ddL" = (
@@ -5931,6 +6113,10 @@
 /obj/effect/landmark/start/nightman,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"dey" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "deT" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -5945,6 +6131,22 @@
 /obj/structure/statue/saints/lady2_r,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"dfz" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"dfH" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "dfK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -6035,11 +6237,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"diw" = (
-/obj/item/rogueweapon/stoneaxe,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "diA" = (
 /mob/living/simple_animal/hostile/mushroom{
 	faction = list("undead")
@@ -6050,6 +6247,10 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"diG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/closed/mineral/rogue,
+/area/rogue/under/cave)
 "diP" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -6068,6 +6269,17 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"djd" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "djA" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -6096,15 +6308,19 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"dkc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "dkf" = (
 /obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
 /obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/hammer,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -6171,10 +6387,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"dlV" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/blocks/newstone/alt,
-/area/rogue/indoors/town/church/chapel)
 "dmw" = (
 /obj/structure/fluff/walldeco/painting/queen{
 	pixel_y = 32
@@ -6192,6 +6404,12 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dmH" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -33
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "dmI" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/suit/roguetown/shirt/rags,
@@ -6233,6 +6451,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
+"doN" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "doW" = (
 /obj/structure/stairs{
 	dir = 4
@@ -6255,6 +6480,15 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"dpr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope,
+/obj/item/rope,
+/obj/item/rope,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dpw" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -6330,6 +6564,15 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dsg" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "dsk" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/roguetown/shirt/vampire,
@@ -6357,9 +6600,20 @@
 "dsB" = (
 /turf/open/water/cleanshallow,
 /area/rogue/indoors)
+"dsR" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "dsW" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "dth" = (
 /obj/structure/fluff/railing/border,
@@ -6375,6 +6629,15 @@
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
+"dua" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "duu" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -6414,6 +6677,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town)
+"dvv" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/bath)
 "dvD" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/bed/rogue,
@@ -6448,13 +6715,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "dwO" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/clothing/suit/roguetown/shirt/rags,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "dwQ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -6526,10 +6791,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "dAf" = (
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "dAk" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -6550,6 +6813,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
+"dAE" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/bath)
 "dBk" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/grass,
@@ -6558,6 +6825,20 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"dBO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/fluff/nest,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "dBV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6565,11 +6846,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"dBY" = (
-/obj/structure/chair/bench/coucha/r,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "dCJ" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
@@ -6704,6 +6980,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"dHw" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "dHC" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -6818,9 +7100,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
 "dMP" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	locked = 1
-	},
+/obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "dNa" = (
@@ -6833,10 +7113,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/vikingarea)
-"dNl" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors)
 "dNu" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
@@ -6844,11 +7120,8 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "dNL" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/under/cave)
 "dOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -6961,6 +7234,13 @@
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"dQe" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "dQp" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/clinic,
@@ -6987,11 +7267,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
 "dRa" = (
-/obj/structure/roguemachine/drugmachine,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
-	dir = 1
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/shop)
+/area/rogue/under/cavewet/bogcaves)
 "dRb" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -7035,6 +7314,9 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"dSP" = (
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "dSQ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -7066,9 +7348,8 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "dTa" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/ruinedwood,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
 "dTB" = (
 /obj/structure/table/wood,
@@ -7082,8 +7363,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "dTD" = (
-/obj/structure/flora/wildplant/wild_herbs,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/tile{
+	icon_state = "greenstone"
+	},
 /area/rogue/under/cavewet/bogcaves)
 "dTL" = (
 /obj/structure/table/wood{
@@ -7185,20 +7467,12 @@
 /obj/structure/guillotine,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"dWR" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
 "dXw" = (
 /obj/structure/table/wood{
 	dir = 10;
 	icon_state = "tablewood2"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "dXC" = (
 /obj/structure/fluff/railing/border{
@@ -7235,13 +7509,6 @@
 	},
 /turf/open/floor/grass/snow,
 /area/rogue/indoors/shelter/mountains)
-"dZh" = (
-/obj/structure/table/wood/fancy,
-/obj/item/roguekey/blk,
-/obj/item/reagent_containers/food/drinks/bottle/absinthe,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "dZu" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -7291,14 +7558,24 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "ebb" = (
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
-"ebe" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/church/chapel)
+"ebe" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "ebg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7334,6 +7611,14 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/indoors/town/bath)
+"ecb" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ecm" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -7354,18 +7639,11 @@
 	},
 /area/rogue/indoors/town)
 "ecC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/roguemachine/stockpile,
+/turf/open/floor/rogue/tile{
+	icon_state = "greenstone"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/area/rogue/under/cavewet/bogcaves)
 "ecD" = (
 /obj/structure/statue/saints/noble2_l,
 /turf/open/floor/rogue/blocks,
@@ -7485,8 +7763,14 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "eeO" = (
-/obj/item/rogueweapon/mace/wsword,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/water/cleanshallow,
 /area/rogue/indoors/town/church/chapel)
 "eeR" = (
 /obj/structure/window/plasma/reinforced/spawner{
@@ -7496,7 +7780,7 @@
 	name = "RPW North"
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors)
 "efg" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road{
@@ -7543,11 +7827,22 @@
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"egd" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "egl" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"egu" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/rack/rogue/shelf/big,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "egx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -7584,6 +7879,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"ehI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ehP" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road{
@@ -7629,27 +7929,29 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ejA" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ejC" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "ejJ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "ejL" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/gravedigger,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
-"ejM" = (
-/obj/structure/fluff/clodpile,
-/obj/effect/decal/dirt,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "ejV" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble/mossy,
@@ -7674,6 +7976,12 @@
 /obj/item/dice/d6,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"eli" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "elk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -7750,7 +8058,7 @@
 	pixel_y = 7
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/town/roofs)
 "ent" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road{
@@ -7792,6 +8100,12 @@
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"eol" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "eou" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -7808,10 +8122,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "eoz" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/mountains)
 "eoA" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -7822,6 +8134,13 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"ept" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "epy" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -7831,7 +8150,7 @@
 	desc = "I shouldn't go in here...";
 	locked = 1;
 	lockid = "vamp";
-	name = "old clinic (Do not Break in)"
+	name = "Old Clinic"
 	},
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -7930,13 +8249,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
-"esE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/wooden/crafted,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "esF" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
@@ -7960,13 +8272,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "etu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
+/obj/structure/bed/rogue/shit,
+/obj/effect/landmark/start/butler{
+	dir = 4
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "ety" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -8002,13 +8313,19 @@
 /area/rogue/indoors/shelter/rtfield)
 "euo" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
+	dir = 1;
+	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
 "eur" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "euC" = (
 /obj/structure/flora/roguegrass/bush,
@@ -8042,9 +8359,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "evb" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/fermenting_barrel/random,
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "evm" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -8061,8 +8379,10 @@
 /area/rogue/indoors/town)
 "evw" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "evJ" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
@@ -8094,7 +8414,6 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
 "exG" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
 "exP" = (
@@ -8129,7 +8448,9 @@
 "eyJ" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "blacksmith"
+	lockid = "blacksmith";
+	max_integrity = 9999;
+	name = "Blacksmith Door"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -8142,9 +8463,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eza" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "ezo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8159,6 +8483,11 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
+"eAm" = (
+/obj/structure/fluff/railing/wood,
+/obj/machinery/loom,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -8196,6 +8525,12 @@
 "eBw" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"eBx" = (
+/obj/machinery/anvil{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "eBz" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -8248,6 +8583,14 @@
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"eDI" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eora's Chamber"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "eDN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8389,10 +8732,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "eIh" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/toilet/secret,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
 "eIj" = (
@@ -8424,15 +8764,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"eJh" = (
-/obj/effect/decal/dirt/road,
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "eJr" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
@@ -8502,15 +8833,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"eLM" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "eMc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -8570,6 +8892,14 @@
 "eOg" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter)
+"eOo" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Armory"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "eOR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop/green{
@@ -8609,7 +8939,7 @@
 "eQE" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors)
 "eQW" = (
 /obj/structure/spacevine,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
@@ -8629,6 +8959,10 @@
 /obj/structure/statue/saints/magelady_r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"eRV" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "eSc" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/tile{
@@ -8663,11 +8997,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "eSt" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
 "eSw" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -8677,6 +9009,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
+"eSE" = (
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
+"eTc" = (
+/obj/structure/roguewindow/openclose,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "eTo" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 8
@@ -8779,10 +9119,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "eVO" = (
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/machinery/light/rogue/firebowl/church,
+/turf/open/floor/rogue/tile{
+	icon_state = "greenstone"
 	},
-/area/rogue/indoors/town/shop)
+/area/rogue/under/cavewet/bogcaves)
 "eVS" = (
 /obj/structure/fluff/wallclock/vampire,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -8804,17 +9145,26 @@
 	lockid = "priest"
 	},
 /obj/item/book/rogue/bibble,
+/obj/item/listenstone,
+/obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "eWj" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eWl" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors)
+"eWC" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "eWM" = (
 /obj/machinery/light/rogue/chand,
 /obj/effect/landmark/start/jester{
@@ -8850,6 +9200,9 @@
 	icon = 'icons/roguetown/misc/longsleep2.dmi';
 	icon_state = "longsleep";
 	name = "mushroom ring - Eora's Sanctuary"
+	},
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -8912,8 +9265,9 @@
 	dir = 1
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -8928,6 +9282,20 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"fbP" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/dice{
+	pixel_y = 13
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fbQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -8986,16 +9354,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "fdo" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "thief2";
-	aportalid = "thief1";
-	icon = 'icons/roguetown/misc/tallstructure.dmi';
-	icon_state = "oknightstatue_l";
-	name = "statue"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
 "fdF" = (
 /obj/structure/table/wood{
@@ -9023,12 +9384,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "few" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+/obj/structure/well/fountain,
+/turf/open/floor/rogue/tile{
+	icon_state = "greenstone"
 	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "feE" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -9099,11 +9458,33 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"fgH" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 2;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"fha" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/closed,
+/area/rogue/indoors/town/dwarfin)
 "fhg" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"fhm" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/garrison)
 "fhu" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -9134,6 +9515,13 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"fiK" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors)
 "fiL" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -9177,6 +9565,15 @@
 /obj/item/rogueweapon/whip,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fjW" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fjX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -9188,6 +9585,16 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/garrison)
+"fkr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "fkC" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -9221,6 +9628,13 @@
 "flH" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/garrison)
+"flI" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "flK" = (
 /obj/structure/flora/shroomstump,
 /turf/open/floor/rogue/dirt,
@@ -9261,6 +9675,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fmV" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fnc" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -9363,6 +9781,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"fqy" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH4";
+	name = "WH Lever 4";
+	pixel_x = 13
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fqE" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town/roofs)
@@ -9391,6 +9818,11 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach)
+"fsu" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fsM" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/knight,
@@ -9499,6 +9931,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"fwJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "fwL" = (
 /obj/item/rogueweapon/hammer{
 	color = gold;
@@ -9537,6 +9977,11 @@
 "fxx" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"fxH" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "fxK" = (
 /obj/structure/flora/roguegrass,
 /turf/open/water/river,
@@ -9576,6 +10021,16 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"fyv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "fyA" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -9615,7 +10070,7 @@
 	},
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "fAb" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -9663,12 +10118,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"fAS" = (
-/obj/effect/decal/border/ruinedwood{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "fAV" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -9688,7 +10137,7 @@
 /area/rogue/under/town/basement)
 "fBF" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "fBL" = (
 /obj/structure/flora/shroomstump,
@@ -9716,8 +10165,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "fCU" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cavewet/bogcaves)
 "fDe" = (
 /obj/structure/closet/crate/roguecloset,
@@ -9738,9 +10186,6 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"fDk" = (
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors)
 "fDw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -9757,23 +10202,24 @@
 	},
 /area/rogue/indoors/town)
 "fDB" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "fDI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
 "fDM" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/fluff/statue/tdummy2,
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors)
+"fEc" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/shop)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fEo" = (
 /obj/item/rogueweapon/woodstaff/wise{
 	color = gold;
@@ -9797,6 +10243,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"fEE" = (
+/obj/structure/closet/crate/chest{
+	name = "BREAK INCASE OF VAMPYRE EMERGENCY"
+	},
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "fEF" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/church,
@@ -9814,6 +10268,18 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"fFW" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"fGq" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "fGF" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -9826,6 +10292,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"fGX" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "fHi" = (
 /obj/structure/fluff/walldeco/masonflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -9849,6 +10321,11 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"fHr" = (
+/obj/structure/table/vtable,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "fHC" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -9901,12 +10378,10 @@
 	},
 /area/rogue/indoors/town/magician)
 "fIB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	icon_state = "border"
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "fID" = (
 /obj/structure/stairs{
@@ -9919,6 +10394,12 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fIK" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fIL" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9970,13 +10451,16 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"fKD" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fKI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/bog)
-"fKV" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "fLd" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/greenstone,
@@ -9989,23 +10473,30 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/outdoors/town)
+"fLv" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH1"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fLI" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fLK" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/apple,
-/obj/item/seeds/apple,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "fMc" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10054,7 +10545,7 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "fPg" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -10111,7 +10602,7 @@
 /obj/item/storage/roguebag,
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "fQm" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -10122,11 +10613,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "fQq" = (
-/obj/effect/landmark/events/testportal{
-	aportalloc = "woodsman"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/indoors/town)
 "fQN" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -10183,6 +10671,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"fRP" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "fRU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/masonic{
@@ -10293,6 +10787,15 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"fVm" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "fVE" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/grass,
@@ -10304,9 +10807,15 @@
 	},
 /area/rogue/under/town/basement)
 "fVM" = (
-/obj/machinery/light/rogue/torchholder,
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/shelter/rtfield)
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/roguemachine/atm{
+	pixel_y = -3;
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "fVQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10390,6 +10899,15 @@
 "fZe" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
+"fZg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "fZw" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobblerock,
@@ -10414,6 +10932,18 @@
 "gaC" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement)
+"gaI" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "gaO" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood{
@@ -10421,6 +10951,26 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gba" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/obj/item/natural/bundle/cloth,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"gbf" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "gbh" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/carpet/purple,
@@ -10439,11 +10989,12 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "gbA" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/chair/bench/church{
+	dir = 1
 	},
-/obj/structure/roguemachine/scomm/r{
-	pixel_x = -33
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -10542,12 +11093,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"geX" = (
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "gfc" = (
 /obj/structure/table/church/m,
 /turf/open/floor/rogue/churchmarble,
@@ -10584,13 +11129,22 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ggG" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "ggR" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "ghZ" = (
 /obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/under/cavewet/bogcaves)
 "gid" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -10607,9 +11161,8 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "gip" = (
-/obj/structure/fluff/walldeco/stone,
-/turf/closed/wall/mineral/rogue/decostone/cand,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/dungeon,
@@ -10626,15 +11179,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"gjj" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/bars/pipe{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "gjl" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10785,16 +11329,22 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church/chapel)
+"gof" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "gok" = (
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "goz" = (
-/obj/structure/fluff/railing/border{
-	dir = 6;
-	icon_state = "border"
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "goK" = (
 /obj/effect/decal/cobbleedge{
@@ -10839,15 +11389,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
-"gqo" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/bottle/blazaam,
-/obj/item/reagent_containers/food/drinks/bottle/blazaam,
-/obj/item/reagent_containers/food/drinks/bottle/blazaam,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
+"gqj" = (
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "gqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -10869,13 +11414,27 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"grj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "grk" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "grQ" = (
 /obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/tile/masonic/inverted,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/shop)
 "grZ" = (
 /obj/structure/closet/crate/roguecloset/inn/chest,
@@ -10884,6 +11443,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"gse" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "gsT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -10927,16 +11492,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"gtE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "gtF" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut/steel,
@@ -10962,6 +11517,14 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"gum" = (
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gut" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
@@ -10975,17 +11538,21 @@
 "guP" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
-"gvi" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 4
+"guS" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
+"gvi" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "gvn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "gvo" = (
@@ -10996,6 +11563,10 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"gvP" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "gvT" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -11134,20 +11705,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/rogue/frybirdtato,
-/obj/item/reagent_containers/food/snacks/rogue/frybirdtato,
-/obj/item/reagent_containers/food/snacks/rogue/friedegg/two,
-/obj/item/reagent_containers/food/snacks/rogue/friedegg/two,
-/obj/item/reagent_containers/food/snacks/rogue/friedegg/tiberian/plated,
-/obj/item/reagent_containers/food/snacks/rogue/friedegg/tiberian/plated,
-/obj/item/reagent_containers/food/snacks/rogue/friedegg/tiberian/plated,
-/obj/item/reagent_containers/food/snacks/rogue/ccake,
-/obj/item/reagent_containers/food/snacks/rogue/meat/bacon/fried,
-/obj/item/reagent_containers/food/snacks/rogue/meat/bacon/fried,
-/obj/item/reagent_containers/food/snacks/rogue/meat/poultry/baked/plated,
-/obj/item/reagent_containers/food/snacks/rogue/handpie,
-/obj/item/reagent_containers/food/snacks/rogue/handpie,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
 "gAk" = (
@@ -11235,6 +11792,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"gDx" = (
+/obj/machinery/light/rogue/wallfire,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "gEj" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/grown/sugarcane,
@@ -11248,6 +11809,16 @@
 "gEq" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
+"gEt" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "gEE" = (
 /obj/structure/bed/rogue/shit,
@@ -11314,14 +11885,18 @@
 	},
 /area/rogue/under/town/basement)
 "gGu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
+"gGF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "gGH" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -11335,7 +11910,7 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "gGN" = (
 /obj/structure/winch{
@@ -11349,6 +11924,11 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
+"gHd" = (
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "gHg" = (
 /obj/structure/chair/stool/rogue,
@@ -11367,9 +11947,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
 "gHQ" = (
-/obj/structure/bed/rogue/inn,
-/obj/item/bedsheet/rogue/pelt,
-/obj/effect/landmark/start/butler,
+/obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "gIl" = (
@@ -11379,6 +11957,14 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"gIo" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/book/rogue/cooking,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "gIv" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -11515,16 +12101,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"gMB" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "gMO" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
@@ -11565,6 +12141,12 @@
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/town)
+"gNz" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "gOa" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/twig,
@@ -11608,10 +12190,6 @@
 "gPy" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor)
-"gPE" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors)
 "gPI" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -11750,10 +12328,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"gSK" = (
-/obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/town/roofs)
 "gSP" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -11784,11 +12358,30 @@
 /obj/structure/roguemachine/musicbox,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"gTY" = (
+/obj/structure/winch{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "gUx" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"gUC" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguemachine/vendor{
+	keycontrol = "blacksmith"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "gUD" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
 	max_integrity = 99999
@@ -11805,6 +12398,17 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"gUR" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "gUV" = (
 /obj/structure/timeddoor,
 /turf/open/floor/rogue/dirt/road{
@@ -11837,6 +12441,10 @@
 /obj/effect/landmark/start/noblelate,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
+"gVW" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "gWs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/chest,
@@ -11865,6 +12473,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"gXk" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "gXr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -11935,6 +12550,12 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"hal" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "greenstone"
+	},
+/area/rogue/under/cavewet/bogcaves)
 "ham" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -11983,12 +12604,9 @@
 	},
 /area/rogue/indoors/town/vault)
 "hbc" = (
-/obj/machinery/light/rogue/smelter,
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/rogue/metal,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "hby" = (
 /obj/structure/stairs{
 	dir = 8
@@ -12005,28 +12623,14 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"hbN" = (
-/obj/structure/bars/pipe,
-/obj/effect/decal/wood/ruinedwood{
-	dir = 1
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 4
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "hbS" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "hcg" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/mountains)
@@ -12045,9 +12649,7 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "hcq" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -12073,6 +12675,11 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
+"hcG" = (
+/obj/structure/closet/crate/chest,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "hcL" = (
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/ruinedwood,
@@ -12108,7 +12715,7 @@
 	lockid = "farm"
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "hdz" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/cudgel,
@@ -12129,7 +12736,6 @@
 /area/rogue/indoors)
 "hdG" = (
 /obj/structure/closet/crate/chest,
-/obj/item/rogueweapon/sword/falchion,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
 "hdL" = (
@@ -12140,8 +12746,7 @@
 	icon_state = "oknightstatue_l";
 	name = "statue"
 	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/ruinedwood/turned,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "hdR" = (
 /obj/structure/table/wood{
@@ -12167,13 +12772,13 @@
 	pixel_x = 1;
 	pixel_y = 7
 	},
-/obj/machinery/light/rogue/smelter,
 /obj/structure/window/plasma/reinforced/spawner{
 	dir = 1;
 	icon = null;
 	max_integrity = 50000;
 	name = "RPW North"
 	},
+/obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -12181,6 +12786,14 @@
 "hew" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"heK" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "heV" = (
 /obj/structure/table/church/m,
 /obj/structure/table/church{
@@ -12205,11 +12818,6 @@
 	},
 /area/rogue/indoors/town/garrison)
 "hfe" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
 /area/rogue/indoors/town/shop)
 "hff" = (
@@ -12357,13 +12965,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "hjD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "hjV" = (
 /obj/structure/flora/wildapples/wildplant/wild_apples,
 /turf/open/floor/rogue/grass,
@@ -12437,6 +13041,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hlY" = (
+/obj/machinery/light/rogue/oven/south,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "hme" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -12462,12 +13072,6 @@
 	max_integrity = 50000;
 	name = "RPW North"
 	},
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -12487,14 +13091,23 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "hmU" = (
-/obj/structure/fluff/statue/myth{
-	desc = "A heroic figure that seems to be in mid-wink toward the viewer.";
-	name = "The Champion"
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hmV" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/concrete,
@@ -12504,6 +13117,12 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/garrison)
+"hmZ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "hnd" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -12530,16 +13149,22 @@
 	icon_state = "tablewood2"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "hnC" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/manor)
-"hnK" = (
-/obj/structure/bed/rogue/shit,
-/obj/effect/landmark/start/servant{
-	dir = 1
-	},
+"hnG" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
+"hnK" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "hnN" = (
 /obj/structure/flora/newtree,
@@ -12606,7 +13231,8 @@
 /obj/structure/mineral_door/wood{
 	locked = 1;
 	lockid = "blacksmith";
-	max_integrity = 1000000
+	max_integrity = 9999;
+	name = "Blacksmith Door"
 	},
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -12677,6 +13303,23 @@
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"hrk" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/obj/item/clothing/under/roguetown/chainlegs/skirt,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"hrT" = (
+/obj/structure/rack/rogue,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hrZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
@@ -12708,16 +13351,9 @@
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/manor)
 "htf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "htj" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/cobble,
@@ -12737,7 +13373,9 @@
 "htZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	desc = "Forges of Malum";
+	name = "Forges of Malum"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -12757,6 +13395,10 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
+"huL" = (
+/obj/effect/landmark/start/grandtemplar,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/indoors/town/church/chapel)
 "hvf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -12777,6 +13419,10 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"hvo" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "hvx" = (
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/tile,
@@ -12803,22 +13449,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
 "hxm" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/shop)
 "hxn" = (
 /obj/structure/bookcase/random,
@@ -12831,13 +13462,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"hyb" = (
-/obj/effect/decal/stone/mossy,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "hyc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/wallfire/candle/l{
@@ -12859,6 +13483,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors)
+"hyM" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "hyR" = (
 /obj/structure/stairs/stone,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -12889,6 +13523,14 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hzl" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "hzS" = (
 /obj/structure/bars/grille,
 /obj/structure/fluff/railing/wood{
@@ -12899,6 +13541,31 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"hzX" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
+"hzY" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"hAa" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
+"hAc" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hAg" = (
 /obj/item/chair/rogue/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -12955,6 +13622,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"hCQ" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hCS" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -12994,6 +13668,18 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"hEB" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hEG" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -13034,6 +13720,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"hFs" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "hFM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/ravager,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13051,7 +13741,7 @@
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "hGr" = (
-/obj/structure/fluff/grindwheel,
+/obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -13135,6 +13825,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"hJj" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hJq" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -13170,6 +13864,18 @@
 /obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hKt" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"hKE" = (
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/church/chapel)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -13199,11 +13905,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/vikingarea)
-"hLI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "hLK" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/rtfield)
@@ -13211,13 +13912,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"hLS" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "hLW" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -13227,6 +13921,10 @@
 /obj/effect/rune,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
+"hMB" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "hMD" = (
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -13249,6 +13947,12 @@
 /obj/structure/fluff/walldeco/psybanner,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"hNk" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "hND" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cobbleedge{
@@ -13271,6 +13975,10 @@
 /obj/effect/landmark/start/archivist,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"hNN" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/bath)
 "hNP" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/cobble,
@@ -13305,6 +14013,18 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"hOM" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/obj/item/clothing/suit/roguetown/armor/leather/hide,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "hOP" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /obj/structure/spider/stickyweb,
@@ -13447,6 +14167,15 @@
 /obj/item/natural/rock,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"hTL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "hTT" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/ambush,
 /turf/open/floor/rogue/blocks,
@@ -13454,11 +14183,6 @@
 "hUa" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town)
-"hUp" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/shop)
 "hUq" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
@@ -13467,7 +14191,9 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/machinery/light/rogue/lanternpost,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "hUI" = (
@@ -13487,19 +14213,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"hVd" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/transparent/openspace,
-/area/rogue/indoors)
 "hVj" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -13515,8 +14228,6 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "hVZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/checkeralt{
 	max_integrity = 99999
 	},
@@ -13537,14 +14248,12 @@
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"hWW" = (
-/obj/item/ash,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "hXf" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
@@ -13646,11 +14355,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "iaf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/rtfield)
 "iaj" = (
 /obj/structure/mineral_door/secret/keep,
 /turf/open/floor/rogue/wood,
@@ -13744,9 +14451,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "idR" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -13809,13 +14514,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "ifg" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/turf/closed/mineral/rogue/gem,
+/area/rogue/indoors/shelter/mountains)
 "ifq" = (
 /obj/machinery/light/rogue/oven{
 	desc = "...?";
@@ -13907,11 +14607,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ijU" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3{
-	pixel_x = -34
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"ijW" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard_spear{
+	name = "Butler"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/bog)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ikc" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -13940,11 +14645,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "ikM" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/stairs/stone,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/rtfield)
 "ikP" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
@@ -13976,11 +14679,11 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"ilM" = (
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 6
-	},
-/area/rogue/outdoors/town/roofs)
+"ilL" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/church/chapel)
 "ilO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14006,8 +14709,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "imj" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobble,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "imp" = (
 /obj/structure/bookcase/random,
@@ -14067,12 +14770,34 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"iqs" = (
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"iqB" = (
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
+/obj/item/reagent_containers/powder/sugar,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "iqD" = (
 /obj/structure/closet/crate/chest,
 /obj/item/paper/scroll,
@@ -14096,12 +14821,6 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors/town/shop)
-"irq" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/structure/chair/bench/coucha,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/shop)
 "irz" = (
 /obj/structure/mineral_door/bars{
@@ -14127,40 +14846,21 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "isM" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
 "itv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/shop)
 "itC" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "itR" = (
 /obj/effect/landmark/start/villager{
 	dir = 1
@@ -14171,9 +14871,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving-t"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "iuh" = (
 /obj/machinery/light/rogue/torchholder{
@@ -14230,24 +14928,11 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ivo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stairs,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "ivH" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
 	},
 /area/rogue/outdoors/town)
-"ivL" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/bars/pipe{
-	dir = 4;
-	icon_state = "pipe"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "ivO" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -14279,6 +14964,15 @@
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iww" = (
+/obj/structure/rack/rogue,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iwU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -14288,6 +14982,15 @@
 /obj/item/clothing/head/peaceflower,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"ixg" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "ixt" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/grass,
@@ -14401,7 +15104,7 @@
 /obj/item/seeds/onion,
 /obj/item/seeds/onion,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "izO" = (
 /obj/structure/lever{
 	redstone_id = "gobcell2"
@@ -14415,6 +15118,16 @@
 	dir = 10
 	},
 /area/rogue/outdoors/bog)
+"iAh" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "MEDICAL WING"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iAi" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -14460,6 +15173,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/vikingarea)
+"iCm" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "iCn" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/church,
@@ -14470,9 +15187,7 @@
 /area/rogue/indoors)
 "iCS" = (
 /obj/item/book/rogue/secret/xylix,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/shop)
 "iCX" = (
 /obj/structure/fermenting_barrel/beer,
@@ -14511,6 +15226,10 @@
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"iDV" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "iEg" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr{
@@ -14544,6 +15263,12 @@
 "iEr" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
+"iEB" = (
+/obj/structure/table/wood,
+/obj/item/candle/yellow,
+/obj/item/clothing/neck/roguetown/psicross/eora,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -14613,6 +15338,7 @@
 	dir = 5;
 	pixel_x = -6
 	},
+/obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "iGh" = (
@@ -14649,14 +15375,16 @@
 /area/rogue/indoors/town/manor)
 "iIl" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "iIo" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"iIA" = (
+/obj/structure/fluff/alch,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "iIG" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = -32;
@@ -14743,14 +15471,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "iLX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
 	},
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/rtfield)
 "iLZ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -14780,9 +15505,6 @@
 	},
 /obj/item/reagent_containers/powder/salt,
 /obj/item/reagent_containers/powder/salt,
-/obj/item/roguekey/roomhunt,
-/obj/item/reagent_containers/food/snacks/rogue/pumpkinspice,
-/obj/item/reagent_containers/food/snacks/rogue/pumpkinspice,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "iMA" = (
@@ -14794,14 +15516,10 @@
 /area/rogue/indoors/town/church/chapel)
 "iME" = (
 /obj/structure/fluff/railing/border{
-	dir = 10;
-	icon_state = "border"
+	dir = 5
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "iML" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
@@ -14872,14 +15590,8 @@
 	},
 /area/rogue/indoors)
 "iOq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	icon_state = "woodrailing"
-	},
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cleanable/generic,
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "iOI" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -14927,13 +15639,23 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"iPF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
+"iPI" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "iPJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "iPY" = (
 /turf/open/water/cleanshallow,
@@ -14942,7 +15664,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "iQh" = (
 /obj/structure/closet/crate/chest/crafted,
@@ -14970,23 +15692,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/indoors/town/church/chapel)
-"iRG" = (
-/obj/structure/roguemachine/vendor/blk,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "iRN" = (
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church"
-	},
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/thresher,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "iRR" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -14996,10 +15705,6 @@
 /area/rogue/indoors/town/magician)
 "iRZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/shop)
 "iSb" = (
@@ -15024,12 +15729,11 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "iSJ" = (
-/obj/structure/ladder,
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "iTv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15089,15 +15793,31 @@
 /obj/item/kitchen/spoon/plastic,
 /obj/item/kitchen/spoon/plastic,
 /obj/item/kitchen/spoon/plastic,
-/obj/item/reagent_containers/food/snacks/rogue/cheesebun,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"iVA" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "iVM" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"iVW" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "iWh" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/veteran{
@@ -15106,9 +15826,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "iWj" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "iWw" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -15147,6 +15869,13 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"iXt" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "iXK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -15195,20 +15924,23 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"iYH" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/shop)
 "iYQ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "iZl" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -15245,11 +15977,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"jav" = (
-/obj/structure/table/wood/bar,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "jaw" = (
 /obj/structure/closet/crate/chest,
 /obj/structure/feedinghole,
@@ -15261,13 +15988,9 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "jaU" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cavewet/bogcaves)
 "jbb" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -15295,9 +16018,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"jbp" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors/shelter/mountains)
 "jbv" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15335,6 +16055,10 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"jcT" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "jcX" = (
 /obj/structure/statue/saints/acolyte_l,
 /turf/open/floor/rogue/blocks,
@@ -15362,6 +16086,10 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
+"jdJ" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jdK" = (
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
@@ -15429,6 +16157,14 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"jfV" = (
+/obj/structure/fluff/walldeco/rpainting{
+	pixel_x = -32;
+	name = "The Funniest Thing Ever Seen";
+	desc = "Painting depicting a skull of a pickle... Odd."
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "jfZ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15490,6 +16226,16 @@
 "jis" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"jit" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jiv" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -15509,10 +16255,10 @@
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
-"jjA" = (
-/obj/item/grown/log/tree/stick,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
+"jjF" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "jjS" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood{
@@ -15526,20 +16272,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"jkj" = (
-/obj/structure/roguemachine/vendor/blk3,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "jkv" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 1;
 	pixel_y = 0
-	},
-/obj/structure/bars/pipe{
-	pixel_y = 16
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
@@ -15567,6 +16307,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"jlk" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/obj/item/rogueweapon/mace/wsword,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jlF" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves)
@@ -15585,33 +16333,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "jlY" = (
-/obj/item/roguekey/dungeon{
-	lockid = "woodsm";
-	name = "old key"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
-"jmh" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "jmi" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
-"jmj" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "jmv" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -15650,14 +16379,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"jnv" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/reagent_containers/food/snacks/rogue/breadslice/toast/buttered,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/tavern)
+"jnN" = (
+/obj/machinery/anvil,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"jnO" = (
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/town/roofs)
 "jod" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/feather,
@@ -15672,7 +16400,7 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "jpg" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -15704,9 +16432,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "jpw" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "jpH" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/dirt/road{
@@ -15744,6 +16473,16 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"jrn" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison";
+	name = "Southwest Tower"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "jrs" = (
 /obj/structure/closet/crate/chest,
 /obj/item/seeds/wheat,
@@ -15752,7 +16491,7 @@
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "jrZ" = (
 /obj/structure/stairs{
 	dir = 4
@@ -15771,7 +16510,7 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jsY" = (
 /obj/structure/stairs{
 	dir = 4
@@ -15801,11 +16540,21 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "jtN" = (
+/obj/item/clothing/gloves/roguetown/plate/blk,
 /obj/item/rogueweapon/sword/rapier,
+/obj/item/storage/belt/rogue/pouch/coins/rich,
 /obj/item/rogueweapon/huntingknife/idagger/steel/parrying,
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"jtV" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "juc" = (
 /obj/item/rogueweapon/sickle/scythe{
 	color = gold;
@@ -15817,18 +16566,13 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"juf" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "juj" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"jul" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
 "jvj" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -15873,12 +16617,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/magician)
-"jws" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/town/roofs)
 "jwN" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -15987,12 +16725,19 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jAJ" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "jAN" = (
 /obj/effect/landmark/start/farmer{
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "jAV" = (
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
@@ -16000,6 +16745,12 @@
 "jAY" = (
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"jBh" = (
+/obj/structure/roguemachine/scomm/r{
+	pixel_x = -33
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "jBv" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -16007,12 +16758,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"jBw" = (
-/obj/structure/fermenting_barrel/random,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "jCh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
@@ -16021,16 +16766,20 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/shelter/mountains)
 "jCr" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/structure/chair/bench/church/smallbench{
+	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jCs" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
 /obj/structure/roguemachine/withdraw,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "jCt" = (
@@ -16111,19 +16860,25 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
-"jEB" = (
-/obj/structure/chair/bench{
-	dir = 1;
-	icon_state = "bench"
+"jEe" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"jEB" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "jEL" = (
 /obj/structure/mineral_door/wood{
 	lockid = "farm"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "jFa" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -16186,6 +16941,14 @@
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
+"jHv" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jHz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchbrick,
@@ -16222,9 +16985,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "jIP" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/outdoors/mountains)
+"jJa" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "jJf" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -16243,14 +17014,6 @@
 /obj/item/storage/foodbag/hardtack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"jJM" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/food/snacks/rogue/cheesebun,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/manor)
 "jKw" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile,
@@ -16287,6 +17050,14 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"jMc" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/relentless,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "jMd" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -16298,23 +17069,8 @@
 	},
 /area/rogue/indoors)
 "jMf" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
-"jMk" = (
-/obj/structure/bars/pipe{
-	dir = 4;
-	icon_state = "pipe"
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jMl" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement)
@@ -16328,6 +17084,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"jMs" = (
+/obj/structure/fluff/wallclock/l,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "jMA" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
@@ -16360,6 +17121,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"jNj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "jNl" = (
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -16368,15 +17136,12 @@
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/tribalfort)
 "jNF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church";
-	name = "Temple of the One"
+/obj/structure/bars/tough,
+/obj/effect/decal/cobbleedge{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jNG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16405,6 +17170,12 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"jNV" = (
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "jOn" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -16443,13 +17214,20 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"jPz" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "jPB" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "jPM" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -16519,6 +17297,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
 "jRR" = (
+/obj/structure/bars,
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
@@ -16538,12 +17317,6 @@
 "jSp" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/church/chapel)
-"jSO" = (
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "jTo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/railing/border{
@@ -16577,9 +17350,12 @@
 /area/rogue/outdoors/bog)
 "jUs" = (
 /obj/structure/stairs/stone,
-/obj/structure/mineral_door/secret/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"jUD" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "jUH" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -16590,15 +17366,6 @@
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/shop)
-"jVa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "jVg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -16631,6 +17398,7 @@
 /area/rogue/under/cavewet/bogcaves)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
+/obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "jXe" = (
@@ -16657,6 +17425,10 @@
 /obj/effect/landmark/start/seelie,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"jXB" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/manor)
 "jXK" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/churchrough,
@@ -16671,12 +17443,30 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"jXU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "jXZ" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
 "jYm" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"jYn" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "priest"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "jYE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/tongs,
@@ -16724,6 +17514,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"jZY" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "jZZ" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
@@ -16785,19 +17579,15 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/church/chapel)
+"kch" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "kcj" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
 	},
 /area/rogue/indoors)
-"kck" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/adminordrazine,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "kcm" = (
 /obj/structure/fluff/statue/knightalt,
 /obj/structure/fluff/walldeco/customflag{
@@ -16810,18 +17600,42 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"kcR" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "kcX" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
-"kds" = (
-/obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
+"kdg" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Western Wing";
+	max_integrity = 9999
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
+"kds" = (
+/obj/structure/table/wood,
+/obj/item/dice{
+	pixel_y = 13
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"kdv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/garrison)
 "kdM" = (
 /obj/structure/mineral_door/wood{
@@ -16832,6 +17646,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"kem" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "keq" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -16856,6 +17678,28 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"keW" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "kfe" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/wsword,
@@ -16874,7 +17718,14 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "kfr" = (
-/obj/machinery/light/rogue/forge,
+/obj/structure/rack/rogue,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "kfv" = (
@@ -16901,6 +17752,13 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"kgd" = (
+/obj/structure/gate/bars{
+	gid = "forestgate1";
+	redstone_id = "estatesgatesouth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "kgj" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
@@ -16910,6 +17768,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"kgt" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "kgC" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -16931,8 +17793,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "khc" = (
-/obj/structure/flora/roguetree,
-/turf/open/water/swamp,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "khC" = (
 /obj/structure/flora/newtree,
@@ -16996,7 +17858,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "kkd" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -17082,11 +17944,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"kpr" = (
-/obj/structure/fluff/alch,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "kpZ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -17094,15 +17951,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "kqc" = (
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -17116,11 +17967,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kqq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "kqI" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/roguetree,
@@ -17146,6 +17992,18 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"kqW" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "kra" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/rooftop{
@@ -17189,11 +18047,18 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"ksh" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ksj" = (
 /obj/structure/table/wood{
 	dir = 1;
 	icon_state = "longtable_mid"
 	},
+/obj/item/scomstone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "kst" = (
@@ -17228,8 +18093,7 @@
 /area/rogue/outdoors/town)
 "ksK" = (
 /obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "ksL" = (
 /obj/structure/roguewindow/stained/silver,
@@ -17276,10 +18140,6 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
-"ktN" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/transparent/openspace,
-/area/rogue/indoors)
 "ktW" = (
 /mob/living/carbon/human/species/skeleton/npc/dungeon/boss,
 /turf/open/floor/rogue/blocks,
@@ -17320,15 +18180,24 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"kuV" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "kvh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kvj" = (
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "kvB" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/tile/masonic{
@@ -17359,6 +18228,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog)
+"kwn" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/indoors)
 "kwq" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/town/tavern)
@@ -17369,13 +18244,12 @@
 	},
 /area/rogue/indoors/town/magician)
 "kwN" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kxx" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pitchfork,
@@ -17450,10 +18324,15 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/basement)
 "kzO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/chair/rogue/crafted,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "kzQ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
@@ -17513,7 +18392,9 @@
 /area/rogue/outdoors/rtfield)
 "kBs" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/craftstone/window{
+	icon_state = "stonewindow"
+	},
 /area/rogue/indoors/town/garrison)
 "kBy" = (
 /obj/structure/mineral_door/wood{
@@ -17540,10 +18421,6 @@
 	name = "Ominous Statue"
 	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/bog)
-"kCg" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/turf/open/transparent/openspace,
 /area/rogue/outdoors/bog)
 "kCh" = (
 /obj/structure/bed/rogue/inn/wool,
@@ -17602,6 +18479,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"kEb" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "kEd" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -17640,10 +18521,15 @@
 	},
 /area/rogue/indoors)
 "kFh" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/wood,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/dice,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kFj" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -17651,7 +18537,7 @@
 /obj/item/rogueweapon/stoneaxe/woodcut,
 /obj/item/natural/stone,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "kFn" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/twig,
@@ -17662,23 +18548,22 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"kFr" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "kFD" = (
 /obj/structure/fluff/statue/who,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "kFG" = (
 /obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/bottle/rogue/luckpot,
-/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,
-/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot,
-/obj/item/reagent_containers/glass/bottle/rogue/endurancepot,
-/obj/item/reagent_containers/glass/bottle/rogue/constitutionpot,
-/obj/item/reagent_containers/glass/bottle/rogue/alacritypot,
-/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot,
-/obj/item/reagent_containers/glass/bottle/rogue/virilitypot,
-/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,
-/obj/item/reagent_containers/glass/bottle/rogue/soporpot,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
 "kFS" = (
@@ -17715,6 +18600,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"kHu" = (
+/obj/structure/closet/crate/coffin/vampire{
+	name = "HC"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "kHA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -17736,14 +18627,13 @@
 /area/rogue/indoors/town/garrison)
 "kIf" = (
 /obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
-"kIt" = (
-/obj/effect/decal/stone/mossy,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
 	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "kIu" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/woodturned,
@@ -17769,6 +18659,16 @@
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kIV" = (
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "kJj" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -17871,6 +18771,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"kMv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "kMx" = (
 /obj/structure/roguewindow/stained/zizo,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -17903,12 +18808,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"kNg" = (
-/obj/structure/bed/rogue/shit{
-	name = "makeshift bed"
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town)
 "kNr" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt/road{
@@ -17919,7 +18818,7 @@
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_x = -31
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "kNv" = (
 /obj/effect/landmark/start/adventurer{
@@ -17954,14 +18853,20 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kOA" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "kOB" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
 	},
 /area/rogue/indoors/shelter)
-"kOJ" = (
-/turf/open/floor/rogue/metal/barograte,
-/area/rogue/outdoors/town/roofs)
 "kOK" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17976,7 +18881,7 @@
 	lockid = "farm"
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "kOZ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -18031,16 +18936,6 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/indoors/town/church/chapel)
-"kQC" = (
-/obj/structure/flora/roguegrass,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/dwarfin)
 "kQN" = (
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
@@ -18063,6 +18958,12 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"kRI" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "kRN" = (
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/concrete,
@@ -18131,6 +19032,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"kTx" = (
+/obj/structure/fluff/statue/small,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "kTT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -18227,13 +19132,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kYc" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "kYg" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/church,
@@ -18249,11 +19150,9 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement)
 "kYS" = (
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "kYU" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/rogue/church,
@@ -18319,17 +19218,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"lat" = (
-/obj/structure/bars/pipe{
-	dir = 5;
-	icon_state = "pipe"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "lay" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/shop)
+/obj/machinery/light/rogue/firebowl/standing,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
 "laV" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -18369,11 +19262,9 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
 "ldr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/shop)
+/obj/structure/fluff/millstone,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "lds" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = -33
@@ -18381,18 +19272,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "ldI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/psycross/copper,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
 "lec" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt,
@@ -18405,14 +19288,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
 "leJ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -5
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/chair/bench/coucha,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
 "leV" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -18506,13 +19385,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "lhd" = (
-/obj/structure/fluff/railing/border{
-	dir = 9;
-	icon_state = "border"
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhg" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/bedsheet/rogue/cloth,
@@ -18522,6 +19397,16 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
+"lhy" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH3"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lhO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor"
@@ -18544,13 +19429,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/shop)
 "lis" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/shoes/roguetown/simpleshoes,
-/obj/item/clothing/suit/roguetown/shirt/formal,
-/obj/item/clothing/suit/roguetown/shirt/formal,
-/obj/item/clothing/suit/roguetown/shirt/undershirt,
-/obj/item/clothing/under/roguetown/tights,
-/obj/item/clothing/under/roguetown/tights/formal,
+/obj/structure/bed/rogue/shit,
+/obj/item/soap,
+/obj/effect/landmark/start/servant{
+	dir = 4
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "lix" = (
@@ -18632,13 +19515,26 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "lll" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/chair/bench/coucha/r,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
+"llo" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"llq" = (
+/obj/structure/roguemachine/scomm/l,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/area/rogue/indoors/town/shop)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lls" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -18656,7 +19552,7 @@
 	lockid = "church";
 	name = "Temple of the One"
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "lmo" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -18729,16 +19625,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "loE" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/peppermill,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "loJ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -18799,6 +19689,13 @@
 "lpR" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"lqm" = (
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "lqz" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -18808,6 +19705,16 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"lqJ" = (
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "lqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -18817,6 +19724,12 @@
 "lqR" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/tribalfort)
+"lrj" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "lrs" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/town/sewer)
@@ -18869,9 +19782,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "ltR" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "ltT" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
@@ -18909,6 +19823,19 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"lvF" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "lvO" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobblerock,
@@ -18926,14 +19853,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
 "lwC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/obj/effect/decal/cobbleedge{
+/obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/shop)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "lwV" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood{
@@ -18945,6 +19869,25 @@
 /obj/structure/mirror/fancy,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"lxN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "lxQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -18952,14 +19895,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
 "lyh" = (
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "lyp" = (
 /obj/structure/stairs/stone,
 /obj/machinery/light/rogue/torchholder/l,
@@ -19052,6 +19991,11 @@
 "lAB" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors)
+"lAK" = (
+/obj/structure/table/wood,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lAO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -19124,6 +20068,13 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach)
+"lEs" = (
+/obj/structure/gate/bars{
+	gid = "forestgate2";
+	redstone_id = "estatesgatenorth"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "lEu" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -19194,28 +20145,35 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"lFR" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "lFV" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cavewet/bogcaves/chapel)
-"lGt" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/bog)
+"lGh" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/garrison)
 "lGI" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "lGR" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
+"lGS" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "lGX" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
@@ -19261,7 +20219,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lIH" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile{
@@ -19293,18 +20251,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"lJH" = (
-/obj/structure/bars/pipe,
-/obj/effect/decal/wood/ruinedwood{
-	dir = 1
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+"lJJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "lJO" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -19328,7 +20278,7 @@
 /obj/structure/mineral_door/wood{
 	locked = 1;
 	lockid = "mason";
-	max_integrity = 1000000
+	max_integrity = 9999
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -19339,23 +20289,18 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "lKn" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
+/obj/item/clothing/head/peaceflower,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
 "lKO" = (
 /obj/structure/fluff/statue/why,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "lKR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
 "lKT" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -19370,6 +20315,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"lLl" = (
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "lLp" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/tile,
@@ -19381,7 +20333,7 @@
 /area/rogue/under/town/basement)
 "lLK" = (
 /obj/effect/landmark/start/druid,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "lMc" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -19406,9 +20358,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "lMZ" = (
-/obj/structure/bed/rogue/inn/hay,
-/obj/effect/landmark/start/vagrantlate,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
 /area/rogue/indoors/town/church/chapel)
 "lNs" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -19431,15 +20386,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "lOH" = (
-/obj/structure/flora/roguegrass/fungus_bush,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/item/rogue/instrument/harp,
+/obj/structure/flora/newleaf,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/shelter/rtfield)
 "lOP" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "lOV" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
@@ -19461,22 +20415,6 @@
 "lPu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/tribalfort)
-"lPy" = (
-/obj/structure/bars/pipe{
-	dir = 4;
-	icon_state = "pipe"
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/obj/effect/decal/border/ruinedwood,
-/obj/effect/decal/border/ruinedwood{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -12
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "lPQ" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19529,7 +20467,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "lTj" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp/deep,
@@ -19541,39 +20479,14 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "lTz" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 7
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 9;
-	pixel_x = -28;
-	pixel_y = 20
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "lTE" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"lTF" = (
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -5
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
 "lTZ" = (
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/tile{
@@ -19594,6 +20507,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"lUT" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "lVe" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
@@ -19614,6 +20531,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"lVF" = (
+/obj/structure/composter/full,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "lVS" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks{
@@ -19627,26 +20548,10 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "lWv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
-"lWQ" = (
-/obj/structure/bars/pipe,
-/obj/effect/decal/wood/ruinedwood{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "lXa" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
@@ -19660,6 +20565,13 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"lXh" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "Nelly";
+	health = "1000"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "lXo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -19685,14 +20597,20 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
+"lXX" = (
+/obj/structure/closet/crate/drawer/inn,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "lYl" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "lYs" = (
 /obj/structure/mineral_door/wood{
@@ -19709,7 +20627,7 @@
 /obj/item/roguekey/farm,
 /obj/item/roguekey/farm,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "lYy" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -19769,6 +20687,14 @@
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"maB" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/short,
+/obj/item/rogueweapon/sword/short,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "maJ" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -19780,16 +20706,6 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"mbx" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "mbF" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
@@ -19847,9 +20763,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mdB" = (
-/obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "mdD" = (
 /obj/structure/statue/saints/paladin,
 /turf/open/floor/rogue/blocks,
@@ -19960,10 +20879,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"mhg" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
+"mhi" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/bath)
 "mho" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -19990,13 +20909,6 @@
 /obj/item/chair/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"mhU" = (
-/obj/structure/bars/pipe{
-	dir = 9;
-	icon_state = "pipe"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "mic" = (
 /obj/structure/mineral_door/wood/red{
 	lockid = "graveyard"
@@ -20044,11 +20956,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "mjP" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/shelter/rtfield)
 "mkb" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -20104,12 +21013,6 @@
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"mlM" = (
-/obj/structure/wallladder{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
 "mmb" = (
 /obj/machinery/anvil,
 /turf/open/floor/rogue/blocks,
@@ -20129,6 +21032,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"mnW" = (
+/obj/effect/decal/cobbleedge,
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "mob" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -20148,7 +21060,7 @@
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "mor" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/cudgel,
@@ -20200,6 +21112,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"mpr" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "mpu" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood,
@@ -20216,6 +21134,10 @@
 "mpP" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -20241,14 +21163,10 @@
 	},
 /area/rogue/indoors/town)
 "mrE" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "mrN" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -20259,13 +21177,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "msk" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "msr" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -20293,8 +21206,14 @@
 "mty" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Temple of the One"
+	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
+	dir = 1;
+	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/church/chapel)
 "mtF" = (
@@ -20333,10 +21252,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
-"muC" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "muQ" = (
 /obj/structure/stairs{
 	dir = 8
@@ -20359,9 +21274,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "mwq" = (
-/obj/structure/well,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "mwz" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20421,7 +21336,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "myR" = (
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
@@ -20439,6 +21354,13 @@
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"mzf" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogue/instrument/lute,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mzk" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -20454,13 +21376,9 @@
 	},
 /area/rogue/outdoors/bog)
 "mzx" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "mzE" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/ruinedwood,
@@ -20490,12 +21408,21 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"mCT" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "mDe" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mDo" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "eora3";
@@ -20529,10 +21456,11 @@
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
 "mDY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
+/obj/structure/ladder,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "mEg" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -20551,6 +21479,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
+"mEy" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "mEz" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -20608,25 +21543,18 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "mGn" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "mGA" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_x = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mGV" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/glass/bottle/rogue/virilitypot,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "mHb" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -20653,6 +21581,19 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"mIC" = (
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
+"mJg" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "mJC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile{
@@ -20677,6 +21618,12 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cavewet/bogcaves/chapel)
+"mKz" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "mKR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -20715,13 +21662,14 @@
 "mMj" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"mMs" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "mMv" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
+/obj/machinery/light/rogue/firebowl/church,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "mMJ" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
@@ -20753,12 +21701,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "mNz" = (
-/obj/effect/decal/dirt{
-	dir = 3
-	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/tile/masonic/single,
-/area/rogue/indoors/town/shop)
+/obj/structure/bearpelt,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "mNI" = (
 /obj/structure/statue/saints/magelady_l,
 /turf/open/floor/rogue/blocks,
@@ -20792,7 +21737,6 @@
 /area/rogue/indoors/town/manor)
 "mOT" = (
 /obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/town)
 "mOW" = (
@@ -20848,17 +21792,15 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "mQr" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 2;
-	pixel_y = 16
-	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/rtfield)
 "mQA" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "mRg" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -20917,6 +21859,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"mTj" = (
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/item/riddleofsteel,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "mTO" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 6
@@ -20955,10 +21903,26 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
+"mUC" = (
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "mUQ" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"mUY" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mVa" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
@@ -20972,9 +21936,13 @@
 	},
 /area/rogue/indoors/town)
 "mVz" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mVN" = (
 /obj/item/flint,
 /obj/item/flint,
@@ -20996,6 +21964,17 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
+"mWn" = (
+/obj/structure/mineral_door/wood{
+	dir = 1;
+	locked = 1;
+	lockid = "garrison";
+	name = "West Gatehouse"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "mWx" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -21006,9 +21985,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"mWE" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
-/area/rogue/under/cavewet/bogcaves)
 "mWV" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -21086,10 +22062,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"mZB" = (
-/obj/structure/bars/grille,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "mZE" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -21137,11 +22109,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "nbh" = (
-/obj/effect/decal/dirt{
-	dir = 3
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/shop)
+/obj/structure/fluff/railing/stonehedge,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "nbk" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4;
@@ -21184,13 +22154,6 @@
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"ncu" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/obj/effect/decal/border/ruinedwood{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "nda" = (
 /obj/structure/rack/rogue,
 /obj/item/storage/keyring,
@@ -21215,24 +22178,15 @@
 	},
 /area/rogue/indoors/town/tavern)
 "ndD" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "eora2";
+	aportalid = "eora1";
+	icon = 'icons/roguetown/misc/longsleep2.dmi';
+	icon_state = "longsleep";
+	name = "fairy ring - Eora's Sanctuary"
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -5
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors/town/shop)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "ndL" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/twig,
@@ -21291,10 +22245,26 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"nfb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH6"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nfG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nfN" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "ngi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -21318,14 +22288,13 @@
 	},
 /area/rogue/indoors/town/vault)
 "nhR" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "woodsm"
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town)
 "nhU" = (
 /obj/structure/fermenting_barrel/beer,
 /turf/open/floor/rogue/twig{
@@ -21386,16 +22355,6 @@
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"nkV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6;
-	pixel_x = 25;
-	pixel_y = -13
-	},
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue{
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "nkW" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -21407,10 +22366,23 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
+"nle" = (
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nlf" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
+"nlC" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nlG" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -21433,18 +22405,26 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"nmu" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "nmA" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"nmC" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"nmF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/mountains)
 "nmR" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -21466,6 +22446,15 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"nnb" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "nnk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
@@ -21479,17 +22468,16 @@
 	dir = 8
 	},
 /area/rogue/outdoors/bog)
+"nnI" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "nnQ" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
-"nog" = (
-/obj/item/natural/bone,
-/obj/item/skull,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "noi" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21509,11 +22497,14 @@
 	},
 /area/rogue/indoors/town/garrison)
 "npm" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4;
-	name = "Guest Room"
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/turf/closed,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "npJ" = (
 /obj/structure/table/wood{
@@ -21587,9 +22578,7 @@
 /area/rogue/indoors/town)
 "nrx" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "nrD" = (
 /obj/structure/fermenting_barrel/beer,
@@ -21635,14 +22624,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "ntQ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
+/obj/item/clothing/head/peaceflower,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "ntY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -21653,15 +22637,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
-"nuj" = (
-/obj/structure/fluff/clodpile,
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "nuD" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
@@ -21681,11 +22656,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nuH" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/candle,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nuV" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -21693,8 +22668,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nvd" = (
-/turf/closed/mineral/random/rogue,
-/area/rogue/indoors/town/shop)
+/turf/open/water/bath,
+/area/rogue/indoors/shelter/rtfield)
+"nvf" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors)
+"nvr" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "nvA" = (
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/church,
@@ -21712,6 +22695,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"nvV" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nvW" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
@@ -21738,12 +22727,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"nwK" = (
-/obj/structure/bars/pipe{
-	dir = 10
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "nwT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -21824,9 +22807,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "nxV" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/metal/barograte,
-/area/rogue/indoors/town/shop)
+/obj/machinery/anomalous_crystal,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/rtfield)
 "nyb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -21834,10 +22817,11 @@
 /turf/open/floor/plating/ashplanet/rocky,
 /area/rogue/outdoors/beach)
 "nyc" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/closed/wall/mineral/rogue/decostone/long{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
 	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "nyd" = (
 /obj/structure/glowshroom,
@@ -21900,6 +22884,9 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"nAy" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nAS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -21915,17 +22902,33 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "nBf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nBo" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"nBp" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "nBq" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
@@ -21946,12 +22949,37 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"nBT" = (
+/obj/structure/mineral_door/wood{
+	dir = 4;
+	locked = 1;
+	lockid = "garrison"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "nBW" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "nCh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
+"nCA" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nCN" = (
 /obj/machinery/light/rogue/torchholder{
@@ -22029,6 +23057,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nGn" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "nGw" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -22100,6 +23132,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"nIq" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "nIr" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -22137,15 +23175,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "nJy" = (
-/obj/structure/handcart,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/huntingknife,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "nJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -22168,6 +23205,11 @@
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
+"nKk" = (
+/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "nKt" = (
 /obj/structure/fluff/statue/tdummy2,
 /turf/open/floor/rogue/grass,
@@ -22176,6 +23218,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/blocks{
 	icon_state = "newstone2"
 	},
@@ -22298,9 +23341,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "nPQ" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "nPR" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -22368,19 +23414,10 @@
 	},
 /area/rogue/outdoors/rtfield)
 "nRo" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
+/obj/effect/decal/cobbleedge{
+	dir = 4
 	},
-/obj/item/dice{
-	pixel_y = 13
-	},
-/obj/item/rogueweapon/huntingknife/stoneknife{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/rogue/ratonastick,
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "nRs" = (
 /obj/structure/bed/rogue/shit,
@@ -22414,9 +23451,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nSr" = (
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "nSs" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -22425,6 +23466,16 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"nSy" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/rogueweapon/hammer,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "nSS" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -22455,9 +23506,14 @@
 	},
 /area/rogue/indoors/town/magician)
 "nTR" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nUi" = (
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/tile/masonic{
@@ -22509,6 +23565,17 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"nVf" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "nVF" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -22545,6 +23612,7 @@
 	dir = 9;
 	icon_state = "border"
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "nWP" = (
@@ -22672,6 +23740,13 @@
 /obj/item/rogueweapon/spear/billhook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"nZw" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "nZQ" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -22682,6 +23757,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"nZV" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "oaa" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -22690,18 +23769,27 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"oaU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "oaY" = (
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
-"obq" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+"obi" = (
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"obq" = (
+/obj/structure/fluff/railing/border,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "obA" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -22720,9 +23808,7 @@
 /obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "obT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -22778,9 +23864,6 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
 "odo" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 34
-	},
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
@@ -22822,6 +23905,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -22870,15 +23954,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ogC" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "ohf" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -22898,12 +23983,20 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"ohA" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+"ohw" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable_mid"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"ohA" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "ohE" = (
 /obj/structure/bed/rogue/shit,
 /obj/structure/spider/stickyweb,
@@ -22943,20 +24036,26 @@
 "oif" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"oiC" = (
-/obj/machinery/light/rogue/firebowl/stump,
+"oir" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "garrison"
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town/garrison)
+"oiC" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "oiD" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
 "oiE" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "oiT" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -22964,9 +24063,17 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"oiW" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ojc" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
@@ -22983,15 +24090,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
-"ojO" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/dirt{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "ojU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -23094,7 +24192,7 @@
 /area/rogue/under/cavewet/bogcaves/tomb)
 "onR" = (
 /obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "onT" = (
 /obj/structure/table/wood{
@@ -23116,6 +24214,12 @@
 "ooJ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
+"ooP" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "opc" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/grass,
@@ -23149,6 +24253,13 @@
 /obj/structure/bed/rogue/inn,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
+"oqs" = (
+/obj/structure/ladder,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oqF" = (
 /obj/effect/sunlight,
 /obj/structure/telescope,
@@ -23156,6 +24267,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"oqH" = (
+/obj/structure/chair/bench/church/smallbench,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oqQ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/water/cleanshallow,
@@ -23177,12 +24292,26 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"orE" = (
+/obj/item/rogueweapon/thresher,
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield)
 "orS" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"orT" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "orY" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -23223,6 +24352,13 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"otr" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ots" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
@@ -23274,6 +24410,16 @@
 "ous" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"ouN" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "ouQ" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -23284,11 +24430,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "ovj" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "ovn" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves)
@@ -23324,6 +24468,19 @@
 	name = "ahelp"
 	},
 /area/rogue/under/cavewet/bogcaves)
+"owf" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"owj" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "owk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -23373,7 +24530,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oxR" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/royalblack,
@@ -23381,6 +24538,18 @@
 "oya" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/rtfield)
+"oye" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "thief2";
+	aportalid = "thief1";
+	icon = 'icons/roguetown/misc/tallstructure.dmi';
+	icon_state = "oknightstatue_l";
+	name = "statue"
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
 /area/rogue/outdoors/rtfield)
 "oyi" = (
 /obj/structure/table/wood{
@@ -23394,6 +24563,10 @@
 /obj/item/natural/poo/horse,
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"oys" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "oyE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/cloth,
@@ -23431,6 +24604,12 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"ozt" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "ozw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -23522,6 +24701,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"oBF" = (
+/obj/structure/closet/crate/chest,
+/obj/item/rogueweapon/mace/church{
+	name = "Ringer of Wuthering Heights"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oBU" = (
 /obj/effect/landmark/start/priest,
 /obj/structure/fluff/walldeco/church/line{
@@ -23617,16 +24803,11 @@
 	},
 /area/rogue/indoors/town/vault)
 "oFi" = (
-/obj/structure/fluff/traveltile{
-	aportalgoesto = "maze2";
-	aportalid = "maze1";
-	desc = "Do you wish to give up everything for eternal fortunes?";
-	icon = 'icons/roguetown/topadd/death/vamp-lord.dmi';
-	icon_state = "portal";
-	name = "The Lava Maze"
+/obj/structure/stairs{
+	dir = 8
 	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/shelter/mountains)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "oFw" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -23703,11 +24884,6 @@
 	dir = 10
 	},
 /area/rogue/outdoors/town/roofs)
-"oHB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "oHN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -23725,7 +24901,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "oIv" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "oIY" = (
 /obj/structure/mineral_door/wood{
@@ -23753,19 +24932,25 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"oJM" = (
-/obj/structure/bars/pipe{
-	dir = 1;
-	pixel_y = -8
+"oJH" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/item/rogue/instrument/drum,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "oJO" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
 	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "oKd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -23793,15 +24978,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"oLi" = (
-/obj/item/grown/log/tree/stick,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
+"oLg" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "oLC" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"oLF" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oLO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb{
@@ -23812,10 +25005,9 @@
 	},
 /area/rogue/indoors/town)
 "oMa" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 1
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/statue/myth,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "oMk" = (
 /obj/structure/bars/pipe{
 	dir = 8;
@@ -23917,6 +25109,14 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"oPp" = (
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "oPv" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -23981,12 +25181,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "oRp" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "oRs" = (
 /obj/structure/fluff/clock,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -24060,6 +25256,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"oTE" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "oUc" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -24072,10 +25276,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "oUn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "oUS" = (
 /obj/structure/roguewindow/openclose{
@@ -24244,13 +25454,7 @@
 /obj/item/seeds/pumpkin,
 /obj/item/seeds/pumpkin,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
-"oYP" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
+/area/rogue/outdoors/rtfield)
 "oYV" = (
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood{
@@ -24346,6 +25550,14 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"pbg" = (
+/obj/item/cooking/pan,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pbG" = (
 /obj/structure/bars/passage{
 	redstone_id = "bogguardjaill"
@@ -24414,12 +25626,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "pcQ" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/handcart,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "pcX" = (
 /turf/open/floor/rogue/cobble,
@@ -24434,13 +25642,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pdm" = (
-/obj/structure/mineral_door/wood/fancywood{
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/obj/structure/table/vtable/v2,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "pds" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -24499,10 +25703,10 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/item/handheld_bell,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
+/obj/item/handheld_bell,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "pfx" = (
@@ -24549,13 +25753,16 @@
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
+"pho" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
 "pht" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
-"phD" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/vikingarea)
 "phR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -24649,6 +25856,14 @@
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bog)
+"pkt" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "pku" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town/manor)
@@ -24680,21 +25895,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"plz" = (
-/obj/structure/wallladder{
-	dir = 8;
-	pixel_y = 22
+"plk" = (
+/obj/structure/long_sleep,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"plR" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
-"plT" = (
-/obj/effect/decal/border/ruinedwood{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -12
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "pmj" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -24739,6 +25949,9 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"pno" = (
+/turf/closed/mineral/rogue,
+/area/rogue/indoors/town)
 "pnD" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -24905,12 +26118,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"pto" = (
-/obj/structure/bed/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "ptq" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -24965,6 +26172,12 @@
 	lockid = "church"
 	},
 /turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
+"put" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
 "pvd" = (
 /obj/structure/fluff/railing/border{
@@ -25105,6 +26318,12 @@
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"pzi" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "pzn" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -25162,10 +26381,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"pAn" = (
-/obj/item/grown/log/tree/stick,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "pAA" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -25195,6 +26410,17 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"pBC" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "pBJ" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -25219,6 +26445,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"pCH" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "pCW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -25238,23 +26477,22 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
-"pDv" = (
-/obj/structure/bed/rogue/shit{
-	name = "makeshift bed"
-	},
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "pDy" = (
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "pDA" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/storage/roguebag{
-	pixel_x = 9;
-	pixel_y = -7
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "pDF" = (
@@ -25271,6 +26509,29 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"pDM" = (
+/obj/structure/fluff/traveltile{
+	aportalgoesto = "wh1";
+	aportalid = "wh2";
+	name = "THE COFFIN OF EVERY SINGLE CATHERINE";
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
+"pDO" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "pDP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8;
@@ -25303,6 +26564,10 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"pEX" = (
+/obj/structure/fluff/walldeco/rpainting/crown,
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town)
 "pFS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/poison,
 /turf/open/floor/rogue/church,
@@ -25345,6 +26610,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
+"pHF" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "pHI" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/tile{
@@ -25384,14 +26655,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"pIV" = (
-/obj/structure/rack/rogue,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "pJa" = (
 /obj/effect/landmark/start/triballate,
 /turf/open/floor/rogue/dirt/road{
@@ -25429,9 +26692,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "pKQ" = (
-/obj/item/reagent_containers/food/snacks/smallrat/dead,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pKR" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -25450,6 +26713,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"pLf" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "pLh" = (
 /obj/structure/fluff/statue/psy{
 	desc = "A statue in the likeness of Psydon.";
@@ -25473,6 +26746,16 @@
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"pLK" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "INDOOR GARDEN"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH4"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pMi" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone,
@@ -25486,9 +26769,22 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pMn" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/thresher,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/sickle,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "pMx" = (
 /obj/structure/fluff/statue/secret{
 	color = "#3F3E3D";
@@ -25614,10 +26910,8 @@
 	},
 /area/rogue/indoors/town/tavern)
 "pPO" = (
-/obj/structure/rack/rogue,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/outdoors/mountains)
 "pQd" = (
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/town)
@@ -25768,18 +27062,18 @@
 /obj/item/quiver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"pUQ" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "pVg" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"pVv" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/bog)
 "pVE" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/fluff/railing/border{
@@ -25787,12 +27081,24 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"pVF" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pVW" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"pWm" = (
+/obj/structure/chair/wood,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "pWy" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -25899,6 +27205,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qab" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "qad" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -25926,7 +27240,7 @@
 /obj/item/rogueweapon/sickle,
 /obj/item/rogueweapon/sickle,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "qaM" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
@@ -25998,11 +27312,6 @@
 /obj/structure/statue/saints/mother,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb)
-"qcG" = (
-/obj/item/chair/rogue/crafted,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "qcO" = (
 /obj/item/natural/feather,
 /turf/open/floor/rogue/dirt,
@@ -26013,7 +27322,7 @@
 	lockid = "butcher"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "qdb" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -26068,27 +27377,14 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"qeH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "qeY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "qfh" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7;
@@ -26132,9 +27428,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cave)
-"qgD" = (
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town)
 "qgH" = (
 /obj/structure/winch{
 	gid = "forestgate2";
@@ -26288,9 +27581,10 @@
 /turf/closed/mineral/rogue/gem,
 /area/rogue/under/cavewet/bogcaves)
 "qls" = (
-/obj/structure/bed/rogue/shit,
-/obj/item/reagent_containers/food/snacks/rogue/ratonastick,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qlt" = (
 /obj/structure/rack/rogue/shelf/big,
@@ -26377,6 +27671,16 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"qof" = (
+/obj/structure/rack/rogue,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qoi" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -26394,16 +27698,25 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town)
-"qos" = (
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "qoE" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"qoP" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qoW" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -26412,26 +27725,24 @@
 /obj/item/storage/bag/tray,
 /obj/item/storage/bag/tray,
 /obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "qoZ" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/bed/rogue,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "qpf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "qpt" = (
-/obj/effect/decal/cobbleedge,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/closed,
+/area/rogue/indoors/town/garrison)
 "qpJ" = (
 /obj/structure/stairs/fancy/l{
 	dir = 1
@@ -26452,11 +27763,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "qpX" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/turf/open/lava{
+	name = "an actual pit of lava"
 	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "qqb" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/water/cleanshallow,
@@ -26535,7 +27845,9 @@
 	},
 /area/rogue/indoors)
 "qrA" = (
-/obj/structure/roguewindow,
+/obj/structure/roguewindow/openclose{
+	dir = 4
+	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qrC" = (
@@ -26560,6 +27872,11 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qsC" = (
+/obj/machinery/anvil,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qsI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -26597,6 +27914,10 @@
 "qtE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
+"qtK" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/manor)
 "qtT" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -26620,6 +27941,12 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"quy" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/church/chapel)
 "quC" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
@@ -26634,18 +27961,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "quL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "quT" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/bog)
@@ -26667,7 +27991,7 @@
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "qvm" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -26702,13 +28026,8 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "qwp" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck{
-	tame = 1
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "qwr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -26745,9 +28064,24 @@
 /obj/item/clothing/gloves/roguetown/chain,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
+"qxL" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "qxN" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue,
 /area/rogue/indoors/town/manor)
+"qxO" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/iron,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qxZ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1;
@@ -26760,6 +28094,18 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"qyS" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "qzd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -26782,18 +28128,33 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"qzx" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "qzy" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "qzF" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "qzH" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
+	},
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "qzV" = (
 /turf/closed/wall/mineral/rogue/wood,
@@ -26854,13 +28215,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"qCJ" = (
-/obj/structure/stairs/stone,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "qCN" = (
 /obj/structure/stairs{
 	dir = 1
@@ -26868,17 +28222,22 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "qCT" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples3,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/fence{
+	dir = 1;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "qDh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "qDn" = (
-/obj/structure/flora/wildplant/wild_poppy,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/xbow{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "qDx" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
@@ -26898,6 +28257,18 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"qEj" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"qEq" = (
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "qEz" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/town/shop)
@@ -26913,12 +28284,6 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs)
-"qFJ" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "qFK" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/churchbrick,
@@ -26933,11 +28298,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "qGh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/structure/chair/bench/church/mid{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "qGD" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -27006,21 +28371,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "qIO" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/powder/sugar,
-/obj/item/reagent_containers/powder/sugar,
-/obj/item/reagent_containers/powder/sugar,
-/obj/item/reagent_containers/powder/sugar,
+/obj/item/soap,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "qJp" = (
@@ -27063,10 +28414,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "qKU" = (
-/obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "qLl" = (
 /obj/effect/decal/cobbleedge{
@@ -27095,8 +28447,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
 "qLF" = (
-/obj/structure/roguewindow/stained/silver,
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qLP" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -27109,10 +28466,6 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
-"qMc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "qMe" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -27123,12 +28476,16 @@
 "qMJ" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"qNz" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+"qNF" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "BASEMENT"
 	},
-/area/rogue/indoors)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/shelter/rtfield)
 "qOa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -27149,6 +28506,13 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"qOT" = (
+/obj/structure/rack/rogue,
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "qOW" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
@@ -27157,7 +28521,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "qPt" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -27204,6 +28568,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"qQw" = (
+/obj/structure/bookcase/random{
+	desc = s
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "qQV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -27223,16 +28593,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "qRm" = (
-/obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/metal,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "qRp" = (
+/obj/structure/chair/bench,
 /obj/structure/fluff/railing/stonehedge{
-	pixel_y = -8
+	pixel_y = 5;
+	dir = 1
 	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "qRD" = (
 /obj/structure/fermenting_barrel/random/beer,
@@ -27272,17 +28643,14 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
+"qSE" = (
+/obj/structure/table/vtable,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "qSU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
-"qSW" = (
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "qTb" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -27347,14 +28715,6 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"qVQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "qWh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1
@@ -27369,6 +28729,11 @@
 	muddy = true
 	},
 /area/rogue/outdoors/rtfield)
+"qWS" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "qXx" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -27413,10 +28778,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "qYw" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/spear,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield)
 "qYC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /turf/open/floor/rogue/herringbone,
@@ -27436,6 +28799,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"qYQ" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "qZh" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble,
@@ -27527,24 +28894,28 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "rcr" = (
-/obj/structure/flora/roguetree,
-/obj/structure/flora/roguetree,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/mountains)
+"rcx" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rcC" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
-"rcT" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "rcU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -27613,13 +28984,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"ren" = (
-/obj/item/skull,
-/obj/item/natural/bone,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "ret" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -27637,14 +29001,6 @@
 "reO" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town)
-"reT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "reW" = (
 /obj/item/grown/log/tree/stick,
 /obj/item/grown/log/tree/stick,
@@ -27657,6 +29013,14 @@
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
+"rfd" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH6";
+	name = "WH Lever 6";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "rfl" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/bog)
@@ -27664,10 +29028,9 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rfO" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rfQ" = (
 /obj/effect/decal/cleanable/food/salt,
 /turf/open/floor/rogue/naturalstone,
@@ -27697,14 +29060,11 @@
 	},
 /area/rogue/indoors/town)
 "rgO" = (
-/obj/structure/closet/crate/chest,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
 	},
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "rgP" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue,
@@ -27785,7 +29145,7 @@
 /area/rogue/under/town/basement)
 "rkf" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/water/cleanshallow,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/chapel)
 "rkp" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -27866,8 +29226,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "rmJ" = (
-/obj/structure/flora/wildplant/wild_herbs,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "rmK" = (
 /obj/structure/flora/wildplant/wild_herbs,
@@ -27891,6 +29254,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"rni" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rns" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/globe,
@@ -27906,15 +29276,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"roj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/under/cavewet/bogcaves)
 "rou" = (
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"roG" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bull,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "roO" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -27943,6 +29314,13 @@
 "rpp" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"rps" = (
+/obj/structure/chair/wood/rogue/chair3,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "rpv" = (
 /obj/item/roguekey/blacksmith/town,
 /obj/item/roguekey/blacksmith/town,
@@ -27985,11 +29363,20 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "rqX" = (
-/obj/structure/bed/rogue/shit,
-/obj/effect/landmark/start/servant{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rrg" = (
 /obj/structure/mineral_door/wood/window{
@@ -28151,21 +29538,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"rwr" = (
-/obj/structure/bars/pipe{
-	dir = 9;
-	icon_state = "pipe"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
-"rwv" = (
-/obj/effect/decal/stone/mossy,
-/obj/effect/decal/dirt/road,
-/obj/effect/decal/dirt,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+"rwD" = (
+/obj/machinery/light/rogue/smelter/great,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "rwH" = (
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
@@ -28192,6 +29568,16 @@
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"rxa" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rxc" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -28207,9 +29593,12 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "rxp" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4;
+	icon_state = "chair1"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rxq" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -28236,6 +29625,12 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"rxS" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ryc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
@@ -28247,6 +29642,13 @@
 "ryg" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"ryE" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "ryI" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -28283,14 +29685,6 @@
 "rAz" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
-"rAP" = (
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/town/roofs)
 "rBh" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cavewet/bogcaves/tomb)
@@ -28331,13 +29725,12 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"rCo" = (
-/obj/effect/decal/dirt/road,
-/obj/effect/decal/dirt{
-	dir = 2
+"rCc" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/church/chapel)
 "rCL" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -28366,6 +29759,19 @@
 "rDv" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"rDD" = (
+/obj/machinery/light/rogue/lanternpost{
+	pixel_x = 15
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
+"rDU" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 8;
+	lockid = "farm"
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/rtfield)
 "rDV" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/under/town/basement)
@@ -28394,7 +29800,7 @@
 	dir = 5;
 	icon_state = "border"
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "rEA" = (
 /obj/structure/bed/rogue/shit/bier,
@@ -28454,21 +29860,16 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "rGY" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "rHi" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "rHj" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/bookcase/random,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "rHM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -28532,6 +29933,7 @@
 /area/rogue/indoors/town/dwarfin)
 "rKn" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -28572,10 +29974,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
-"rMd" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "rMl" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -28635,6 +30033,10 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/tavern)
+"rNT" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/manor)
 "rOb" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -28642,24 +30044,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
 "rOe" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
+/obj/structure/rack/rogue,
+/obj/item/storage/belt/rogue/pouch/coins/mid,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/obj/item/clothing/head/helmet/skull,
-/obj/item/reagent_containers/food/snacks/crow{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet/bogcaves)
-"rOs" = (
-/obj/effect/decal/dirt{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rOt" = (
 /obj/structure/stairs{
 	dir = 1;
@@ -28674,14 +30064,6 @@
 "rOF" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/bog)
-"rOQ" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "rOU" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -28709,6 +30091,10 @@
 /obj/structure/crabnest,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
+"rPU" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/carpet/inn,
+/area/rogue/indoors/town/church/chapel)
 "rPX" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -28754,9 +30140,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
 "rRA" = (
-/obj/effect/landmark/start/grandtemplar,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bookcase,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "rRB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -28770,22 +30156,31 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "rRD" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"rRM" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rSc" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "rSg" = (
-/obj/structure/chair/bench/church/mid{
+/obj/structure/chair/bench/church/r{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "rSn" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -28814,13 +30209,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"rSN" = (
-/obj/structure/table/wood,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "rSO" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -28832,25 +30220,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "rST" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/outdoors/mountains)
 "rSX" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
 /turf/open/floor/rogue/cobble/mossy,
@@ -28858,9 +30229,7 @@
 "rTm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/fluff/statue/tdummy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "rTv" = (
 /obj/structure/fluff/traveltile/vampire{
@@ -28899,15 +30268,22 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"rUm" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "rUn" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
 "rUr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
+/obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "rUt" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
@@ -29006,6 +30382,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"rXt" = (
+/obj/structure/well/fountain{
+	pixel_x = -14
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/rtfield)
 "rXE" = (
 /mob/living/carbon/human/species/human/northern/searaider,
 /turf/open/floor/rogue/cobble,
@@ -29024,6 +30406,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"rYs" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "rYt" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -29114,6 +30504,12 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bog)
+"saP" = (
+/obj/structure/flora/tree/crystal{
+	name = "Drained Bough"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "saS" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -29124,21 +30520,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
-"sba" = (
-/obj/structure/bars/pipe,
-/obj/effect/decal/wood/ruinedwood{
-	dir = 1
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = 0
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "sby" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/herringbone,
@@ -29148,12 +30529,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/bogcaves/tomb/martyr)
 "sbF" = (
-/obj/structure/roguemachine/withdraw{
-	pixel_x = -1;
-	pixel_y = 31
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "scd" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
@@ -29163,10 +30541,6 @@
 	muddy = true
 	},
 /area/rogue/indoors)
-"scl" = (
-/obj/structure/roguewindow/stained/zizo,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cavewet/bogcaves)
 "sct" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -29183,14 +30557,6 @@
 /mob/living/carbon/human/species/human/northern/searaider/brute,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"scF" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/item/reagent_containers/food/snacks/rogue/sandwich/cheese,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/tavern)
 "scN" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -29220,7 +30586,7 @@
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
 	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "sdj" = (
 /obj/structure/fluff/railing/border{
@@ -29228,6 +30594,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/bog)
+"sdl" = (
+/obj/machinery/light/rogue/smelter,
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sdo" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/rack/rogue/shelf/big,
@@ -29276,12 +30647,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "seC" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "seR" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/cobblerock,
@@ -29371,6 +30741,17 @@
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
+"shJ" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "shV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -29406,6 +30787,10 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"siG" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/church/chapel)
 "siI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/crate/roguecloset/inn,
@@ -29425,7 +30810,7 @@
 "sjH" = (
 /obj/structure/roguewindow,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "sjP" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
@@ -29498,17 +30883,12 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
 "sme" = (
-/obj/structure/closet/crate/chest{
-	lockid = "keep_armory"
+/obj/structure/mineral_door/wood{
+	locked = 1
 	},
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/butter,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/spacevine,
+/turf/open/floor/rogue/cobble,
+/area/rogue)
 "smi" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/ruinedwood{
@@ -29538,10 +30918,6 @@
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"snb" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cavewet/bogcaves)
 "snj" = (
 /obj/structure/bars/passage{
 	redstone_id = "tourneybottom"
@@ -29686,6 +31062,13 @@
 "squ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
+"sqL" = (
+/obj/item/paper{
+	name = "HIT THINE BELL";
+	desc = "AND LET EVERYONE KNOW YOU HAVE BESTED WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sqW" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
 /area/rogue/outdoors/mountains)
@@ -29726,6 +31109,36 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"ssD" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"ssF" = (
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/item/trash/applecore,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "ssG" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -29766,6 +31179,15 @@
 "sue" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors)
+"sug" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sux" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -29787,9 +31209,7 @@
 /area/rogue/outdoors/beach)
 "suN" = (
 /obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "suY" = (
 /obj/structure/fluff/railing/border{
@@ -29814,6 +31234,25 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"svL" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "svX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -29854,29 +31293,24 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/tribalfort)
 "sxM" = (
-/obj/structure/fluff/walldeco/painting/queen{
-	pixel_y = 32
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "sxR" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
 	icon_state = "barsbent";
 	layer = 2.81;
-	max_integrity = 1000000
+	max_integrity = 99999
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -29901,10 +31335,13 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
-"syF" = (
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
+"syt" = (
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "syL" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/woodturned,
@@ -29928,6 +31365,10 @@
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
+"szJ" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "szM" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/dirt,
@@ -29953,6 +31394,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"sAC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "sAP" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -29989,6 +31436,14 @@
 /obj/item/clothing/cloak/apron/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"sBJ" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sBX" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -30010,10 +31465,10 @@
 /area/rogue/outdoors/town)
 "sDa" = (
 /obj/effect/decal/cobbleedge{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "sDd" = (
 /obj/structure/mineral_door/wood{
 	dir = 8;
@@ -30032,6 +31487,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"sDR" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "sDX" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/cobble,
@@ -30104,6 +31566,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"sGx" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sGM" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
@@ -30163,13 +31629,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "sIE" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
 	},
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
-	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "sIG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -30185,14 +31649,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
-"sIT" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "sJZ" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -30207,6 +31663,10 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
+"sKs" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "sKL" = (
 /obj/structure/chair/wood/rogue{
@@ -30234,7 +31694,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/tribalfort)
 "sLc" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "sLF" = (
@@ -30248,6 +31710,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"sLM" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "sMb" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/wood,
@@ -30260,12 +31726,6 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
-"sNb" = (
-/obj/effect/decal/dirt{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "sNp" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -30280,6 +31740,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
+"sNG" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "sNY" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -30290,6 +31761,13 @@
 /obj/effect/landmark/start/seelielate,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"sOh" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sOy" = (
 /obj/structure/closet/crate/chest,
 /obj/item/clothing/mask/cigarette/pipe/westman,
@@ -30297,14 +31775,10 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
-"sPd" = (
-/obj/effect/decal/border/ruinedwood{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
+"sOY" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/church/chapel)
 "sPj" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt,
@@ -30329,11 +31803,6 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
-"sPV" = (
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 5
-	},
-/area/rogue/outdoors/town/roofs)
 "sPZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood{
@@ -30348,6 +31817,22 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
+"sQI" = (
+/obj/structure/fluff/millstone{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/structure/table/wood{
+	dir = 9;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
+"sQV" = (
+/obj/structure/fluff/wallclock/r,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/stairs{
 	dir = 8
@@ -30361,10 +31846,14 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
-"sRX" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
+"sRU" = (
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "sSe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -30396,6 +31885,10 @@
 /obj/structure/toilet,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"sSL" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/church/chapel)
 "sSS" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave)
@@ -30486,6 +31979,16 @@
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/outdoors/bog)
+"sVd" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH7"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "sVB" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -30499,6 +32002,15 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"sWi" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "sWl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
@@ -30526,11 +32038,25 @@
 "sXz" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town)
+"sXG" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "sXU" = (
 /obj/structure/fermenting_barrel/random,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"sXW" = (
+/obj/structure/rack/rogue,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "sYa" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -30542,6 +32068,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town)
+"sYv" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "sYw" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
@@ -30551,6 +32084,10 @@
 "sYA" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
@@ -30577,6 +32114,19 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"sZk" = (
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
+"sZv" = (
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/item/rogueweapon/huntingknife,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "sZI" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -30591,10 +32141,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tak" = (
-/obj/structure/chair/bench/church{
+/obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	icon_state = "churchslate"
+	},
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "tat" = (
 /obj/structure/fluff/railing/border{
@@ -30606,14 +32160,8 @@
 	},
 /area/rogue/indoors/town/garrison)
 "taw" = (
-/obj/structure/closet/crate/chest{
-	lockid = "keep_armory"
-	},
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/woodturned,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "taK" = (
 /obj/structure/fluff/railing/border{
@@ -30684,6 +32232,12 @@
 	muddy = true
 	},
 /area/rogue/indoors/town)
+"tcq" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/wood,
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/water/bath,
+/area/rogue/indoors/town/church/chapel)
 "tcM" = (
 /obj/structure/stairs{
 	dir = 8
@@ -30703,6 +32257,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "tdz" = (
@@ -30716,10 +32271,15 @@
 	},
 /area/rogue/indoors)
 "tdJ" = (
-/obj/structure/closet/crate/chest,
-/obj/item/ingot/silver,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tei" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/rogue/ruinedwood{
@@ -30771,11 +32331,11 @@
 "tfp" = (
 /obj/structure/table/wood{
 	dir = 1;
-	icon_state = "longtable"
+	icon_state = "largetable"
 	},
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/natural/feather,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "tfH" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/twig,
@@ -30789,6 +32349,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"tfW" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "tfX" = (
 /obj/structure/stairs{
 	dir = 8
@@ -30834,10 +32403,9 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "tiH" = (
-/turf/closed/wall/mineral/rogue/decostone/end{
-	dir = 4
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/coffin/sarcophagus/dungeon,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tiZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -30933,14 +32501,22 @@
 /obj/structure/chair/bench/church{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "tlb" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"tlB" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "tlN" = (
 /obj/structure/ladder{
 	pixel_y = 18
@@ -30948,8 +32524,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "tlQ" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "tlX" = (
 /obj/structure/table/wood{
@@ -30983,6 +32562,11 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"tnh" = (
+/obj/structure/table/vtable/v2,
+/mob/living/carbon/human/species/skeleton/no_equipment,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "tnn" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/cobble,
@@ -31020,41 +32604,26 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/dwarfin)
-"tnG" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/obj/effect/decal/wood/ruinedwood/turned,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "tnQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"tnW" = (
-/obj/structure/closet/crate/chest/crafted,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "tou" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"tox" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
-"tpd" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "tpy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31077,12 +32646,6 @@
 	muddy = true
 	},
 /area/rogue/under/town/basement)
-"tqB" = (
-/obj/effect/decal/dirt{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "tqF" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/woodturned,
@@ -31164,6 +32727,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ttW" = (
+/mob/living/simple_animal/hostile/rogue/gravelord{
+	name = "The Erlking";
+	health = 1500
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tuj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/twig,
@@ -31266,12 +32836,6 @@
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"twS" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "twT" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shovel,
@@ -31280,10 +32844,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "twX" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "txa" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -31353,9 +32918,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"tyH" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet/bogcaves)
 "tyK" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -31429,6 +32991,14 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
+"tAs" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "tAt" = (
 /obj/structure/fluff/millstone{
 	pixel_y = 7
@@ -31437,16 +33007,22 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"tAu" = (
-/obj/effect/decal/remains/saiga,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "tAN" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"tAT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/obj/item/signal_horn,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tAX" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road{
@@ -31519,18 +33095,25 @@
 	},
 /area/rogue/outdoors/beach)
 "tCz" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "manor";
-	name = "Servant's Room"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/manor)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "tCG" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"tCN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "tCX" = (
 /obj/structure/spacevine{
 	opacity = 1
@@ -31556,6 +33139,10 @@
 /area/rogue/outdoors/rtfield)
 "tDq" = (
 /obj/structure/roguewindow/openclose,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tDJ" = (
@@ -31593,7 +33180,7 @@
 /obj/item/seeds/pipeweed,
 /obj/item/seeds/pipeweed,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "tEH" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road{
@@ -31638,6 +33225,8 @@
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
+/obj/item/listenstone,
+/obj/item/scomstone,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "tGg" = (
@@ -31725,24 +33314,55 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tJw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	redstone_id = "WH1";
+	name = "WH Lever 1";
+	pixel_x = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "tJx" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tJC" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors)
+/obj/structure/chair/bench{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "tJJ" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"tKf" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"tKg" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "tKu" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -31768,15 +33388,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/indoors)
-"tLP" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "tLU" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -31849,16 +33460,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town)
-"tNI" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "tNP" = (
 /obj/structure/fluff/walldeco/serpflag,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -31892,6 +33493,10 @@
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"tOv" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "tOz" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/manor)
@@ -31956,6 +33561,11 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"tSN" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "tTb" = (
 /obj/machinery/light/rogue/wallfire/candle/l{
 	light_on = 0;
@@ -31996,12 +33606,11 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tUp" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/effect/decal/cobbleedge{
-	dir = 10
+/obj/structure/stationary_bell{
+	name = "Bell of Wuthering Heights"
 	},
-/turf/open/water/swamp,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "tUw" = (
 /obj/structure/fluff/littlebanners/greenwhite,
 /turf/open/floor/rogue/blocks,
@@ -32010,9 +33619,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/rtfield)
 "tUR" = (
-/obj/item/candle/lit,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "tUT" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguecoin/copper/pile,
@@ -32034,6 +33643,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors/town)
+"tVu" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "tVx" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -32042,12 +33658,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
-"tVJ" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "tVN" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
@@ -32152,16 +33762,20 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tZZ" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
-"uaj" = (
-/obj/structure/fluff/grindwheel,
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
-	},
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"uai" = (
+/obj/structure/bars/passage/shutter{
+	density = 0;
+	icon_state = "shutter1";
+	redstone_id = "estategatew"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
+"uaj" = (
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "uaL" = (
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
@@ -32189,15 +33803,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors)
-"ubK" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/obj/effect/decal/border/ruinedwood{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "ubZ" = (
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/chapel)
@@ -32284,6 +33889,14 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"ueS" = (
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "ueX" = (
 /obj/structure/long_sleep,
 /turf/open/floor/rogue/grass,
@@ -32304,16 +33917,14 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"ufN" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "ufR" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
-"ufU" = (
-/obj/structure/bed/rogue/shit{
-	name = "makeshift bed"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/town/roofs)
 "ugm" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/woodturned,
@@ -32373,6 +33984,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uiv" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/sword/long,
+/obj/item/rogueweapon/mace/steel,
+/obj/item/listenstone,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "uiN" = (
 /obj/effect/spawner/lootdrop/roguetown/sarcophagi,
 /turf/open/floor/rogue/blocks,
@@ -32386,6 +34004,10 @@
 /obj/item/candle/lit,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"uje" = (
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "ujh" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
@@ -32446,21 +34068,36 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"ukL" = (
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "ukU" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"ulj" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH2";
+	name = "WH Lever 2";
+	pixel_x = 16
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ulu" = (
-/obj/machinery/light/rogue/firebowl,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church"
+	},
+/obj/item/seeds/sweetleaf,
+/obj/item/seeds/sweetleaf,
+/obj/item/seeds/sweetleaf,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
-"ulG" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/turf/closed,
-/area/rogue/indoors/shelter/mountains)
 "ulY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -32471,19 +34108,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"umY" = (
-/obj/effect/decal/dirt/road,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
-"unk" = (
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "unm" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
@@ -32538,7 +34162,7 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "uoX" = (
 /obj/structure/bars/grille,
 /obj/machinery/light/rogue/torchholder/c,
@@ -32559,6 +34183,14 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"upI" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "upU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/asteroid/elite/broodmother,
 /turf/open/floor/rogue/blocks,
@@ -32602,21 +34234,30 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"ure" = (
+/obj/structure/table/wood{
+	dir = 2;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "urr" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "urF" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/item/rogueweapon/hammer,
-/obj/machinery/light/rogue/torchholder{
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
 "urH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -32743,7 +34384,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "uuy" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/railing/wood{
@@ -32770,25 +34411,10 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
-"uuW" = (
-/obj/structure/wallladder,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
-"uuY" = (
-/obj/structure/wallladder{
-	dir = 8;
-	pixel_y = 22
-	},
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roof"
-	},
-/area/rogue/outdoors/town/roofs)
 "uvu" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	dir = 8
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uvB" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -32803,15 +34429,14 @@
 "uvF" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/shop)
+"uvI" = (
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "uwa" = (
-/obj/structure/mineral_door/wood/fancywood{
-	locked = 1;
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/outdoors/rtfield)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uwn" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -32860,23 +34485,18 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "uxV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/area/rogue/outdoors/mountains)
 "uxW" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "uxZ" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/candle,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "uya" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -32895,6 +34515,12 @@
 /obj/item/roguekey/church,
 /obj/item/paper/confession,
 /obj/item/roguekey/priest,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "uyw" = (
@@ -32925,11 +34551,20 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "uzT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/powder/ozium{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uAe" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -32994,16 +34629,17 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/vikingarea)
 "uBu" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/flint,
-/obj/item/candle/skull,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/rtfield)
 "uBv" = (
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/church,
+/obj/structure/fluff/alch,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "uBE" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -33050,13 +34686,21 @@
 	},
 /area/rogue/indoors)
 "uDi" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "uDv" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"uDw" = (
+/obj/structure/fluff/dryingrack,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uDy" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
@@ -33073,16 +34717,6 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town)
-"uDV" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
 "uEG" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -33097,16 +34731,18 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "uEX" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "uFe" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/shelter/mountains)
 "uFp" = (
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "uFE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/shelter/mountains)
@@ -33127,9 +34763,8 @@
 	},
 /area/rogue/outdoors/bog)
 "uGf" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "uGo" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -33167,6 +34802,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"uHa" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
 "uHb" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -33178,23 +34819,19 @@
 /area/rogue/indoors/town/church/chapel)
 "uHg" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHh" = (
 /obj/structure/feedinghole,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "uHj" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "uHk" = (
-/obj/structure/fluff/railing/stonehedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "uHF" = (
 /obj/structure/statue/saints/lady_r,
 /turf/open/floor/rogue/blocks,
@@ -33319,10 +34956,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"uMF" = (
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors)
 "uMO" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
@@ -33348,6 +34981,21 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/tomb)
+"uOc" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/spear/billhook,
+/obj/item/rogueweapon/spear/billhook,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"uOu" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/garrison)
 "uOB" = (
 /obj/structure/stairs{
 	dir = 4
@@ -33380,10 +35028,31 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "uPa" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/landmark/start/druid,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
+"uPi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/outdoors/mountains)
 "uPj" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /turf/open/floor/rogue/hexstone,
@@ -33461,6 +35130,16 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
+"uRR" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "uRZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/dirt/road{
@@ -33471,10 +35150,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/rtfield)
 "uSx" = (
-/obj/structure/rack/rogue,
-/obj/item/storage/backpack/rogue/backpack/surgery,
-/obj/item/needle,
-/obj/item/rope,
+/obj/structure/chair/bench/church/r{
+	dir = 1
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
@@ -33483,6 +35161,14 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/basement)
+"uTc" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/outdoors/mountains)
 "uTf" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt,
@@ -33510,10 +35196,8 @@
 /area/rogue/indoors/town/dwarfin)
 "uTT" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 1;
+	icon_state = "churchslate"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -33552,6 +35236,18 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"uVj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uVn" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/naturalstone,
@@ -33559,6 +35255,14 @@
 "uVq" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/indoors/town/church/chapel)
+"uVs" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "uVz" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobble,
@@ -33568,7 +35272,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "uVN" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/woodturned,
@@ -33593,6 +35297,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uWj" = (
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/shield{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "uWE" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/shop)
@@ -33602,7 +35312,7 @@
 	},
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/garrison)
 "uXb" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -33630,6 +35340,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"uXS" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "uXW" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33674,6 +35388,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"uYU" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "uYV" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "butcher"
@@ -33700,10 +35421,6 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
 "uZC" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/chapel)
 "uZD" = (
@@ -33715,9 +35432,10 @@
 "uZM" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/huntingknife/idagger/steel,
-/obj/item/clothing/gloves/roguetown/leather,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet/bogcaves)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town)
 "uZY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -33751,6 +35469,10 @@
 "vaN" = (
 /turf/open/floor/rogue/dirt/snow,
 /area/rogue/indoors/shelter/mountains)
+"vaQ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/outdoors/mountains)
 "vbe" = (
 /obj/structure/stairs{
 	dir = 1
@@ -33763,11 +35485,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town/roofs)
-"vbD" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "vbM" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -33797,6 +35514,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vcA" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/church/chapel)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -33804,9 +35525,27 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "vdg" = (
-/obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"vdj" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1;
+	icon_state = "woodwindowdir"
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/indoors/town/church/chapel)
 "vdl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8
@@ -33815,6 +35554,10 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/chapel)
+"vdm" = (
+/obj/structure/table/wood,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vdo" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
@@ -33826,6 +35569,12 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors)
+"vdZ" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "vec" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/golden,
@@ -33860,6 +35609,10 @@
 /obj/structure/plasticflaps,
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
+"veE" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "veK" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -33881,8 +35634,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "veW" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/cobblerock,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/rtfield)
 "vfj" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
@@ -33929,8 +35681,20 @@
 	dir = 1;
 	icon_state = "border"
 	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vgH" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/indoors/town/church/chapel)
 "vgZ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -33996,16 +35760,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vjs" = (
-/obj/structure/mineral_door/wood/window{
-	lockid = "woodsm"
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors)
-"vju" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1
-	},
-/area/rogue/outdoors/town/roofs)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/hard,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "vjx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood,
@@ -34059,6 +35816,13 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"vlN" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vlX" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -34092,6 +35856,13 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog)
+"vmX" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "vng" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -34110,6 +35881,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
+"vnu" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vnA" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
@@ -34118,6 +35893,10 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"vnO" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vnX" = (
 /turf/closed/mineral/rogue/salt,
 /area/rogue/outdoors/tribalfort)
@@ -34144,19 +35923,26 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"vor" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/mountains)
 "vou" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
 	lockid = "farm"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "vox" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks{
-	icon_state = "paving"
-	},
-/area/rogue/indoors)
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "voY" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
@@ -34213,14 +35999,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/garrison)
-"vqH" = (
-/obj/effect/decal/border/ruinedwood{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
-/area/rogue/indoors)
 "vra" = (
 /obj/structure/stairs{
 	dir = 1
@@ -34262,9 +36040,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "vsg" = (
-/obj/structure/fluff/clock,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/effect/spawner/lootdrop/roguetown/dungeon_mob_spawner/undead/easy,
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "vsh" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -34300,14 +36081,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"vtp" = (
-/obj/structure/rack/rogue,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "vtw" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church/chapel)
@@ -34464,6 +36237,17 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"vxV" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
+"vyn" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/church/chapel)
 "vyW" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "hell1";
@@ -34495,7 +36279,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors)
 "vzm" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
@@ -34579,12 +36363,9 @@
 /obj/item/clothing/neck/roguetown/psicross/silver,
 /obj/item/clothing/neck/roguetown/psicross,
 /obj/item/clothing/neck/roguetown/psicross,
+/obj/item/listenstone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"vBn" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "vBH" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -34614,9 +36395,7 @@
 /obj/structure/chair/bench/church/mid{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "vCs" = (
 /obj/effect/decal/cobbleedge{
@@ -34706,6 +36485,10 @@
 /obj/effect/holodeck_effect/cards,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"vEx" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vEz" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood,
@@ -34736,22 +36519,23 @@
 	},
 /area/rogue/outdoors/beach)
 "vFj" = (
-/obj/structure/flora/roguegrass,
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
-"vFz" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "garrison";
-	name = "West Gatehouse"
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
+"vFy" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/church/chapel)
+"vFz" = (
+/obj/structure/roguewindow,
+/obj/structure/roguewindow,
+/turf/closed,
+/area/rogue/outdoors/mountains)
 "vFU" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road{
@@ -34770,15 +36554,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "vGN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/roguewindow/openclose{
+	dir = 4
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed,
+/area/rogue/indoors/town)
 "vGQ" = (
-/obj/structure/rack/rogue,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/forge{
+	pixel_x = -1
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "vGT" = (
 /obj/structure/spacevine,
@@ -34790,13 +36575,22 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains)
 "vHd" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples2,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
-"vHn" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	locked = 1
+/obj/structure/mirror{
+	pixel_x = 28;
+	pixel_y = 0
 	},
+/obj/structure/bed/rogue/inn/double,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"vHh" = (
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed,
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
+"vHn" = (
+/obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vIa" = (
@@ -34808,6 +36602,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"vII" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "vIJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
@@ -34818,8 +36619,8 @@
 "vIX" = (
 /obj/structure/roguemachine/scomm/r,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks{
-	icon_state = "newstone2"
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
 "vJb" = (
@@ -34860,8 +36661,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "vLA" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/church/chapel)
 "vLD" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder{
@@ -34898,7 +36703,6 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "vMQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
 	dir = 4;
 	layer = 2.8;
@@ -34938,6 +36742,17 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"vND" = (
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/church/chapel)
 "vOa" = (
 /obj/structure/stairs{
 	dir = 8
@@ -34956,7 +36771,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vOX" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/rogue/grass,
@@ -34970,10 +36785,9 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
 "vPA" = (
-/obj/structure/flora/roguegrass,
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/mountains)
 "vPJ" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -35015,9 +36829,8 @@
 /turf/open/floor/plasteel/stairs/left,
 /area/rogue/outdoors/rtfield)
 "vQV" = (
-/obj/machinery/light/rogue/smelter/great,
-/turf/open/floor/rogue/metal,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "vRq" = (
 /obj/structure/flora/roguegrass/fungus_bush,
 /turf/open/floor/rogue/grass,
@@ -35061,8 +36874,13 @@
 	},
 /area/rogue/outdoors/bog)
 "vSM" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
 /area/rogue/indoors/town/church/chapel)
 "vSQ" = (
 /obj/structure/stairs/stone{
@@ -35113,8 +36931,7 @@
 	},
 /area/rogue/under/cave)
 "vUf" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "vUN" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
@@ -35131,6 +36948,12 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"vVt" = (
+/obj/machinery/light/rogue/hearth,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "vVG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -35167,7 +36990,7 @@
 /area/rogue/indoors/town)
 "vWk" = (
 /obj/structure/mineral_door/secret/rogue,
-/turf/open/floor/rogue/ruinedwood/turned,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "vWn" = (
 /obj/structure/plasticflaps,
@@ -35177,6 +37000,17 @@
 /obj/structure/table/wood/crafted,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"vWy" = (
+/obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "feedingline"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "vWA" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
@@ -35191,19 +37025,28 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bog)
 "vWY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/roguewindow/openclose,
+/obj/structure/bars,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/outdoors/town/roofs)
 "vXj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "vXm" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/blocks,
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks{
+	icon_state = "paving"
+	},
 /area/rogue/outdoors/town)
+"vXz" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "vXF" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
@@ -35229,6 +37072,13 @@
 	muddy = true
 	},
 /area/rogue/indoors)
+"vYE" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "vYF" = (
 /obj/item/reagent_containers/glass/cup/wooden/crafted,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35241,13 +37091,16 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "vYT" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/rtfield)
+"vZc" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "vZd" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -35332,18 +37185,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"wbC" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/obj/effect/decal/border/ruinedwood{
+"wbE" = (
+/obj/effect/decal/cobbleedge{
 	dir = 1;
-	pixel_x = 0;
-	pixel_y = -12
+	icon_state = "borderfall"
 	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "wbG" = (
 /obj/item/grown/log/tree/small,
 /obj/item/grown/log/tree/small,
@@ -35354,6 +37202,12 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
+"wbT" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/item/clothing/ring/dragon_ring,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wcd" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35373,7 +37227,7 @@
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/farmer,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "wdL" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
@@ -35405,9 +37259,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
 "wew" = (
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "weB" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -35442,12 +37298,18 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"wgf" = (
+/obj/structure/table/wood,
+/obj/item/rogueweapon/stoneaxe/woodcut,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wgn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "wgt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/woodturned,
@@ -35481,6 +37343,16 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors)
+"whz" = (
+/obj/structure/fluff/railing/stonehedge{
+	pixel_y = -8
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "whR" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves)
@@ -35492,6 +37364,26 @@
 /obj/structure/pillory/town_square,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter)
+"wiH" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
+"wjj" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/roguemachine/scomm{
+	dir = 3;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "wjr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -35519,23 +37411,16 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wkw" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "wkH" = (
 /obj/effect/landmark/start/prisonerb{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"wle" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81;
-	max_integrity = 1000000
-	},
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
 "wlq" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
@@ -35566,15 +37451,9 @@
 	},
 /area/rogue/outdoors/bog)
 "wmj" = (
-/obj/structure/fluff/millstone,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/manor)
-"wmv" = (
-/obj/structure/bars/pipe{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors)
 "wmK" = (
 /obj/structure/stairs{
 	dir = 1
@@ -35604,9 +37483,16 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "wnv" = (
+/obj/structure/roguewindow,
 /obj/structure/bars,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
+"wnE" = (
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/dwarfin)
 "wnG" = (
 /obj/structure/spacevine,
 /obj/structure/statue/saints/acolyte_r,
@@ -35622,18 +37508,28 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "woq" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wou" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/mob/living/simple_animal/hostile/rogue/skeleton/axe{
+	name = "Butler"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woP" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"woV" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "woX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -35657,9 +37553,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
 "wpm" = (
-/obj/structure/flora/wildapples/wildplant/wild_apples,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "wpr" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/feather,
@@ -35676,8 +37572,16 @@
 	},
 /area/rogue/outdoors/rtfield)
 "wqq" = (
-/obj/structure/flora/roguetree,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 10
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 9
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "wqE" = (
 /obj/structure/fluff/traveltile{
@@ -35701,30 +37605,26 @@
 	},
 /area/rogue/outdoors/beach)
 "wra" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/mountains)
 "wrj" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/manor)
 "wsr" = (
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"wsx" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town)
 "wsR" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wsZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -35735,18 +37635,20 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bog)
 "wte" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/dwarfin)
 "wtl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
 	icon_state = "churchslate"
 	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "wty" = (
 /obj/effect/decal/cobbleedge,
@@ -35828,6 +37730,15 @@
 	muddy = true
 	},
 /area/rogue/indoors/shelter/rtfield)
+"wwM" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/tile{
+	icon_state = "linoleum"
+	},
+/area/rogue/indoors/town/church/chapel)
 "wwV" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/wood,
@@ -35850,10 +37761,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "wxZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble,
+/obj/structure/chair/bench,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "wyr" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -35862,23 +37771,14 @@
 	muddy = true
 	},
 /area/rogue/indoors/town/tavern)
-"wyz" = (
-/obj/effect/decal/dirt{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/bog)
 "wyA" = (
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/lever/wall{
+	redstone_id = "WH7";
+	name = "WH Lever 7";
+	pixel_x = 11
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wyY" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueore/coal,
@@ -35891,6 +37791,13 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"wzb" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "wzo" = (
 /obj/structure/fluff/statue/knightalt/r,
 /obj/structure/fluff/walldeco/customflag{
@@ -35924,6 +37831,22 @@
 	muddy = true
 	},
 /area/rogue/outdoors/tribalfort)
+"wAL" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/storage/roguebag{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "wAP" = (
 /obj/structure/rack/rogue,
 /obj/item/flint,
@@ -35985,6 +37908,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"wBZ" = (
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "wCg" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -36012,6 +37941,10 @@
 "wDj" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
@@ -36041,23 +37974,40 @@
 	},
 /area/rogue/outdoors/vikingarea)
 "wDz" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
+/obj/structure/roguemachine/scomm/l{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/item/rogueweapon/mace/wsword,
-/obj/item/rogueweapon/mace/wsword,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/garrison)
 "wDD" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/bog)
 "wDZ" = (
-/obj/structure/well/fountain,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	icon_state = "border"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"wEa" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wEd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/cobble,
@@ -36099,10 +38049,21 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
 "wFp" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/structure/rack/rogue,
+/obj/machinery/light/rogue/torchholder{
+	dir = 8
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
+"wFC" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/soap,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "wFQ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -36125,13 +38086,6 @@
 /obj/item/natural/poo,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
-"wGd" = (
-/obj/structure/roguemachine/vendor/blk2,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
-	dir = 1;
-	max_integrity = 99999
-	},
-/area/rogue/indoors/town/shop)
 "wGl" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -36164,6 +38118,14 @@
 "wHE" = (
 /turf/closed/mineral/rogue/gold,
 /area/rogue/under/cavewet/bogcaves)
+"wIi" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/item/book/granter/trait/war/undying,
+/obj/effect/spawner/lootdrop/roguetown/dungeon_chest,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
+/area/rogue/under/cave)
 "wIl" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -36171,7 +38133,7 @@
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/blocks/stone/stonepattern2,
 /area/rogue/indoors/town/church/chapel)
 "wIt" = (
 /turf/closed/wall/mineral/rogue/tent{
@@ -36250,18 +38212,25 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
-"wKv" = (
-/obj/item/natural/bone,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/shelter/mountains)
 "wKB" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
 	icon_state = "iron_corner"
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wKF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "wKL" = (
 /obj/structure/pillory/dungeon/double,
 /turf/open/floor/rogue/cobble,
@@ -36276,6 +38245,12 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves)
+"wLn" = (
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wLx" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/bog)
@@ -36296,6 +38271,18 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wLT" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple{
+	name = "Daupie"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/church/chapel)
 "wMi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle,
@@ -36303,7 +38290,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wMj" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -36325,6 +38312,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"wMo" = (
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/church/chapel)
 "wMr" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -36362,6 +38357,12 @@
 "wOR" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"wPd" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "wPf" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/church,
@@ -36446,9 +38447,10 @@
 /area/rogue/indoors)
 "wQn" = (
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church"
+	lockid = "church";
+	name = "Cathedral of Enigma"
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "wQq" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -36480,10 +38482,6 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"wRc" = (
-/obj/structure/bars/grille,
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town)
 "wRy" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -36492,6 +38490,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
+"wRE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "wSc" = (
 /obj/structure/table/wood,
 /obj/item/flint{
@@ -36502,20 +38510,17 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
+/obj/structure/fluff/railing/wood{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 4;
-	pixel_y = 11
+/obj/structure/fluff/railing/wood,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
 	},
-/obj/item/reagent_containers/powder/ozium{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town/church/chapel)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -36532,12 +38537,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "wTs" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/tile/checker,
+/area/rogue/indoors/town)
 "wTA" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/fungus_bush,
@@ -36559,15 +38564,13 @@
 "wTU" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves)
-"wUc" = (
-/obj/item/roguebin/trash,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "wUw" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wUx" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -36601,6 +38604,12 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"wWE" = (
+/mob/living/simple_animal/hostile/rogue/ghost/wraith{
+	name = "Every Catherine"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "wWK" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -36655,12 +38664,17 @@
 	},
 /obj/effect/landmark/start/churchling,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "wYv" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "wYB" = (
 /obj/item/rogueweapon/shovel,
@@ -36671,7 +38685,7 @@
 /obj/item/rogueweapon/thresher,
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/mountains)
 "wYW" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/church,
@@ -36689,6 +38703,13 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cavewet/bogcaves)
+"wZr" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/obj/structure/bars,
+/turf/closed,
+/area/rogue/indoors/town)
 "wZJ" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword,
@@ -36700,12 +38721,30 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cavewet/bogcaves)
 "xaD" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1;
-	pixel_y = -6
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"xaX" = (
+/obj/item/cooking/pan,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xba" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -36719,12 +38758,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xbo" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
-	},
+/obj/structure/well/fountain,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xbr" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -36750,17 +38785,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xbW" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/lever/wall{
+	redstone_id = "WH3";
+	name = "WH Lever 3";
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/rtfield)
 "xce" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -36809,28 +38840,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "xdw" = (
-/obj/structure/closet/crate/chest,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/trash/applecore,
-/obj/item/natural/stone,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xdZ" = (
 /obj/effect/landmark/start/royalguard{
 	dir = 4
@@ -36864,9 +38878,15 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/basement)
 "xfh" = (
-/obj/machinery/light/rogue/torchholder/r{
-	dir = 4
-	},
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
 	},
@@ -36875,12 +38895,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"xfP" = (
-/obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
 "xgf" = (
 /obj/item/reagent_containers/food/snacks/smallrat/dead,
 /turf/open/floor/rogue/cobblerock,
@@ -37015,6 +39029,14 @@
 "xjl" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"xjp" = (
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace/goden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xjq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -37059,15 +39081,15 @@
 "xkm" = (
 /turf/open/lava,
 /area/rogue/under/cavewet/bogcaves)
-"xkD" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
 "xkF" = (
-/obj/structure/bed/rogue,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town)
 "xkI" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/natural/bundle/cloth,
@@ -37085,12 +39107,24 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"xld" = (
-/obj/structure/roguewindow/openclose,
+"xlb" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town/garrison)
+"xld" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/obj/item/candle/yellow/lit,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "xll" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobblerock,
@@ -37146,8 +39180,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xnv" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	max_integrity = 9999;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -37194,11 +39230,6 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/manor)
-"xoe" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "xoj" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 8
@@ -37257,15 +39288,8 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "xpM" = (
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
-"xqi" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "xqo" = (
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/ruinedwood,
@@ -37294,11 +39318,8 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "xqX" = (
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l,
-/obj/structure/bars/pipe{
-	dir = 4;
-	icon_state = "pipe"
-	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "xrd" = (
@@ -37306,14 +39327,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "xrf" = (
-/obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/chair/bench/church/r{
-	dir = 1
-	},
-/turf/open/floor/rogue/church,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xrg" = (
 /obj/structure/rack/rogue/shelf,
@@ -37323,13 +39340,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "xrl" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	locked = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/mountains)
 "xrH" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
@@ -37441,10 +39454,13 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
 "xvs" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors)
+/obj/structure/closet/crate/roguecloset,
+/obj/item/flint,
+/obj/item/candle/skull,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/manor)
 "xvu" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
@@ -37486,15 +39502,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "xwi" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/machinery/loom,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/outdoors/mountains)
 "xwu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -37526,7 +39536,7 @@
 /obj/item/seeds/sugarcane,
 /obj/item/seeds/sugarcane,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/outdoors/rtfield)
 "xxa" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/shop)
@@ -37546,6 +39556,15 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/magician)
+"xxw" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/water/river{
+	dir = 4;
+	icon_state = "rockwd"
+	},
+/area/rogue/under/cave)
 "xxA" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -37625,15 +39644,20 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "xAh" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
 "xAi" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"xAo" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xAt" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
@@ -37651,10 +39675,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"xAQ" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
 "xAR" = (
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -37692,15 +39712,6 @@
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement)
-"xCv" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town/shop)
 "xCw" = (
 /obj/item/natural/stone,
 /turf/open/water/swamp,
@@ -37828,16 +39839,11 @@
 	},
 /area/rogue/outdoors/town)
 "xET" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "xFk" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
@@ -37855,6 +39861,31 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/shop)
+"xFB" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
+"xFC" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "West Shutters";
+	pixel_y = -8;
+	redstone_id = "eastgatew";
+	pixel_x = -2
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "East Shutters";
+	pixel_y = 6;
+	redstone_id = "estategatee"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "xFD" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/carpet,
@@ -37863,6 +39894,12 @@
 /obj/effect/landmark/start/barkeep,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"xFL" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/closed,
+/area/rogue/indoors/town/church/chapel)
 "xFZ" = (
 /obj/structure/spacevine,
 /turf/open/water/cleanshallow,
@@ -37908,19 +39945,22 @@
 	},
 /area/rogue/indoors/town/shop)
 "xGM" = (
-/obj/machinery/light/rogue/lanternpost,
-/turf/open/floor/rogue/dirt/road{
-	muddy = true
+/obj/structure/fluff/railing/stonehedge{
+	dir = 4
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "xGW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "xHe" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/structure/bars/tough,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xHn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -37958,6 +39998,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"xId" = (
+/obj/structure/lever/wall{
+	redstone_id = "WH5";
+	name = "WH Lever 5";
+	pixel_x = 17
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "xIh" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope,
@@ -37976,9 +40024,18 @@
 /obj/effect/landmark/start/guardsman,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"xIK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saigabuck/tame,
+/turf/open/floor/rogue/dirt/road{
+	muddy = true
+	},
+/area/rogue/outdoors/rtfield)
+"xJb" = (
+/obj/machinery/light/rogue/forge,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "xJe" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/herringbone,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/town/church/chapel)
 "xJr" = (
 /obj/structure/table/wood{
@@ -38078,16 +40135,6 @@
 "xMr" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town)
-"xMI" = (
-/obj/effect/decal/wood/ruinedwood/turned,
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 4
-	},
-/obj/effect/decal/wood/ruinedwood/turned{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/shelter/mountains)
 "xMZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -38198,6 +40245,15 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
+"xQv" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/wood,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -38399,6 +40455,13 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor)
+"xWw" = (
+/obj/structure/fluff/railing/wood{
+	pixel_y = -4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xWN" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
@@ -38418,6 +40481,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"xXc" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Feeding Line";
+	pixel_y = -6;
+	redstone_id = "feedingline"
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/church/chapel)
 "xXd" = (
 /mob/living/simple_animal/hostile/rogue/ghost/wraith/wraith3,
 /turf/open/floor/rogue/twig,
@@ -38461,23 +40533,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
 "xXN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church/chapel)
 "xXQ" = (
@@ -38485,12 +40545,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/indoors)
-"xYg" = (
-/obj/item/natural/bone,
-/obj/item/clothing/suit/roguetown/shirt/shortshirt/bog,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xYr" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/churchbrick,
@@ -38530,7 +40585,6 @@
 /obj/item/kitchen/fork,
 /obj/item/kitchen/fork,
 /obj/item/kitchen/fork,
-/obj/item/reagent_containers/food/snacks/rogue/pumpkinpie,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "xZD" = (
@@ -38621,11 +40675,18 @@
 	},
 /area/rogue/outdoors/town)
 "ycz" = (
-/obj/structure/roguewindow/openclose{
+/mob/living/simple_animal/hostile/rogue/skeleton/guard/crypt_guard{
+	name = "Wild Hunt Reimagining"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
+"ycL" = (
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/garrison)
 "ycT" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
@@ -38637,6 +40698,16 @@
 "ydm" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
+"ydJ" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
 "ydR" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt,
@@ -38674,6 +40745,10 @@
 	muddy = true
 	},
 /area/rogue/outdoors/bog)
+"yeA" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/mountains)
 "yeF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -38802,12 +40877,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "yiI" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/templar,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/fluff/walldeco/rpainting/forest,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town)
 "yiU" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/shop)
@@ -38817,6 +40889,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"yjl" = (
+/obj/structure/mineral_door/wood{
+	lockid = "mansionvampire";
+	name = "WUTHERING HEIGHTS"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "WH5"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/outdoors/mountains)
 "yjp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -38834,10 +40916,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "yjP" = (
-/obj/structure/bed/rogue/shit,
-/obj/item/reagent_containers/food/snacks/rogue/ratonastick,
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/nest,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/church/chapel)
 "yjW" = (
 /obj/effect/landmark/start/tribalsmith,
 /turf/open/floor/rogue/blocks,
@@ -38908,13 +40996,6 @@
 	muddy = true
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"ylU" = (
-/obj/structure/bars/pipe{
-	dir = 4;
-	icon_state = "pipe"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "ylX" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_line"
@@ -41301,9 +43382,9 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
+amk
+amk
+amk
 amk
 sYw
 whb
@@ -41695,17 +43776,17 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 sYw
 whb
@@ -42084,30 +44165,30 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 sYw
 whb
@@ -42486,30 +44567,30 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 sYw
 whb
@@ -42888,30 +44969,30 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 sYw
 whb
@@ -43290,23 +45371,23 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-ike
-ike
-ike
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -43700,9 +45781,9 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
+amk
+amk
+amk
 amk
 amk
 amk
@@ -44077,17 +46158,6 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-amk
-amk
-ike
-ike
 amk
 amk
 amk
@@ -44101,10 +46171,21 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -44479,17 +46560,17 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -44881,17 +46962,6 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-amk
-amk
-ike
-ike
 amk
 amk
 amk
@@ -44914,10 +46984,21 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -45283,43 +47364,43 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-amk
-amk
-ike
-ike
-amk
-amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -45685,12 +47766,6 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
@@ -45698,30 +47773,36 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -46087,12 +48168,6 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
@@ -46100,30 +48175,36 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -46482,8 +48563,6 @@ amk
 amk
 amk
 amk
-bpD
-ike
 amk
 amk
 amk
@@ -46502,12 +48581,6 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
@@ -46522,10 +48595,18 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -46884,32 +48965,6 @@ amk
 amk
 amk
 amk
-bpD
-ike
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
@@ -46924,10 +48979,36 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -47286,32 +49367,6 @@ amk
 amk
 amk
 amk
-bpD
-ike
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
@@ -47326,10 +49381,36 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -47690,30 +49771,6 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-amk
-ike
-ike
-ike
-ike
-ike
-ike
 amk
 amk
 amk
@@ -47728,10 +49785,34 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -48092,12 +50173,12 @@ amk
 amk
 amk
 amk
-ike
-ike
-ike
-ike
-ike
-ike
+amk
+amk
+amk
+amk
+amk
+amk
 amk
 amk
 amk
@@ -99919,9 +102000,9 @@ xkm
 dVO
 dVO
 dVO
-ovT
-ovT
-ovT
+dVO
+dVO
+dVO
 dVO
 dVO
 dVO
@@ -108941,7 +111022,7 @@ bpD
 bpD
 aAI
 aMh
-aXR
+dAE
 bgI
 bgI
 bgI
@@ -110152,7 +112233,7 @@ bqP
 baS
 baS
 aAs
-clA
+dvv
 clA
 aAs
 aAs
@@ -111358,7 +113439,7 @@ baS
 baS
 baS
 aAs
-clA
+mhi
 clA
 cHE
 bJd
@@ -112961,7 +115042,7 @@ bpD
 bpD
 aAI
 aMh
-aXR
+hNN
 bgI
 bgI
 bgI
@@ -141768,44 +143849,44 @@ fyc
 fyc
 fyc
 fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
 fyc
 fyc
 fyc
@@ -142170,44 +144251,44 @@ fyc
 fyc
 fyc
 fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
+fyc
 fyc
 fyc
 fyc
@@ -142534,7 +144615,7 @@ whb
 whb
 whb
 whb
-fyc
+whb
 whb
 whb
 whb
@@ -142572,46 +144653,46 @@ aUc
 aUc
 aUc
 aUc
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
 aUc
-fyc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+whb
 whb
 whb
 whb
@@ -142936,32 +145017,29 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 aUc
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -142991,15 +145069,6 @@ rbn
 rbn
 rbn
 rbn
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -143011,9 +145080,21 @@ rbn
 rbn
 fZe
 fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -143333,37 +145414,34 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 aUc
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -143382,15 +145460,6 @@ rbn
 rbn
 rbn
 rbn
-rbn
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -143401,6 +145470,18 @@ rbn
 rbn
 fZe
 fZe
+fZe
+fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+fZe
+fZe
 rbn
 rbn
 rbn
@@ -143413,9 +145494,9 @@ fZe
 rbn
 fZe
 fZe
-fZe
-fZe
-fyc
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -143729,55 +145810,40 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -143788,11 +145854,9 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
 rbn
 rbn
-fZe
+rbn
 rbn
 rbn
 rbn
@@ -143809,15 +145873,32 @@ rbn
 fZe
 rbn
 rbn
+fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -144131,60 +146212,40 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
-rbn
 rbn
 rbn
 rbn
@@ -144192,10 +146253,8 @@ rbn
 rbn
 fZe
 fZe
-rbn
-rbn
 fZe
-fZe
+rbn
 fZe
 fZe
 fZe
@@ -144208,6 +146267,19 @@ rbn
 rbn
 rbn
 rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+fZe
+rbn
+rbn
+fZe
+fZe
+rbn
+fZe
+fZe
 fZe
 rbn
 rbn
@@ -144215,11 +146287,20 @@ rbn
 rbn
 rbn
 rbn
+rbn
+rbn
 fZe
-fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -144533,59 +146614,46 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
-fZe
-fZe
-fZe
 rbn
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
 rbn
 rbn
 rbn
@@ -144593,15 +146661,11 @@ rbn
 rbn
 rbn
 fZe
-fZe
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
 rbn
-fZe
+rbn
 rbn
 rbn
 rbn
@@ -144617,11 +146681,28 @@ rbn
 rbn
 rbn
 rbn
+rbn
 fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -144935,47 +147016,40 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
 aUc
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -144988,29 +147062,19 @@ rbn
 rbn
 rbn
 rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-fZe
 fZe
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-rbn
-fZe
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 fZe
 rbn
@@ -145019,11 +147083,28 @@ rbn
 rbn
 rbn
 rbn
+rbn
 fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -145337,38 +147418,38 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -145409,23 +147490,23 @@ fZe
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-rbn
-fZe
-rbn
 rbn
 rbn
 rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -145435,10 +147516,10 @@ whb
 whb
 sYw
 sYw
-phD
-phD
-phD
-phD
+qDI
+qDI
+qDI
+qDI
 sYw
 sYw
 sYw
@@ -145739,38 +147820,38 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -145791,12 +147872,6 @@ rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-rbn
-rbn
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -145807,14 +147882,11 @@ rbn
 rbn
 rbn
 rbn
-fZe
 rbn
-fZe
 rbn
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
 rbn
 fZe
 rbn
@@ -145822,12 +147894,21 @@ rbn
 rbn
 rbn
 rbn
+rbn
+rbn
+rbn
+fZe
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
 fZe
 fZe
 fZe
-fZe
-fyc
+aUc
+whb
 whb
 whb
 whb
@@ -146141,69 +148222,40 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-fZe
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-fZe
-rbn
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-rbn
-rbn
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
-fZe
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+aUc
 fZe
 fZe
 fZe
@@ -146213,10 +148265,39 @@ fZe
 rbn
 rbn
 rbn
+rbn
+rbn
+rbn
 fZe
+rbn
+rbn
+rbn
+rbn
 fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 fZe
 rbn
@@ -146228,8 +148309,8 @@ fZe
 fZe
 fZe
 fZe
-fZe
-fyc
+aUc
+whb
 whb
 whb
 whb
@@ -146542,70 +148623,41 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-fZe
-rbn
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-fZe
-fZe
-rbn
-rbn
-rbn
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
-fZe
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+aUc
 fZe
 fZe
 fZe
@@ -146615,10 +148667,39 @@ fZe
 rbn
 rbn
 rbn
+rbn
 fZe
 fZe
 fZe
+rbn
+rbn
+rbn
+rbn
 fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 fZe
 fZe
@@ -146628,10 +148709,10 @@ fZe
 fZe
 fZe
 fZe
-oFi
 fZe
 fZe
-fyc
+aUc
+whb
 whb
 whb
 whb
@@ -146944,41 +149025,41 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fZe
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+aUc
 fZe
 aJR
 fZe
@@ -146990,17 +149071,6 @@ rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-fZe
-fZe
-rbn
-rbn
-rbn
 rbn
 rbn
 rbn
@@ -147008,9 +149078,31 @@ rbn
 rbn
 rbn
 fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 fZe
@@ -147021,19 +149113,8 @@ fZe
 fZe
 fZe
 fZe
-rbn
-rbn
-rbn
-fZe
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-fyc
+aUc
+whb
 whb
 whb
 whb
@@ -147346,44 +149427,44 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+aUc
 fZe
 fZe
 fZe
-fZe
 rbn
 rbn
 rbn
@@ -147392,23 +149473,6 @@ rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
 rbn
 rbn
 rbn
@@ -147426,6 +149490,23 @@ rbn
 rbn
 rbn
 rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
 rbn
 rbn
@@ -147434,8 +149515,8 @@ fZe
 fZe
 fZe
 fZe
-fZe
-fyc
+aUc
+whb
 whb
 whb
 whb
@@ -147748,57 +149829,41 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+aUc
 fZe
 fZe
 fZe
@@ -147807,9 +149872,8 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
+rbn
+rbn
 fZe
 fZe
 fZe
@@ -147824,6 +149888,23 @@ rbn
 rbn
 rbn
 rbn
+fZe
+fZe
+fZe
+fZe
+fZe
+fZe
+fZe
+fZe
+fZe
+fZe
+fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 rbn
@@ -147836,8 +149917,8 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fyc
+aUc
+whb
 whb
 whb
 whb
@@ -148150,39 +150231,39 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -148210,10 +150291,6 @@ rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -148223,14 +150300,10 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
-fZe
+rbn
+rbn
 rbn
 rbn
 rbn
@@ -148239,7 +150312,15 @@ rbn
 rbn
 rbn
 fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -148552,39 +150633,39 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
 whb
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -148612,10 +150693,6 @@ rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -148625,14 +150702,6 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-rbn
-rbn
-fZe
 rbn
 rbn
 rbn
@@ -148640,8 +150709,20 @@ rbn
 rbn
 fZe
 fZe
+rbn
+rbn
+rbn
+rbn
 fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -148954,46 +151035,41 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
-fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
@@ -149010,28 +151086,12 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
-fZe
-rbn
-fZe
-rbn
-fZe
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
 rbn
 rbn
 fZe
@@ -149040,10 +151100,31 @@ rbn
 rbn
 rbn
 rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
 fZe
+rbn
+rbn
+rbn
+rbn
 fZe
-fyc
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -149356,70 +151437,56 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 aUc
-fZe
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
-fZe
-fZe
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 rbn
@@ -149430,10 +151497,24 @@ rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 fZe
@@ -149442,10 +151523,10 @@ fZe
 fZe
 rbn
 rbn
-fZe
-fZe
-fZe
-fyc
+rbn
+rbn
+aUc
+whb
 whb
 whb
 whb
@@ -149758,70 +151839,70 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
-fZe
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 rbn
 fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
-fZe
-fZe
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
+rbn
 rbn
 rbn
 rbn
@@ -149847,7 +151928,7 @@ rbn
 fZe
 fZe
 aUc
-fyc
+whb
 whb
 whb
 whb
@@ -150162,37 +152243,37 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-whb
-whb
-dVO
-dVO
 whb
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -150203,16 +152284,16 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
 fZe
 rbn
 fZe
 fZe
-fZe
+rbn
 fZe
 fZe
 rbn
@@ -150564,37 +152645,37 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-whb
-whb
-dVO
-dVO
 whb
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -150605,21 +152686,21 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
-fZe
-fZe
-rbn
-fZe
-fZe
-fZe
-fZe
 rbn
 rbn
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 rbn
@@ -150966,37 +153047,37 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-whb
-dVO
-dVO
-dVO
-dVO
-whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
 whb
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 aUc
 rbn
@@ -151014,10 +153095,10 @@ rbn
 rbn
 rbn
 rbn
-fZe
-fZe
-fZe
-fZe
+rbn
+rbn
+rbn
+rbn
 rbn
 rbn
 rbn
@@ -151368,38 +153449,38 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fyc
-fyc
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 aUc
 aUc
 aUc
@@ -151770,36 +153851,36 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
 whb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -152173,35 +154254,35 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -152575,35 +154656,35 @@ whb
 whb
 whb
 whb
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -152977,35 +155058,35 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -153386,28 +155467,28 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -153794,22 +155875,22 @@ whb
 whb
 whb
 whb
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
-fyc
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -181686,18 +183767,18 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -182088,18 +184169,18 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -182490,21 +184571,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -182892,21 +184973,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+gVW
+uaj
+uaj
+rgO
+gVW
+dNL
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -183294,21 +185375,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+uaj
+uaj
+rgO
+uaj
+bDf
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -183696,21 +185777,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+aMK
+sDR
+uaj
+uaj
+uaj
+uaj
+uaj
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -184098,21 +186179,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+qpX
+qpX
+tlB
+iME
+eRV
+uaj
+rgO
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -184500,21 +186581,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+aIT
+qpX
+qpX
+wIi
+cCC
+uaj
+sqL
+uaj
+bUi
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -184902,21 +186983,21 @@ bpD
 bpD
 bpD
 bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+kHu
+qpX
+qpX
+jMc
+cCC
+pDM
+uaj
+uaj
+bUi
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -185304,21 +187385,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+qpX
+qpX
+hyM
+uaj
+eRV
+uaj
+rgO
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -185706,21 +187787,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+vII
+orT
+uaj
+uaj
+uaj
+uaj
+uaj
+gVW
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -186108,21 +188189,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+uaj
+uaj
+uaj
+uaj
+bDf
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -186510,21 +188591,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+gVW
+bHe
+rgO
+rgO
+gVW
+dNL
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -186912,21 +188993,21 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+dNL
+sYw
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -187314,17 +189395,17 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+sYw
+qpX
 bpD
 bpD
 bpD
@@ -187716,17 +189797,17 @@ sSS
 sSS
 sSS
 sSS
-sSS
-sSS
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
-bpD
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
+qpX
 bpD
 bpD
 bpD
@@ -200952,15 +203033,15 @@ vRu
 vRu
 vRu
 fjw
-cEK
-ylC
-cEK
-ylC
-ylC
-ylC
-ylC
-cBf
-cBf
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
+bCb
 vup
 iTw
 iTw
@@ -201354,7 +203435,7 @@ vRu
 vRu
 fjw
 fjw
-ylC
+bCb
 txa
 txa
 txa
@@ -201756,7 +203837,7 @@ vRu
 vRu
 vRu
 fjw
-vRu
+sYw
 txa
 rpo
 opv
@@ -202158,7 +204239,7 @@ vRu
 vRu
 vRu
 fjw
-vRu
+sYw
 txa
 iML
 opv
@@ -202560,7 +204641,7 @@ vRu
 vRu
 fjw
 fjw
-vRu
+sYw
 txa
 yeM
 cGw
@@ -202962,7 +205043,7 @@ vRu
 fjw
 fjw
 vRu
-vRu
+sYw
 txa
 nhC
 lHK
@@ -203364,7 +205445,7 @@ vRu
 fjw
 fjw
 vRu
-vRu
+sYw
 txa
 aaI
 icc
@@ -203766,7 +205847,7 @@ vRu
 fjw
 fjw
 fjw
-vRu
+sYw
 txa
 rpo
 opv
@@ -203973,15 +206054,15 @@ whb
 fyc
 ilt
 dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+dRa
+dRa
+dRa
+dRa
+dRa
+dRa
+dRa
+fCU
+fCU
 dVO
 dVO
 dVO
@@ -204168,7 +206249,7 @@ vRu
 vRu
 fjw
 fjw
-fjw
+sYw
 txa
 uKD
 rpo
@@ -204374,17 +206455,17 @@ whb
 whb
 pEm
 dVO
-snb
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+dcH
+dTD
+eVO
+fCU
+dRa
+eVO
+eVO
+dRa
+fCU
+eVO
+dTD
 dVO
 dVO
 dVO
@@ -204570,7 +206651,7 @@ vRu
 vRu
 vRu
 vRu
-vuH
+sYw
 txa
 txa
 txa
@@ -204778,17 +206859,17 @@ whb
 cuA
 cuA
 dTD
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
+dTD
+fCU
+dRa
+dTD
+dTD
+dRa
+fCU
+dTD
+dTD
+dTD
+jaU
 dVO
 dVO
 dVO
@@ -204966,13 +207047,13 @@ fyc
 (159,1,2) = {"
 sYw
 sYw
-vRu
-vRu
-vRu
-vRu
-vRu
-txa
-iTw
+sYw
+sYw
+sYw
+sYw
+sYw
+bCb
+bCb
 txa
 cFQ
 cBf
@@ -205178,19 +207259,19 @@ whb
 whb
 whb
 cuA
+cuA
+dTD
+dTD
+fCU
 dRa
-ptK
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-dVO
-ptK
-dVO
-dVO
-nvd
+dTD
+dTD
+dRa
+fCU
+dTD
+dTD
+dTD
+cuA
 dVO
 dVO
 dVO
@@ -205581,19 +207662,19 @@ whb
 whb
 cuA
 cuA
-dVO
-ptK
-dVO
-ptK
-dVO
-dVO
-dVO
+dTD
+dTD
 fCU
-dVO
-oYP
-oYP
-nvd
-nvd
+dRa
+dTD
+dTD
+dRa
+fCU
+dTD
+dTD
+dTD
+cuA
+cuA
 dVO
 dVO
 dVO
@@ -205983,19 +208064,19 @@ whb
 whb
 cuA
 cuA
-hJf
-dVO
-dVO
-dVO
-dVO
-ptK
-dVO
-dVO
-dVO
-dWR
-msk
-nvd
-nvd
+ecC
+dTD
+fCU
+dRa
+dTD
+dTD
+dRa
+fCU
+dTD
+dTD
+dTD
+cuA
+cuA
 whb
 dVO
 dVO
@@ -206385,19 +208466,19 @@ whb
 whb
 cuA
 cuA
-hJf
-dVO
-snb
-dVO
-roj
-snb
-dVO
-snb
-dVO
+dTD
 few
-mzx
-nvd
-nvd
+fCU
+dRa
+hal
+hal
+dRa
+fCU
+dTD
+few
+dTD
+cuA
+cuA
 whb
 whb
 dVO
@@ -206787,17 +208868,17 @@ whb
 whb
 cuA
 cuA
-sml
-hJf
+dTD
+dTD
 gdv
 ghZ
 gdv
 gdv
 ghZ
 gdv
-hJf
-lKn
-mMv
+dTD
+dTD
+dTD
 cuA
 cuA
 eqK
@@ -207192,17 +209273,17 @@ cIa
 ekI
 ekI
 cIa
-gGu
-hUp
-lay
-ldI
+qBX
+qBX
+qBX
+qBX
 cIa
 ekI
 ekI
 ekI
 cuA
 cuA
-nxV
+jqC
 jqC
 jqC
 dIo
@@ -207600,7 +209681,7 @@ isM
 grQ
 cIa
 ekI
-lKR
+ekI
 ekI
 cuA
 cuA
@@ -207993,16 +210074,16 @@ dSL
 dSL
 cuA
 dIo
-irq
+exG
 exG
 get
 gvn
 hxm
 itv
-leJ
-ltR
-jul
-eVO
+hxm
+gGu
+hxm
+gGu
 iRZ
 cuA
 cuA
@@ -208395,22 +210476,22 @@ dSL
 dSL
 cuA
 dIo
-dBY
 exG
-iRG
-ecC
-jaU
-jul
-lll
-lwC
+exG
+geu
+gGu
+hxm
+gGu
+hxm
+gGu
 iCS
-lOH
-mNz
+gGu
+hxm
 jdW
 jqC
 jyb
 jqC
-nxV
+jqC
 dIo
 dVO
 dVO
@@ -208797,17 +210878,17 @@ dSL
 dSL
 cuA
 dIo
-jav
 exG
-wGd
-etu
-jul
-ldr
-ecC
-jaU
-eVO
-eVO
-nbh
+exG
+geu
+gGu
+hxm
+gGu
+hxm
+gGu
+hxm
+gGu
+hxm
 cIa
 cIa
 eqK
@@ -209199,17 +211280,17 @@ dSL
 dSL
 cuA
 dIo
-aJS
 exG
-jkj
-eVO
-eVO
-eVO
-eVO
-etu
-eVO
-eVO
-nbh
+exG
+geu
+gGu
+hxm
+gGu
+hxm
+gGu
+hxm
+gGu
+hxm
 cIa
 cIa
 eqK
@@ -209601,19 +211682,19 @@ dSL
 dSL
 cuA
 dIo
-vbD
 exG
-dbw
-eVO
-kYc
-kYc
-kYc
-kYc
-leJ
-lTz
-ndD
+exG
+geu
+gGu
+hxm
+gGu
+hxm
+gGu
+hxm
+gGu
+hxm
 jdW
-nxV
+jqC
 jqC
 jqC
 jqC
@@ -210006,13 +212087,13 @@ dIo
 exG
 exG
 geu
-fDM
-kYS
-kYS
-kYS
-kYS
-lyh
-lTF
+gvn
+hxm
+gGu
+hxm
+gGu
+hxm
+gGu
 iYN
 cuA
 cuA
@@ -210405,17 +212486,17 @@ dSL
 dSL
 cuA
 dIo
-kpr
+exG
 exG
 get
-gtE
+gUD
 gUD
 ixE
 ixE
 ixE
 gUD
 gUD
-nkV
+get
 cuA
 cuA
 jqC
@@ -210807,17 +212888,17 @@ dSL
 dSL
 cuA
 dIo
-dZh
+exG
 exG
 dIo
-hbS
-mGV
-sIT
-gqo
-xCv
-tNI
-iaf
-iaf
+exG
+exG
+exG
+exG
+exG
+exG
+exG
+exG
 dIo
 cuA
 jyb
@@ -211212,14 +213293,14 @@ dIo
 exG
 exG
 cIa
-iaf
-hVZ
-iaf
-iaf
 exG
-iaf
-lWv
-ntQ
+hVZ
+exG
+exG
+exG
+exG
+exG
+exG
 dIo
 cuA
 eqK
@@ -211614,14 +213695,14 @@ dIo
 eIh
 exG
 gfG
-iLX
-twS
-hLS
-kck
-twS
-rOQ
-iaf
-tpd
+exG
+exG
+exG
+exG
+exG
+exG
+exG
+exG
 dIo
 cuA
 whb
@@ -225477,7 +227558,7 @@ eZy
 eLe
 eZy
 eZy
-eLe
+vuH
 eZy
 eZy
 fjX
@@ -225879,7 +227960,7 @@ acD
 acD
 fhw
 acD
-acD
+wRE
 acD
 acD
 acD
@@ -226277,13 +228358,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
 acD
 acD
 acD
-vRu
-vRu
-vRu
+acD
+vuH
+uDi
+vsg
 acD
 azH
 azH
@@ -226679,13 +228760,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+qgC
+vuH
+qgC
+qgC
 acD
 qgC
 qgC
@@ -227081,13 +229162,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+vsg
+qgC
+uDi
+vuH
+uDi
+vsg
 acD
 qgC
 qgC
@@ -227483,13 +229564,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+qgC
+vuH
+uDi
+vsg
 acD
 qgC
 qgC
@@ -227885,13 +229966,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+vsg
+qgC
+qgC
+vuH
+uDi
+vsg
 acD
 qgC
 qgC
@@ -228287,14 +230368,14 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+bsS
+vuH
+uDi
+qgC
+acD
 vRu
 vRu
 vRu
@@ -228688,15 +230769,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
+acD
+acD
+xxw
+acD
+acD
+acD
 vRu
 vRu
 vRu
@@ -229090,15 +231171,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+qgC
+vuH
+ffw
+qgC
+qgC
+acD
 vRu
 vRu
 vRu
@@ -229492,15 +231573,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+ogC
+vuH
+ffw
+qgC
+vsg
+acD
 vRu
 vRu
 vRu
@@ -229894,15 +231975,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+ogC
+qgC
+vuH
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -230296,15 +232377,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+vsg
+qgC
+ogC
+vuH
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -230698,15 +232779,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+qgC
+qgC
+qgC
+vuH
+ffw
+qgC
+acD
 vRu
 vRu
 vRu
@@ -231100,15 +233181,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+qgC
+diG
+qgC
+diG
+ffw
+vuH
+qgC
+acD
 vRu
 vRu
 vRu
@@ -231502,15 +233583,15 @@ vRu
 vRu
 vRu
 vRu
+acD
+qgC
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+ogC
+vuH
+vuH
+vuH
+vsg
+acD
 vRu
 vRu
 vRu
@@ -231904,15 +233985,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
+acD
+acD
+hcG
+hnG
+acD
+acD
 vRu
 vRu
 vRu
@@ -232311,9 +234392,9 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
+acD
+acD
+acD
 vRu
 vRu
 vRu
@@ -263789,8 +265870,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -264192,8 +266273,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -264596,9 +266677,9 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -265000,8 +267081,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -265404,8 +267485,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -265808,7 +267889,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -266211,7 +268292,7 @@ tmH
 tmH
 tmH
 tmH
-tmH
+aUc
 tmH
 tmH
 tmH
@@ -266614,8 +268695,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 tmH
 vIa
@@ -267017,8 +269098,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 tmH
 vIa
 rbn
@@ -267420,8 +269501,8 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
+aUc
+aUc
 aUc
 aUc
 vIa
@@ -278575,33 +280656,33 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 tmH
 tmH
 tmH
@@ -278977,62 +281058,62 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+mjP
+mjP
+mjP
+mjP
+mjP
+mjP
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+uSw
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -279379,62 +281460,62 @@ uaL
 uaL
 uaL
 uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-uaL
-hcW
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-fxx
-fxx
-uaL
-wSn
-hcW
-hcW
+veW
+qYw
+iRN
+jMf
+jMf
+nSy
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -279781,62 +281862,62 @@ wSn
 wSn
 uaL
 uaL
+veW
+qYw
+jnN
+jMf
+jMf
+jMf
+nrw
+nrw
+ydJ
+uWj
+qwp
+uwa
+uwa
+cVu
+nrw
+qxL
+jlY
+jlY
+hmZ
+kzQ
+aac
+fDB
+fDB
+dsg
+djd
+nrw
+jMf
+jMf
+uHk
 uaL
 uaL
-qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-iNT
-iNT
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-qvR
-qvR
-qvR
-uaL
-uaL
-uaL
-hcW
-uaL
-wSn
-wSn
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
+paf
 qvR
 qvR
-fxx
-fxx
-wSn
-wSn
-wSn
-hcW
+khc
+uaL
+veW
+veW
+veW
+veW
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -280183,66 +282264,66 @@ wSn
 wSn
 tzK
 uaL
+veW
+qYw
+aSD
+jMf
+tOv
+vnO
+nrw
+nrw
+pVF
+qwp
+qwp
+vnu
+vnu
+vnu
+nrw
+jlO
+jlY
+wTs
+jlY
+jlO
+aac
+fDB
+fDB
+kIV
+baV
+nrw
+jMf
+jMf
+uHk
+roG
 uaL
-qvR
-uaL
-uaL
-uaL
-uaL
-tzK
-qvR
-uaL
-uaL
-uaL
-wSn
-uTf
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-wSn
+paf
 qvR
 qvR
-fxx
-fxx
-wSn
-wSn
-wSn
-wSn
-hcW
-hcW
-hcW
-hcW
+khc
+uaL
+uaL
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
+cWT
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -280584,67 +282665,67 @@ wSn
 wSn
 uaL
 uaL
-tzK
 uaL
-qvR
+veW
+qYw
+rwD
+jMf
+jMf
+vnO
+nrw
+nrw
+owf
+qwp
+qwp
+uWj
+qwp
+qwp
+oJO
+jlO
+jlY
+gIo
+jlY
+jlO
+evo
+cqU
+fDB
+buB
+fDB
+nrw
+jMf
+jMf
+uHk
+iWj
 uaL
-uaL
-uaL
-qvR
-uaL
-qvR
-uaL
-wSn
-wSn
-tzK
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
+paf
 qvR
 qvR
-qvR
+khc
 fxx
-fxx
+aJj
 wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-hcW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+cWT
 hcW
 hcW
 hcW
@@ -280987,66 +283068,66 @@ wSn
 uaL
 uaL
 uaL
+veW
+qYw
+qYw
+mQr
+mQr
+nZV
+qYw
+nrw
+ksh
+nle
+qwp
+qwp
+qwp
+qwp
+oJO
+jlO
+jlY
+wFC
+jlY
+jlO
+nrw
+tKg
+fDB
+fDB
+fDB
+lGS
+jMf
+jMf
+uHk
+uaL
+uaL
+lrj
 uaL
 qvR
-uaL
-qvR
-uaL
-uaL
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
+khc
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
 wSn
 wSn
-wSn
-uaL
-wSn
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-hcW
-wSn
-qvR
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-uaL
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 hcW
@@ -281389,68 +283470,68 @@ wSn
 wSn
 uaL
 uaL
+veW
+qYw
+rwD
+mQr
+mQr
+nZV
+qYw
+nrw
+iXt
+uWj
+qwp
+aem
+aem
+aem
+nrw
+bmL
+jlY
+wEa
+jlY
+bmL
+nrw
+hlY
+fDB
+jMf
+jMf
+lGS
+jMf
+jMf
+uHk
+ykt
+ykt
+ykt
 uaL
 qvR
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
+khc
+fxx
+fxx
 wSn
-wSn
-wSn
-qvR
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-hcW
-hcW
-wSn
-qvR
-uaL
-vRq
-qvR
-uaL
-fxx
-fxx
-qvR
-qvR
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+aJj
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 hcW
 hcW
 uaL
@@ -281752,7 +283833,7 @@ cWT
 hcW
 hcW
 hcW
-uaL
+oye
 wSn
 wSn
 wSn
@@ -281791,69 +283872,69 @@ uaL
 uaL
 uaL
 uaL
+veW
+qYw
+iRN
+mQr
+hMB
+mQr
+wiH
+qwp
+qwp
+qwp
+lUT
+vnu
+vnu
+nKk
+nrw
+tJw
+jlY
+jlY
+jlY
+jlO
+nrw
+cqU
+fDB
+jMf
+jMf
+lGS
+cCS
+jMf
+uHk
+uaL
+uaL
+lrj
 uaL
 qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-wSn
-wSn
-wSn
-wSn
-uaL
+khc
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-qvR
-uaL
 wSn
 uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-qvR
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-uaL
-qvR
-uaL
-tzK
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
 uaL
 uaL
 wSn
@@ -282184,7 +284265,7 @@ uaL
 uaL
 uaL
 wSn
-tzK
+uaL
 uaL
 uaL
 hcW
@@ -282193,69 +284274,69 @@ hcW
 hcW
 uaL
 uaL
+veW
+qYw
+jnN
+mQr
+mQr
+mQr
+qYw
+nrw
+oJO
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+jlO
+bDh
+bmL
+jlO
+nrw
+vVt
+fDB
+jMf
+nlC
+nrw
+vdm
+jMf
+uHk
+xIK
+uaL
+paf
 uaL
 qvR
-qvR
-uaL
-uaL
-uaL
-qvR
-wSn
-wSn
-uaL
-wSn
-wSn
+khc
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-wSn
-wSn
-uaL
-fxx
-uaL
-qvR
-qvR
-qvR
-uaL
-hcW
-hcW
-hcW
-uaL
-uaL
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-qvR
-qvR
-uaL
-uaL
-uaL
-fxx
-fxx
-qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-qvR
-uaL
 wSn
 uaL
-qvR
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 wSn
 wSn
@@ -282595,81 +284676,81 @@ hcW
 hcW
 uaL
 uaL
+veW
+qYw
+aSD
+xbW
+mQr
+mQr
+fFW
+jMf
+jMf
+jMs
+jMf
+jdJ
+jdJ
+jMf
+mwq
+nrw
+fyv
+nrw
+jlO
+jlO
+nrw
+xkF
+xaX
+jMf
+otr
+nrw
+cCS
+jMf
+uHk
+uHa
+uaL
+paf
 uaL
 qvR
-qvR
-uaL
-uaL
-qvR
-uaL
-uaL
-uaL
+khc
+fxx
+fxx
+fxx
 uaL
 wSn
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+qvR
+qvR
+qvR
+uaL
+uaL
+qvR
+qvR
+qvR
+qvR
+qvR
+qvR
 wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-wSn
-mHb
-uaL
-uaL
-fxx
-fxx
-qvR
-qvR
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lcg
-oMa
-bdN
-bdN
-bdN
-bCb
-lcg
-fxx
-fxx
-qvR
-qvR
-qvR
-uaL
-pPy
-uaL
-qvR
-qvR
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
-uTf
 spp
 nzw
 qvR
@@ -282997,68 +285078,68 @@ hcW
 hcW
 hcW
 uaL
-tzK
-qvR
-qvR
-uaL
-qvR
-qvR
-uaL
+veW
+qYw
+qYw
+qYw
+qYw
+nrw
+nrw
 mwq
-uaL
-wSn
-uaL
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-wSn
-uTf
-wSn
-wSn
-uaL
-gvi
-uaL
-uaL
-jlY
-uaL
-uaL
-lcg
-fxx
-fxx
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
+jMf
+tOv
+jMf
+tOv
+jMf
+jMf
+jMf
+jMf
+jMf
+nrw
+wzb
+nrw
+nrw
+nrw
+nrw
+wZr
+nrw
+nrw
+jMf
+jMf
+uHk
+lsD
+lsD
+jJa
 uaL
 qvR
-qvR
-iNT
+khc
+fxx
+fxx
+fxx
+fxx
+wSn
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
 uaL
 uaL
 uaL
@@ -283399,66 +285480,66 @@ hcW
 hcW
 uaL
 uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-wSn
-uaL
-wSn
-wSn
-uaL
-uaL
+veW
+veW
+veW
+veW
+veW
+evo
+nrw
+nrw
+pHF
+pHF
+wbE
+gip
+rxp
+rxp
+rxp
+gip
+jMf
+nrw
+qwp
+eol
+fIK
+nrw
+cSi
+cCS
+vdm
+cCS
+jMf
+jMf
+uHk
+rhD
+rhD
+rhD
+rhD
+rhD
+khc
+rZt
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
 uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fTe
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uvu
-uaL
-uaL
-uaL
-uaL
-uaL
-uwa
-fxx
-fxx
-qvR
-qvR
-uaL
-uaL
-uaL
-uaL
-aPF
-uaL
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
 uaL
 uaL
@@ -283784,7 +285865,7 @@ uaL
 wSn
 uaL
 uaL
-uTf
+wSn
 wSn
 wSn
 wSn
@@ -283804,63 +285885,63 @@ uaL
 uaL
 uaL
 qvR
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
 qvR
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-gvi
-tev
+veW
+evo
+pEX
+vdm
+cbG
+cbG
+uPa
+gip
+gum
+avN
+lFR
+sKs
+jMf
+nrw
 qwp
-uaL
-tev
-uaL
-lcg
+dHw
+qwp
+jPz
+jMf
+jMf
+cCS
+jMf
+jMf
+jMf
+owj
 fxx
 fxx
-qvR
-qvR
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+aJj
 wSn
-uaL
-wSn
-uaL
-uaL
-uaL
+veW
+veW
+kVc
+kVc
+veW
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
 uaL
 uaL
@@ -284207,14 +286288,34 @@ uaL
 uaL
 qvR
 qvR
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
+fQq
+evo
+gDx
+vdm
+cbG
+cbG
+rYs
+gip
+tfp
+ohw
+ure
+gip
+jMf
+fLv
+qwp
+tUR
+qwp
+wzb
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+owj
+fxx
+fxx
+rXt
 fxx
 fxx
 fxx
@@ -284222,48 +286323,28 @@ fxx
 fxx
 fxx
 fxx
-fxx
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-pPy
-uaL
-qvR
-qvR
-uaL
-uaL
-lVe
-lVe
-cQY
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-lVe
-fxx
-fxx
-qvR
 uaL
 wSn
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
-uaL
-uaL
-wSn
-uaL
-tzK
 wSn
 uaL
 tzK
@@ -284609,62 +286690,62 @@ uaL
 uaL
 qvR
 qvR
+fQq
+evo
+yiI
+vdm
+cbG
+cbG
+wbE
+gip
+bkF
+rni
+llo
+gip
+jMf
+nrw
+fEc
+fEc
+tUR
+wzb
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+owj
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
 uaL
 uaL
-uaL
-wSn
-qvR
-qvR
-qvR
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-wSn
-wSn
-uTf
-wSn
-uaL
-uaL
-qvR
-lyL
-qvR
-uaL
-lVe
-jyE
-ooJ
-xHe
-lVe
-jCh
-jCh
-jCh
-gvx
-jCh
-jCh
-lVe
-fxx
-fxx
-qvR
-qvR
-wSn
-wSn
-wSn
-wSn
-wSn
-qvR
+kVc
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 uaL
 uaL
@@ -284975,7 +287056,7 @@ uaL
 uaL
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -285011,62 +287092,62 @@ uaL
 uaL
 qvR
 qvR
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
+fQq
+evo
+nrw
+nrw
+xFB
+xFB
+wbE
+sKs
+nPQ
+nPQ
+nPQ
+gip
+jMf
+nrw
+fRP
+wsR
+qwp
+jPz
+jMf
+jMf
+cCS
+jMf
+jMf
+jMf
+uHk
+rhD
+rhD
+rhD
+rhD
+rhD
+khc
+rZt
 fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-qvR
-qvR
-uaL
-lVe
-upY
-ooJ
-azl
-lVe
-jCh
-jCh
-jCh
-gvx
-jCh
-jCh
-lVe
-fxx
-fxx
-uaL
-qvR
-qvR
-qvR
-iNT
-qvR
-qvR
-qvR
+aJj
+kVc
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 uaL
 uaL
@@ -285413,62 +287494,62 @@ uaL
 uaL
 qvR
 qvR
+veW
+evo
+nrw
+mwq
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+jMf
+tOv
+jMf
+nrw
+nrw
+nrw
+sVd
+nrw
+cSi
+cCS
+vdm
+cCS
+jMf
+jMf
+uHk
+orE
 qvR
 qvR
 qvR
-uaL
-tzK
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
 qvR
-rBC
-uaL
-uaL
+khc
 fxx
 fxx
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-qvR
-lyL
-qvR
-lVe
-til
-ooJ
-ooJ
-lVe
-ifg
-ifg
-rgO
-vox
-jCh
-jCh
-lVe
 fxx
 fxx
-wSn
-qvR
-qvR
+fxx
 uaL
-uaL
-qvR
-qvR
-uaL
+aJj
+veW
+veW
+veW
+kVc
+kVc
+veW
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+veW
+kVc
 qvR
 qvR
 qvR
@@ -285815,62 +287896,62 @@ uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-qvR
-qvR
-qvR
+veW
+evo
+nrw
+ulj
+iCm
+sQV
+jMf
+iCm
+iCm
+jMf
+mwq
+nrw
+nrw
+nrw
+nrw
+rRA
+qwp
+nrw
+nrw
+vGN
+nrw
+nrw
+cCS
+jMf
+uHk
 uaL
 uaL
 uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
 uaL
 qvR
-qvR
-qvR
-uaL
+khc
 fxx
 fxx
-uaL
-wSn
-uaL
-wSn
-wSn
-wSn
-rCL
-qvR
-qvR
-qvR
-lVe
-lLp
-ooJ
-tuw
-lVe
-kwN
-dAf
-auL
-vox
-jCh
-jCh
-lVe
+fxx
 fxx
 fxx
 wSn
-qvR
-qvR
-qvR
-wSn
-qvR
-qvR
-uaL
+aJj
+veW
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 uaL
 wSn
 uaL
@@ -286186,7 +288267,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -286215,64 +288296,64 @@ uaL
 uaL
 uaL
 hcW
+veW
+veW
+veW
+evo
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+iPF
+iPF
+nrw
+rRA
+qwp
+rRA
+pWm
+aym
+uwa
+nrw
+vdm
+jMf
+uHk
+uaL
+uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-wSn
-qvR
-uaL
-uaL
-rcr
-rcr
-uaL
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
+khc
 fxx
 fxx
-uaL
-uaL
-uaL
-qvR
-qvR
-qvR
-qvR
-uaL
-uaL
-uaL
-lVe
-lVe
-vjs
-lVe
-lVe
-lVe
-nhR
-lVe
-lVe
-lVe
-lVe
-lVe
 fxx
 fxx
-uaL
-qvR
-vRq
-qvR
-lyL
-qvR
-qvR
-uaL
+fxx
+wSn
+aJj
+kVc
+veW
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+aZu
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
 uaL
 uaL
 qvR
@@ -286618,63 +288699,63 @@ hcW
 hcW
 hcW
 hcW
-uaL
-uaL
-uaL
-uaL
+cWT
+mjP
+mjP
+mjP
+mjP
+rRA
+rRA
+rRA
+iPF
+iPF
+rRA
+rRA
+rRA
+qwp
+cjJ
+nrw
+bhR
+qwp
+tUR
+qwp
+dHw
+qwp
+vYE
+cCS
+jMf
+uHk
+qvR
+qvR
+qvR
+qvR
+qvR
+khc
+fxx
+fxx
+fxx
+fxx
+fxx
 wSn
 wSn
-wSn
-uaL
-tzK
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-qvR
-uaL
-uTf
-qvR
-uaL
-fxx
-fxx
-fxx
-uaL
-qvR
-uaL
-wSn
-wSn
-wSn
-uTf
-uaL
-uaL
-lVe
-afA
-ddv
-ddv
-lVe
-bqt
-wlD
-lVe
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-wSn
-qvR
-uaL
-qvR
-qvR
-qvR
-qvR
+kVc
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
+kVc
 qvR
 qvR
 qvR
@@ -286707,7 +288788,7 @@ uaL
 uaL
 uaL
 qvR
-vHd
+qvR
 qvR
 qvR
 qvR
@@ -287018,64 +289099,64 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+cWT
+mjP
+iJR
+ikM
+qNF
+qwp
+rRD
+cjJ
+ijU
+rRD
+rRD
+cjJ
+rRD
+oaU
+qwp
+gDx
+aym
+qwp
+qwp
+qwp
+tUR
+qwp
+jPz
+jMf
+jMf
+uHk
 uaL
 uaL
 uaL
 uaL
 qvR
-uaL
-uaL
-qvR
-uaL
+khc
 fxx
-fxx
-fxx
-qvR
-qzy
-wSn
-wSn
-uaL
-uaL
-wSn
-uaL
-uaL
-cQY
-wlD
-ddv
-ddv
-wlD
-wlD
-wlD
-cQY
-fxx
-fQq
 fxx
 fxx
 fxx
 fxx
 wSn
 wSn
-oZH
-qvR
-qvR
-qvR
-qvR
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 lyL
 aPF
@@ -287384,6 +289465,22 @@ uaL
 uaL
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -287395,89 +289492,73 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+mjP
+iJR
+blT
+qNF
+qwp
+rRD
+cjJ
+cvC
+rRD
+cjJ
+ijU
+cjJ
+cjJ
+qwp
+nrw
+qwp
+qwp
+aem
+aem
+qwp
+qwp
+jPz
+jMf
+jMf
+uHk
 uaL
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-wSn
-wSn
 uaL
 uaL
 uaL
 qvR
-qvR
-qvR
-qvR
-lyL
+khc
 fxx
 fxx
-qvR
-qvR
-wSn
-wSn
-uaL
-uaL
-uTf
-uaL
-wSn
-uaL
-lVe
-wlD
-iim
-wlD
-wlD
-ddv
-wlD
-lVe
-gwN
 fxx
 fxx
+fxx
+uaL
+wSn
 veW
-fxx
-fxx
-uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-tzK
+kVc
+kVc
+kVc
+veW
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 qvR
 qvR
@@ -287820,66 +289901,66 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
+cWT
+mjP
+mjP
+mjP
+mjP
+rRA
+rRA
+rRA
+nhR
+nhR
+rRA
+rRA
+rRA
+ijU
+qwp
+aev
+qwp
+qwp
+vHd
+uvu
+vEx
+rRA
+nrw
+jMf
+jMf
+uHk
+fZg
 qvR
-uaL
-tzK
-uaL
 qvR
+qvR
+qvR
+khc
 fxx
 fxx
-qvR
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-cQY
-wlD
-izm
-psH
-czI
-ddv
-wlD
-pdm
-jlY
-uaL
-uaL
-uaL
 fxx
 fxx
-uaL
-qvR
-iNT
-qvR
-qvR
-qvR
-uaL
+fxx
+fxx
+wSn
+veW
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 qvR
 qvR
@@ -287889,7 +289970,7 @@ uaL
 uaL
 wSn
 wSn
-qzy
+qvR
 qvR
 qvR
 spp
@@ -288215,6 +290296,7 @@ hcW
 hcW
 hcW
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -288225,63 +290307,62 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-fuA
-uaL
-uaL
-wSn
-uaL
-tzK
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-qvR
-qvR
+cWT
+cWT
+cWT
+cWT
+mjP
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+nrw
+evo
+evo
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
 fxx
 fxx
-wSn
-wSn
-wSn
-wSn
-uaL
-wSn
-wSn
-wSn
-uaL
-uaL
-lVe
-sFE
-mzk
-nQE
-wKh
-ddv
-wlD
-lVe
-uaL
-uaL
-vLS
-uaL
+fxx
+fxx
 fxx
 fxx
 uaL
-qvR
-qvR
-xis
-qvR
-qvR
-uaL
+kVc
+kVc
+veW
+kVc
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 uaL
 uaL
@@ -288599,6 +290680,7 @@ qvR
 uaL
 uaL
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -288616,6 +290698,14 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -288623,67 +290713,58 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-fuA
+cWT
+fQq
+fQq
+pno
+pno
+evo
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+ykt
+qvR
+qvR
+qvR
 uaL
 uaL
 uaL
-tzK
-tzK
-uaL
-wSn
-mHb
-wSn
-wSn
-wSn
-lyL
-xis
+qvR
 fxx
 fxx
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-cQY
-wlD
-dlx
-dlx
-wlD
-ddv
-wlD
-cQY
-uaL
-vLS
-glM
-uaL
+fxx
+fxx
 fxx
 fxx
 uaL
-qvR
-qvR
-qvR
-qvR
-qvR
-qvR
+aJj
+kVc
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
+kVc
 qvR
 qvR
 uaL
@@ -289002,6 +291083,16 @@ qvR
 qvR
 hcW
 hcW
+dbH
+hcW
+kYc
+kYS
+kYS
+mzx
+kYc
+mzx
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289025,66 +291116,56 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-lcg
-bdN
-oZE
-lcg
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
+pno
+fQq
+evo
+evo
+evo
+dpZ
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+qvR
+qvR
+qvR
 qvR
 qvR
 fxx
 fxx
-uaL
-wSn
-uaL
-aPF
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lVe
-rGY
-wlD
-wlD
-uhe
-ddv
-afA
-lVe
-aok
-uaL
-uaL
-vLS
+fxx
+fxx
 fxx
 fxx
 uaL
-qvR
-qvR
-qvR
-qvR
-iNT
+uaL
+uaL
+veW
+uaL
+kVc
+kVc
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+veW
+kVc
 qvR
 qvR
 qvR
@@ -289108,7 +291189,7 @@ qvR
 qvR
 ptV
 qvR
-wpm
+qvR
 qvR
 wSn
 rhD
@@ -289406,6 +291487,26 @@ hcW
 hcW
 hcW
 hcW
+kYS
+kYS
+kYc
+kYS
+kYS
+mzx
+hcW
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289418,31 +291519,10 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 hLK
 vra
 fxx
-dpZ
 fxx
 fxx
 fxx
@@ -289457,35 +291537,36 @@ fxx
 fxx
 fxx
 fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fTe
 uaL
+aJj
 uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-lVe
-lVe
-dbH
-lVe
-lVe
-cQY
-lVe
-lVe
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-uaL
-wSn
-rBC
-qvR
-qvR
+fTe
+kVc
+ykt
+xKz
+bOK
+xKz
+bOK
+xKz
+bOK
+xKz
+ykt
 uaL
 qvR
 qvR
@@ -289808,6 +291889,26 @@ hcW
 hcW
 hcW
 hcW
+lay
+lKn
+msk
+mMv
+msk
+ntQ
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+hcW
+dbH
+hcW
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -289820,27 +291921,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 hLK
 vra
 fxx
@@ -289852,15 +291933,6 @@ fxx
 fxx
 fxx
 fxx
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
 fxx
 fxx
 fxx
@@ -289870,23 +291942,32 @@ fxx
 fxx
 fxx
 fxx
-lVe
-lVe
-lVe
-uaL
-uaL
-uaL
-uaL
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
 uaL
 uaL
 uaL
 fxx
 fxx
-fxx
-uaL
-wSn
-wSn
-wSn
+jNF
+goz
+goz
+goz
+goz
+goz
+jNF
 wSn
 uaL
 uaL
@@ -290207,6 +292288,15 @@ sJZ
 sJZ
 qvR
 hcW
+dbH
+hcW
+hcW
+ldI
+lKR
+msk
+msk
+nbh
+nvd
 hcW
 hcW
 hcW
@@ -290233,16 +292323,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
 lcg
 bdN
 oZE
@@ -290282,13 +292363,13 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+lEs
+peN
+peN
+peN
+peN
+peN
+kgd
 fxx
 fxx
 fxx
@@ -290597,7 +292678,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 qvR
@@ -290612,6 +292693,12 @@ hcW
 hcW
 hcW
 hcW
+leJ
+lOH
+msk
+mNz
+nbh
+nvd
 hcW
 hcW
 hcW
@@ -290623,6 +292710,13 @@ hcW
 hcW
 hcW
 hcW
+dbH
+hcW
+dbH
+hcW
+hcW
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -290631,36 +292725,23 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-fuA
-fuA
-fuA
-fuA
+cWT
+cWT
+cWT
+cWT
+cWT
 uaL
-fuA
-uaL
-fuA
-fuA
-fDB
-fDB
-uaL
+ykt
+ykt
+ykt
+ykt
+ykt
+xKz
+xKz
+xKz
+jeb
+jeb
+xKz
 fxx
 fxx
 fxx
@@ -290684,13 +292765,13 @@ fxx
 fxx
 fxx
 fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
+goz
+peN
+peN
+peN
+hzY
+peN
+goz
 fxx
 fxx
 fxx
@@ -291014,6 +293095,12 @@ hcW
 hcW
 hcW
 hcW
+lll
+lKR
+msk
+msk
+nbh
+nvd
 hcW
 hcW
 hcW
@@ -291028,6 +293115,10 @@ hcW
 hcW
 hcW
 hcW
+dbH
+dbH
+hcW
+dbH
 hcW
 hcW
 hcW
@@ -291041,51 +293132,26 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-uaL
-uTf
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-fuA
-mjP
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
 uaL
 wSn
 wSn
 wSn
 wSn
 wSn
+xKz
+upI
+nTR
+lLa
+xKz
+xKz
+jXU
+uai
+mnW
+xKz
+jeb
+jeb
+xKz
+xKz
 uaL
 uaL
 uaL
@@ -291095,7 +293161,22 @@ uaL
 uaL
 uaL
 uaL
-uTf
+uaL
+wSn
+wSn
+wSn
+wSn
+wSn
+peN
+peN
+peN
+peN
+peN
+peN
+peN
+uaL
+uaL
+wSn
 uaL
 uaL
 uaL
@@ -291416,6 +293497,12 @@ hcW
 hcW
 hcW
 hcW
+ldI
+lKR
+msk
+msk
+nbh
+nvd
 hcW
 hcW
 hcW
@@ -291425,14 +293512,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+dbH
+dbH
 hcW
 hcW
 hcW
@@ -291455,24 +293536,24 @@ hcW
 hcW
 uaL
 wSn
-uTf
 wSn
 wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-fxx
-fxx
-fxx
-fxx
-fTe
-uaL
-uaL
-uaL
+wSn
+wSn
+xKz
+bUr
+iYQ
+fVQ
+nZw
+qpt
+sDa
+peN
+rUr
+quL
+nZw
+fVQ
+sNG
+xKz
 qvR
 qvR
 qvR
@@ -291488,13 +293569,13 @@ wSn
 uaL
 fTe
 wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
+xHe
+dQe
+aIb
+aIb
+aIb
+dQe
+xHe
 uaL
 uaL
 uaL
@@ -291818,6 +293899,12 @@ hcW
 hcW
 hcW
 hcW
+lay
+lKn
+msk
+mMv
+msk
+ntQ
 hcW
 hcW
 hcW
@@ -291829,13 +293916,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -291856,28 +293937,28 @@ hcW
 hcW
 hcW
 uaL
-uTf
+wSn
 bHL
 wSn
-uaL
+wSn
+wSn
+xKz
+qWS
+nTR
+fVQ
+lLa
+qpt
+sDa
+peN
+rUr
+quL
+lLa
+fVQ
+seC
+xKz
 qvR
-uaL
-uaL
-uaL
-qvR
-aPR
-uaL
-fxx
-fxx
-fxx
-uaL
-uaL
-uaL
-lyL
 qvR
 qvR
-uaL
-uaL
 vRq
 qvR
 qvR
@@ -291890,14 +293971,14 @@ uaL
 uaL
 uaL
 uaL
+xKz
+bOK
+jeb
+sRU
+jeb
+bOK
+xKz
 uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
-xqL
 uaL
 uaL
 uaL
@@ -292220,24 +294301,24 @@ hcW
 hcW
 hcW
 hcW
+ltR
+lTz
+mzx
+kYS
+kYc
+kYS
 hcW
 hcW
 hcW
 hcW
+dbH
 hcW
 hcW
 hcW
 hcW
+dbH
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -292261,26 +294342,26 @@ uaL
 wSn
 wSn
 wSn
-qvR
-qvR
-tzK
-uaL
 wSn
 wSn
-qvR
-tAf
-fxx
-fxx
-fxx
-uaL
+xKz
+bUr
+iYQ
+fVQ
+xaD
+qpt
+sDa
+peN
+rUr
+quL
 hmU
-wSn
-wSn
-wSn
+fVQ
+seC
+xKz
 qvR
 qvR
-uaL
-uTf
+qvR
+wSn
 lyL
 qvR
 uaL
@@ -292289,16 +294370,16 @@ uTf
 uaL
 uaL
 uaL
-tzK
 uaL
 uaL
 uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-uaL
+bOK
+tYP
+tYP
+ozt
+tYP
+tYP
+xKz
 uaL
 uaL
 wSn
@@ -292608,7 +294689,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 qvR
 qvR
@@ -292622,15 +294703,15 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+lyh
+lWv
+mzx
+mzx
+ndD
+kYc
+msk
+nxV
+dbH
 hcW
 hcW
 hcW
@@ -292663,25 +294744,25 @@ uaL
 wSn
 uTf
 wSn
-qvR
-uaL
-uaL
-uaL
-uaL
 wSn
-qvR
-qvR
+wSn
+xKz
+qWS
+nTR
+fVQ
+jeb
+jeb
 sDa
-xxp
+peN
 rUr
-uaL
-wSn
-wSn
-wSn
-wSn
-uaL
+jeb
+jeb
+fVQ
+jNj
+xKz
 qvR
 qvR
+uaL
 uaL
 xis
 qvR
@@ -292694,13 +294775,13 @@ uaL
 qvR
 qvR
 uaL
-wSn
-uaL
-xqL
-wSn
-wSn
-uaL
-uaL
+uOu
+tYP
+gTY
+tYP
+bHX
+tYP
+xKz
 qvR
 qvR
 uaL
@@ -293064,26 +295145,26 @@ uaL
 wSn
 wSn
 wSn
-uTf
-qvR
-uaL
-uaL
-uaL
 wSn
 wSn
-tAf
-qvR
+wSn
+xKz
+ycL
+iYQ
+fVQ
+fVQ
+jeb
 wgn
-jXZ
-kIf
+peN
+rUr
+jeb
+fVQ
+tYP
+kdv
+xKz
+qvR
+qvR
 uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-lyL
 qvR
 qvR
 qvR
@@ -293096,13 +295177,13 @@ qvR
 qvR
 uaL
 wSn
-wSn
-uaL
-uaL
-wSn
-wSn
-wSn
-uaL
+xKz
+wDz
+tYP
+tYP
+tYP
+tYP
+xKz
 qvR
 qvR
 qvR
@@ -293422,7 +295503,7 @@ uaL
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -293467,28 +295548,28 @@ wSn
 wSn
 wSn
 wSn
+wSn
+wSn
+xKz
+dwO
+lLa
+fVQ
+fVQ
+nBT
+sDa
+peN
+rUr
+nBT
+fVQ
+sCg
+mrE
+xKz
 qvR
 uaL
 uaL
-efg
-wSn
-wSn
-xqL
-tAf
-wgn
-jXZ
-kIf
-aJj
-wSn
-wSn
-uTf
-wSn
-wSn
-wSn
-wSn
 qvR
 qvR
-qzy
+qvR
 qvR
 wSn
 wSn
@@ -293498,14 +295579,14 @@ qvR
 aPF
 uaL
 wSn
-wSn
-wSn
-uaL
+bOK
+tYP
+szJ
+tYP
+sCg
+jUD
+xKz
 qvR
-uaL
-qvR
-qvR
-iNT
 qvR
 qvR
 qvR
@@ -293831,7 +295912,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -293868,26 +295949,26 @@ uaL
 wSn
 jct
 wSn
-wSn
 xKz
 xKz
+xKz
+xKz
+dwO
+lLa
+kMi
+gXk
 jeb
-jeb
-jeb
-xKz
-xKz
-tUp
 wgn
-jXZ
-kIf
-aJj
-wSn
-wSn
-wSn
-wSn
-oxc
-wSn
-wSn
+peN
+rUr
+jeb
+fVQ
+sCg
+mrE
+xKz
+qvR
+uaL
+qvR
 uaL
 qvR
 qvR
@@ -293900,18 +295981,18 @@ uaL
 uaL
 wSn
 wSn
-wSn
-wSn
-iNT
-qvR
-qvR
-qvR
-qvR
+xKz
+xKz
+xKz
+nnI
+sCg
+mrE
+xKz
 qvR
 qvR
 qvR
 uaL
-tzK
+uaL
 uTf
 uaL
 qvR
@@ -294263,52 +296344,52 @@ uaL
 uaL
 uaL
 uaL
-tzK
-tzK
 uaL
 uaL
-wSn
+uaL
+uaL
 wSn
 wSn
 wSn
 xKz
-peN
-qGh
+xKz
 mDY
-qeY
+fVQ
+fVQ
+fVQ
+kMi
+ycL
+jeb
+sDa
 peN
+rUr
+jeb
+fVQ
+tYP
+mrE
 xKz
-kIf
-wgn
-jXZ
-kIf
-aJj
-uaL
-wSn
-wSn
-wSn
-wSn
-wSn
-wSn
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-uaL
-wSn
-wSn
-wSn
-wSn
 qvR
 qvR
-lyL
 qvR
-rCL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+uaL
+wSn
+wSn
+xKz
+xKz
+xKz
+tYP
+sCg
+mrE
+xKz
 qvR
 qvR
 uaL
@@ -294617,7 +296698,7 @@ hcW
 wSn
 uaL
 hcW
-hcW
+dbH
 hcW
 hcW
 hcW
@@ -294672,26 +296753,26 @@ uaL
 wSn
 wSn
 wSn
-wSn
-jeb
+xKz
+xKz
 mDY
-goz
-cRP
+fVQ
+fVQ
 fIB
-qeY
-jeb
-kIf
-wgn
-jXZ
-kIf
-aJj
-bmL
-wSn
+fVQ
+fVQ
+qpt
+sDa
+peN
+rUr
+quL
+lLa
+fVQ
+ohA
+xKz
+qvR
 uaL
-wSn
-uaL
-wSn
-uaL
+qvR
 uaL
 uaL
 wSn
@@ -294704,13 +296785,13 @@ uaL
 wSn
 uTf
 wSn
-wSn
-wSn
-qvR
-qvR
-qvR
-qvR
-qvR
+xKz
+xKz
+xKz
+nnI
+sCg
+jUD
+xKz
 qvR
 uaL
 uaL
@@ -294732,7 +296813,7 @@ wOD
 qvR
 qvR
 qvR
-qzy
+qvR
 qvR
 fxx
 fxx
@@ -295019,6 +297100,7 @@ wSn
 wSn
 uaL
 hcW
+dbH
 hcW
 hcW
 hcW
@@ -295027,8 +297109,7 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+dbH
 wSn
 wSn
 qvR
@@ -295074,26 +297155,26 @@ uaL
 xqL
 wSn
 wSn
-wSn
 xKz
-xNo
-jpw
-eoz
-itC
-xNo
+gXk
+gqa
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+qpt
+sDa
+peN
+rUr
+quL
+lLa
+fVQ
+hrT
 xKz
-iaX
-jXZ
-jXZ
-jXZ
-ykt
-ykt
-uTf
-wSn
-wSn
-uaL
-uaL
-uaL
+qvR
+qvR
+qvR
 uaL
 uaL
 tzK
@@ -295106,10 +297187,10 @@ uaL
 wSn
 wSn
 uaL
-uaL
-uaL
 xKz
 xKz
+xKz
+jit
 xKz
 xKz
 xKz
@@ -295418,19 +297499,19 @@ fyc
 cWT
 cWT
 wSn
+dbH
+dbH
+dbH
+dbH
+hcW
+dbH
 hcW
 hcW
 hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+dbH
+dbH
+dbH
+dbH
 wSn
 wSn
 qvR
@@ -295465,7 +297546,7 @@ aJj
 aJj
 aJj
 aJj
-khc
+aJj
 aJj
 aJj
 aJj
@@ -295476,27 +297557,27 @@ aJj
 aJj
 uaL
 qvR
-qvR
-jeb
+xKz
+bUr
 iYQ
-iME
-oRp
-lhd
-uxV
-jeb
+lLa
+fVQ
+fIB
+fVQ
+fVQ
 qpt
-wgn
-jXZ
-kIf
-wgn
-ykt
-wSn
-aJj
-aJj
+sDa
+peN
+rUr
+quL
+xFC
+fVQ
+mGn
+xKz
+uaL
 uaL
 qvR
 qvR
-qvR
 uaL
 aJj
 aJj
@@ -295508,8 +297589,8 @@ uaL
 aJj
 aJj
 aJj
-aJj
-aJj
+xKz
+xKz
 xKz
 waI
 kyo
@@ -295820,9 +297901,9 @@ fyc
 cWT
 cWT
 uaL
-hcW
-hcW
-hcW
+dbH
+dbH
+dbH
 hcW
 hcW
 hcW
@@ -295878,40 +297959,40 @@ evo
 evo
 evo
 evo
-evo
 xKz
-bOK
+ycL
+nTR
 kds
-szV
-uxV
-peN
-vFz
+sOh
+xKz
+xaD
+fVQ
+xKz
+gUR
+nmC
 kIf
-wgn
-jXZ
-kIf
-wgn
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
-evo
+fhm
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
 xKz
 cWG
 bOK
@@ -296236,7 +298317,7 @@ uaL
 wSn
 wSn
 wSn
-iNT
+qvR
 qvR
 qvR
 wSn
@@ -296288,31 +298369,31 @@ xKz
 xKz
 xKz
 xKz
-oAn
+xKz
 uWL
-wjB
-wjB
-oAn
-evo
-xAi
-xAi
-dCV
-dCV
-dCV
-dCV
-dCV
-dCV
-cVN
-cVN
-dCV
-dCV
-xAi
-xAi
-xAi
-xAi
-dCV
-dCV
-dCV
+egd
+egd
+xKz
+xKz
+uGf
+uGf
+bPz
+bPz
+bPz
+bPz
+bPz
+bPz
+lGh
+lGh
+bPz
+bPz
+uGf
+uGf
+uGf
+uGf
+bPz
+bPz
+bPz
 axq
 dnx
 axl
@@ -296638,7 +298719,7 @@ qvR
 uaL
 uaL
 wSn
-iNT
+qvR
 qvR
 qvR
 iNT
@@ -297528,7 +299609,7 @@ uaL
 uaL
 uaL
 qvR
-iNT
+qvR
 qvR
 uaL
 uaL
@@ -299151,7 +301232,7 @@ trG
 ryI
 ryI
 fxx
-oiE
+qvR
 qvR
 qvR
 fxx
@@ -299506,7 +301587,7 @@ xNo
 xKz
 wVI
 wbg
-wRc
+wbg
 wbg
 wVI
 yiU
@@ -299616,16 +301697,16 @@ wvy
 iae
 odi
 odi
-wyz
-wyz
-wyz
+lOV
+lOV
+lOV
 pAV
 hHI
 hHI
 pAV
 pAV
-geX
-aCE
+pAV
+pAV
 pAV
 pAV
 vIa
@@ -299842,12 +301923,12 @@ cWT
 hcW
 ltM
 hcW
-uOL
-jDm
-jDm
-jDm
-jDm
-uOL
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 gPy
 pAm
 gPy
@@ -300022,13 +302103,13 @@ lOV
 lOV
 pAV
 pAV
-qVQ
-qos
+xou
+xou
 hnf
 pAV
 xou
-cpb
-rCo
+xou
+xou
 pAV
 pAV
 gxt
@@ -300244,13 +302325,13 @@ cWT
 hcW
 ltM
 hcW
-sHm
-pIV
-qIO
-sme
-taw
-cUy
-sHm
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+gPy
 dds
 gPy
 bOL
@@ -300646,13 +302727,13 @@ cWT
 hcW
 ltM
 hcW
-sHm
-pPO
-eUJ
-eUJ
-eUJ
-uBu
-sHm
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
+gPy
 dds
 gPy
 gPy
@@ -300826,13 +302907,13 @@ lOV
 lOV
 xou
 xou
-cpb
 xou
-cpb
 xou
-biZ
-cpb
-cpb
+xou
+xou
+xou
+xou
+xou
 aaq
 pAV
 gxt
@@ -301048,13 +303129,13 @@ cWT
 hcW
 ltM
 ltM
-sHm
-qoZ
-rST
-eUJ
-eUJ
-uDV
-sHm
+ltM
+ltM
+ltM
+ltM
+ltM
+ltM
+gPy
 bOL
 yhZ
 wbg
@@ -301227,13 +303308,13 @@ sYx
 lOV
 lOV
 pAV
-tqB
 xou
-att
-afc
-cpb
-qcG
-plT
+xou
+xou
+xou
+xou
+fdc
+xou
 xou
 aaq
 pAV
@@ -301454,9 +303535,9 @@ uOL
 jDm
 jDm
 jDm
-lae
 jDm
-uOL
+jDm
+jDm
 uOL
 jDm
 rBs
@@ -301631,12 +303712,12 @@ lOV
 hHI
 hHI
 gXr
-sNb
-cpb
-att
 xou
-cpb
-umY
+xou
+xou
+xou
+xou
+xou
 hHI
 hHI
 gxt
@@ -301855,10 +303936,10 @@ vGc
 sHm
 vDa
 eUJ
-eUJ
+ldr
 eUJ
 wPU
-vYT
+uOL
 sHm
 eUJ
 eUJ
@@ -302259,8 +304340,8 @@ vDa
 cNY
 cNY
 cNY
-eUJ
-eUJ
+uOL
+xDn
 sHm
 eUJ
 eUJ
@@ -302434,14 +304515,14 @@ lOV
 lOV
 lOV
 lOV
-wyz
-mbx
 lOV
 lOV
 lOV
 lOV
-wyz
-wyz
+lOV
+lOV
+lOV
+lOV
 lOV
 lOV
 lOV
@@ -302662,7 +304743,7 @@ cNY
 sGv
 cNY
 eUJ
-eUJ
+uOL
 sHm
 eUJ
 eUJ
@@ -302756,7 +304837,7 @@ uaL
 uaL
 wSn
 wSn
-uDi
+wSn
 rCL
 qvR
 qvR
@@ -302773,7 +304854,7 @@ mcm
 qvR
 fxx
 fxx
-qvR
+wBx
 okF
 okF
 okF
@@ -302840,7 +304921,7 @@ lOV
 lOV
 lOV
 lOV
-fAS
+lOV
 lOV
 lOV
 lOV
@@ -303176,7 +305257,7 @@ qvR
 fxx
 fxx
 qvR
-qzy
+qvR
 gex
 qvR
 rhD
@@ -303236,7 +305317,6 @@ lOV
 lOV
 lOV
 lOV
-sYx
 lOV
 lOV
 lOV
@@ -303244,7 +305324,8 @@ lOV
 lOV
 lOV
 lOV
-vBn
+lOV
+lOV
 lOV
 lOV
 lOV
@@ -303466,7 +305547,7 @@ cNY
 mea
 cNY
 eUJ
-eUJ
+uOL
 sHm
 vCQ
 xlm
@@ -303527,7 +305608,7 @@ xKz
 wVI
 wbg
 wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -303867,8 +305948,8 @@ jXN
 cNY
 rNB
 cNY
-eUJ
-wmj
+uOL
+xDn
 sHm
 niU
 xlm
@@ -303883,7 +305964,7 @@ mcK
 nBW
 mOY
 nBW
-nBW
+jXB
 nBW
 wtF
 wbg
@@ -303965,7 +306046,7 @@ uaL
 uaL
 qvR
 qvR
-iNT
+qvR
 qvR
 jJx
 sTr
@@ -304044,7 +306125,7 @@ lOV
 lOV
 lOV
 lOV
-pAn
+lOV
 lOV
 lOV
 lOV
@@ -304269,7 +306350,7 @@ gQn
 cNY
 cNY
 cNY
-eUJ
+hbS
 uOL
 uOL
 coE
@@ -304450,7 +306531,7 @@ lOV
 lOV
 lOV
 lOV
-sYx
+lOV
 lOV
 lOV
 lOV
@@ -304681,7 +306762,7 @@ kmV
 kuS
 kBK
 ohf
-jJM
+qAk
 lJX
 tqq
 tqq
@@ -304845,15 +306926,15 @@ lOV
 lOV
 lOV
 lOV
-jSO
 lOV
 lOV
-jSO
-jSO
 lOV
-jSO
-jSO
-jSO
+lOV
+lOV
+lOV
+lOV
+lOV
+lOV
 lOV
 lOV
 lOV
@@ -305071,10 +307152,10 @@ ltM
 sHm
 jDm
 jDm
+jDm
+lae
+jDm
 uOL
-tCz
-uOL
-sHm
 axW
 xlm
 nSZ
@@ -305248,15 +307329,15 @@ lOV
 lOV
 rZt
 hHI
-wlD
+hHI
 tIU
 hHI
 pAV
-kqq
+pAV
 tIU
 pAV
 pAV
-cGk
+aDG
 lOV
 wGD
 wGD
@@ -305472,11 +307553,11 @@ hcW
 ltM
 sHm
 lis
-yhZ
-cUy
-yhZ
-yhZ
-sHm
+etu
+jDm
+oif
+xvs
+uOL
 wtF
 vCQ
 xlm
@@ -305497,7 +307578,7 @@ wtF
 wbg
 wbg
 wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -305650,13 +307731,13 @@ lOV
 lOV
 hHI
 hHI
-rOs
-qSW
-nuj
-qSW
-kIt
-qSW
-eJh
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
 pAV
 hHI
 gxt
@@ -305876,9 +307957,9 @@ sHm
 yhZ
 yhZ
 gtJ
-yhZ
+qIO
 hnK
-sHm
+wtF
 wtF
 xlm
 xlm
@@ -305975,12 +308056,12 @@ uaL
 uaL
 qvR
 qvR
-iNT
+qvR
 qvR
 eOg
 uAZ
 xzN
-rNg
+xzN
 lOo
 rNg
 nuD
@@ -306051,15 +308132,15 @@ lOV
 lOV
 lOV
 hHI
-ojO
-hyb
-hWW
-tAu
-vqH
-hWW
 hHF
 hHF
-rwv
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
 hHI
 gxt
 kVc
@@ -306275,12 +308356,12 @@ hcW
 hcW
 ltM
 sHm
-imj
+hAa
 yhZ
-eAu
+jDm
 imj
-yhZ
-sHm
+taw
+wtF
 wtF
 tZJ
 xlm
@@ -306453,15 +308534,15 @@ odi
 lOV
 lOV
 hHF
-kIt
-qeH
 hHF
 hHF
-kIt
-kIt
-qeH
-qeH
-ejM
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
 hHI
 gxt
 kVc
@@ -306679,10 +308760,10 @@ ltM
 sHm
 gHQ
 crz
-sHm
+jDm
+iqB
 rqX
-rqX
-cUy
+wtF
 wtF
 xlm
 xlm
@@ -306849,21 +308930,21 @@ wGD
 iae
 wGD
 sYx
-ijU
+odi
 odi
 wGD
 wGD
 lOV
 pAV
-rOs
 hHF
-kIt
-hWW
-sPd
-tAu
-qeH
-hyb
-cWU
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
 pAV
 gxt
 kVc
@@ -307083,7 +309164,7 @@ jDm
 jDm
 jDm
 jDm
-jDm
+wtF
 jDm
 wtF
 wtF
@@ -307182,7 +309263,7 @@ qvR
 qvR
 qvR
 qvR
-vHd
+qvR
 qvR
 eXH
 efS
@@ -307258,13 +309339,13 @@ aTh
 sYx
 pAV
 pAV
-aZo
-aZo
-aZo
-aZo
-jVa
-jVa
-aZo
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
+hHF
 pAV
 pAV
 gxt
@@ -307504,7 +309585,7 @@ jDm
 uOL
 lbC
 hOh
-aev
+hOh
 aHx
 aHx
 lbC
@@ -307580,7 +309661,7 @@ olN
 uaL
 qvR
 uaL
-iNT
+qvR
 qvR
 qvR
 qvR
@@ -307620,9 +309701,9 @@ bwS
 lVe
 bwS
 lVe
-hHF
+kwn
 goK
-wlD
+nvf
 sux
 pYf
 pYf
@@ -307668,7 +309749,7 @@ hHI
 hHI
 pAV
 hHI
-gAA
+gxt
 gxt
 kVc
 kVc
@@ -308007,7 +310088,7 @@ uaL
 uaL
 qvR
 xis
-qvR
+wBx
 fxx
 wSn
 wSn
@@ -308756,14 +310837,14 @@ wbg
 wbg
 wbg
 wVI
-wVI
-wVI
+rDD
+plk
 nHz
 wVI
 wVI
 wVI
-nHz
-wVI
+fVM
+rDD
 wVI
 tUw
 wVI
@@ -308799,7 +310880,7 @@ fxx
 fxx
 fxx
 fxx
-fxx
+kch
 fxx
 boU
 fxx
@@ -308817,13 +310898,13 @@ qvR
 wSn
 cyr
 hHF
-enD
+fiK
 wlD
 sIG
 wlD
 wlD
 wlD
-wlD
+nvf
 wlD
 sIG
 wlD
@@ -309097,7 +311178,7 @@ sqd
 miX
 wxB
 wxB
-wxB
+miX
 wxB
 wxB
 wxB
@@ -309124,7 +311205,7 @@ wbg
 xXq
 yhZ
 yhZ
-yhZ
+qtK
 yhZ
 yhZ
 xXq
@@ -309137,15 +311218,11 @@ wbg
 wbg
 wbg
 wbg
-wRc
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
-aGZ
 wbg
 wbg
 wbg
@@ -309153,10 +311230,14 @@ aGZ
 wbg
 wbg
 wbg
+aGZ
 wbg
 wbg
-wRc
-wRc
+wbg
+wbg
+wbg
+wbg
+wbg
 wbg
 wbg
 wbg
@@ -309537,17 +311618,13 @@ xez
 wbg
 wbg
 wbg
+ovj
 wbg
 wbg
 wbg
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-aGZ
+ovj
 wbg
 wbg
 wbg
@@ -309555,10 +311632,14 @@ aGZ
 wbg
 wbg
 wbg
+aGZ
 wbg
 wbg
-wRc
-wRc
+wbg
+wbg
+wbg
+wbg
+wbg
 wbg
 wbg
 wbg
@@ -309591,7 +311672,7 @@ fxx
 fxx
 fxx
 fxx
-fxx
+kch
 fxx
 fxx
 fxx
@@ -309616,7 +311697,7 @@ mHb
 wSn
 wSn
 wSn
-dNL
+qvR
 wSn
 wSn
 cyr
@@ -309916,7 +311997,7 @@ uYE
 sHm
 mwE
 mwE
-nPQ
+mwE
 mwE
 lpq
 mwE
@@ -309959,6 +312040,7 @@ wbg
 wbg
 wbg
 wbg
+ovj
 wbg
 wbg
 wbg
@@ -309966,8 +312048,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
-wbg
+ovj
 wbg
 wbg
 wbg
@@ -310005,10 +312086,10 @@ fxx
 fxx
 fxx
 wxd
-qzy
-oxc
-wSn
-wSn
+iDD
+wmj
+cyr
+cyr
 wxd
 fxx
 fxx
@@ -310350,7 +312431,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 qcm
 cZg
 fRa
@@ -310406,9 +312487,9 @@ fxx
 fxx
 wxd
 wxd
-wSn
-qvR
-gex
+cyr
+iDD
+fDM
 eQE
 vza
 aar
@@ -310752,9 +312833,9 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 heo
-kQC
+rJX
 pUl
 pUl
 gFQ
@@ -310807,10 +312888,10 @@ ntc
 boU
 fxx
 wxd
-wSn
-wSn
-oxc
-wSn
+cyr
+cyr
+wmj
+cyr
 eQE
 eeR
 fxx
@@ -311154,7 +313235,7 @@ wbg
 wbg
 wbg
 wbg
-wVI
+wbg
 urH
 pUl
 pUl
@@ -311166,17 +313247,17 @@ wbg
 wbg
 wbg
 wbg
-wbg
+qzH
 hUt
 vFj
 qzH
 wbg
-jIP
-mwE
-mwE
+wbg
+wbg
 xGM
-rfO
-wsR
+xGM
+qzH
+adK
 ukb
 wvE
 rLt
@@ -311197,7 +313278,7 @@ uaL
 uaL
 uaL
 uaL
-tzK
+uaL
 qvR
 qvR
 qvR
@@ -311208,7 +313289,7 @@ qvR
 qvR
 fxx
 fxx
-ryI
+lcg
 trG
 dwQ
 xWT
@@ -311217,7 +313298,7 @@ trG
 ryI
 fZw
 fxx
-fxx
+kch
 rhD
 qvR
 qvR
@@ -311556,7 +313637,7 @@ tJx
 wVI
 wbg
 wbg
-wVI
+wbg
 jbj
 pUl
 dkf
@@ -311567,18 +313648,18 @@ guP
 vce
 wbg
 wbg
-wbg
 qtV
-wJq
-vPA
+iPY
+iPY
+iPY
 wew
-aOv
+wxZ
 nRo
 bQf
-mwE
-qDn
-mwE
-wsR
+bez
+iPY
+vdZ
+adK
 ukb
 wvE
 wvE
@@ -311601,7 +313682,7 @@ wSn
 wSn
 uaL
 uaL
-uEX
+wSn
 wSn
 wSn
 uaL
@@ -311610,7 +313691,7 @@ spp
 bzI
 fxx
 fxx
-wOD
+hLK
 qoE
 lEG
 wAU
@@ -311932,7 +314013,7 @@ aOn
 aOn
 lpa
 nCh
-wbg
+ovj
 wbg
 wbg
 hOh
@@ -311958,28 +314039,28 @@ xdq
 vka
 qqW
 wbg
-wVI
+wbg
 tnv
 pUl
 pUl
 rJX
 tCr
 guP
-guP
-guP
-teR
-wbg
+wte
+jjF
+vlN
 wbg
 qtV
+iPY
+iPY
 mwE
-yjP
+qeY
 wVI
+weX
 wVI
-wSl
-bQf
-mwE
-pKQ
-mwE
+dua
+hRv
+vdZ
 adK
 xMr
 yho
@@ -312012,7 +314093,7 @@ qvR
 bzI
 fxx
 fxx
-wOD
+hLK
 peT
 wAU
 cyr
@@ -312360,28 +314441,28 @@ xdq
 vka
 qqW
 wbg
-wVI
+wbg
 hmk
 pUl
 rJX
 eai
 tCr
 guP
-guP
-guP
+grj
+vmX
 iGf
 viq
-wbg
 qtV
-uFp
-vWY
-weX
+iPY
+iPY
+iPY
+hCQ
 wxZ
-wYv
-mwE
-ueX
-mwE
-mwE
+wVI
+bQf
+wKF
+nXd
+whz
 adK
 dHZ
 xww
@@ -312401,7 +314482,6 @@ qvR
 qvR
 spp
 qvR
-qzy
 qvR
 qvR
 qvR
@@ -312410,11 +314490,12 @@ qvR
 qvR
 qvR
 qvR
-wpm
+qvR
+qvR
 bzI
 fxx
 fxx
-wOD
+hLK
 qoE
 wAU
 cyr
@@ -312762,7 +314843,7 @@ wan
 xdq
 oAn
 wbg
-wVI
+wbg
 ufu
 pUl
 pUl
@@ -312771,18 +314852,18 @@ fQm
 guP
 guP
 guP
-guP
+jjF
 uTQ
-wbg
-wbg
-wbg
-wbg
-ybh
-wDZ
-utL
-jEB
-aOn
-mwE
+qtV
+nXd
+kwN
+cND
+wYv
+wVI
+wVI
+wVI
+wVI
+wVI
 rmJ
 adK
 pht
@@ -312816,7 +314897,7 @@ wSn
 uaL
 fxx
 fxx
-ryI
+lcg
 trG
 trG
 iow
@@ -312841,7 +314922,7 @@ lVe
 uxL
 sZI
 xlx
-usw
+dTa
 iTv
 cXU
 iTv
@@ -313119,7 +315200,7 @@ uOL
 jxy
 vbO
 oif
-oif
+uvI
 oif
 uJk
 tOz
@@ -313164,28 +315245,28 @@ iqY
 tYm
 oAn
 wbg
-wVI
+wbg
 wKT
 wKT
 hpJ
 wKT
 wKT
+gUC
 sxR
 sxR
 sxR
-sxR
-wKT
+abh
 wbg
-wbg
-wbg
+jCr
+jCr
 aSH
-fRN
-pkK
-mwE
-jEB
-mwE
-qKU
-mwE
+jCr
+wVI
+wVI
+wVI
+wVI
+wVI
+aEG
 oUn
 xMr
 vwQ
@@ -313218,13 +315299,13 @@ sjP
 uaL
 fxx
 fxx
-wOD
+hLK
 jrs
 jAN
-ltT
+gkv
 lSn
 tEC
-wOD
+hLK
 nht
 fxx
 fxx
@@ -313566,28 +315647,28 @@ iqY
 tYm
 oAn
 wbg
-wVI
-wKT
+wbg
+dsR
 dTB
 tVP
 tVP
 jLX
-tVP
+tCG
 tVP
 tVP
 tCG
-wKT
+rUm
 wbg
-wbg
-fRN
-aOn
-mwE
-mwE
-mwE
-nPQ
-auT
-qRp
-mwE
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+rZY
 ejJ
 xMr
 wCE
@@ -313620,13 +315701,13 @@ uaL
 wSn
 fxx
 fxx
-dwQ
+vYT
 moh
-ltT
-ltT
+gkv
+gkv
 jAN
 izN
-dwQ
+vYT
 jkG
 fxx
 fxx
@@ -313968,7 +316049,7 @@ dWG
 xdq
 xAu
 wbg
-wVI
+wbg
 wKT
 sSW
 tVP
@@ -313978,19 +316059,19 @@ tVP
 tVP
 tVP
 tVP
-wKT
-wbg
+nnb
 qtV
-mwE
-eSt
-aOn
-pKQ
+fKD
+rZY
+wVI
+wxZ
+wVI
 xbo
-aOn
-auT
-qKU
-uHk
-uHk
+wVI
+bQf
+wVI
+wVI
+rZY
 dHZ
 xMr
 xMr
@@ -314022,13 +316103,13 @@ uaL
 uaL
 fxx
 fxx
-wOD
+hLK
 oYA
-ltT
-ltT
-ltT
+gkv
+gkv
+gkv
 xwM
-wOD
+hLK
 oCW
 fxx
 fxx
@@ -314368,31 +316449,31 @@ pAS
 sZN
 sZN
 xdq
-wUc
+sIE
 wbg
-wVI
-wKT
+wbg
+dsR
 rJC
 tVP
+wnE
+iYH
+tVP
+kEb
 tVP
 tVP
-tZZ
-tZZ
-tZZ
-tVP
-wKT
-wVI
+nnb
 qtV
-hOh
-aOn
-aOn
-mwE
-mwE
-mwE
-mwE
-xEB
-wJq
-gaq
+fKD
+rZY
+wVI
+wxZ
+wVI
+wVI
+wVI
+bQf
+wVI
+rZY
+qKU
 kjH
 kjH
 kjH
@@ -314422,15 +316503,15 @@ vLS
 uaL
 sjP
 wSn
+kch
 fxx
-fxx
-ryI
+lcg
 fQg
-ltT
-ltT
-ltT
-uMF
-ryI
+gkv
+gkv
+gkv
+pyI
+lcg
 gwN
 fxx
 fxx
@@ -314770,31 +316851,31 @@ sZN
 sZN
 sZN
 xdq
-wVI
+qeY
 wbg
-wVI
+wbg
 wKT
 kFS
 tVP
+veE
+lqJ
+keW
+wgf
 tVP
-tVP
-tVP
-tVP
-tVP
-xaD
-abh
-wVI
+tCG
+nnb
 wbg
-xEB
-gDe
-aOn
-uFp
-mwE
-gSp
-nZQ
-mwE
-mwE
-aOn
+wbg
+wVI
+uEX
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
+wVI
 oVI
 bmi
 hyR
@@ -314827,11 +316908,11 @@ uaL
 fxx
 fxx
 hdm
-fBT
-fBT
-fBT
-fBT
-fBT
+fxx
+fxx
+fxx
+fxx
+fxx
 kOU
 fxx
 fxx
@@ -315122,7 +317203,7 @@ oif
 oif
 oif
 oif
-eUJ
+rNT
 eUJ
 eUJ
 jxy
@@ -315172,31 +317253,31 @@ sZN
 sZN
 lzC
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 wKT
 eWj
 yfY
-yfY
-tVP
+ijS
+mmb
 tZZ
 vGQ
-vGQ
-tVP
+yfY
+yfY
 wKT
 onR
-wbg
-hOh
+qEa
 vXm
-wjB
-wjB
-wjB
-quL
-mwE
-mwE
-mwE
-aOn
+vXm
+vXm
+nCA
+mUY
+wVI
+wVI
+wVI
+rZY
+wVI
 kjH
 bmi
 bmi
@@ -315229,11 +317310,11 @@ uaL
 fxx
 fxx
 hdm
-fBT
-fBT
-cyB
-fBT
-fBT
+fxx
+fxx
+pXE
+fxx
+fxx
 kOU
 fxx
 fxx
@@ -315574,7 +317655,7 @@ sZN
 sZN
 lzC
 xdq
-wVI
+qls
 wbg
 aNQ
 wKT
@@ -315589,16 +317670,16 @@ yfY
 wKT
 eur
 wbg
-ddH
-wVI
 uqe
 ewM
 uqe
-wra
-auT
-aOn
-mwE
-mwE
+lxN
+qeY
+wVI
+wVI
+rZY
+fbP
+rZY
 jXw
 xgi
 rYE
@@ -315630,13 +317711,13 @@ uaL
 sjP
 fxx
 fxx
-ryI
-trG
-trG
-ryI
-ltT
-ltT
-ryI
+lcg
+bdN
+bdN
+lcg
+gkv
+gkv
+lcg
 ccX
 fxx
 fxx
@@ -315976,9 +318057,9 @@ pDy
 sZN
 sZN
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 cCQ
 yfY
 yfY
@@ -315988,19 +318069,19 @@ yfY
 yfY
 yfY
 yfY
-wKT
+fha
+wbg
+mMs
+uqe
+uqe
+uqe
+tCN
+wew
+weX
 wVI
-wbg
-wbg
-pMn
-uqe
-uqe
-uqe
-wra
-mwE
-mwE
-mwE
-mwE
+rZY
+uzT
+rZY
 jXw
 xgi
 rYE
@@ -316032,16 +318113,16 @@ uaL
 tAf
 fxx
 fxx
-wOD
-phV
-phV
-ryI
-ltT
-ltT
-wOD
+hLK
+uBu
+uBu
+lcg
+gkv
+gkv
+hLK
 njv
 fxx
-fxx
+kch
 wxd
 wxd
 wSn
@@ -316347,7 +318428,7 @@ wrj
 jDm
 jDm
 mwE
-mwE
+sLM
 mwE
 wbg
 wbg
@@ -316378,31 +318459,31 @@ pAS
 sZN
 sZN
 xdq
-wVI
+qeY
 wbg
-wVI
+wbg
 cJz
 yfY
+dfH
 ijS
+eBx
+vGQ
+tZZ
 kfr
-mmb
-uaj
-mmb
-kfr
-ijS
+nBp
 wKT
 cIh
 wbg
-wbg
-wVI
 uqe
 ewM
 uqe
-wra
-mwE
-mwE
-aOn
-mwE
+tCN
+wew
+wVI
+wVI
+wVI
+rZY
+wVI
 kjH
 gDi
 bmi
@@ -316434,13 +318515,13 @@ uaL
 uaL
 fxx
 fxx
-dwQ
-ltT
-ltT
+vYT
+gkv
+gkv
 jEL
-ltT
-ltT
-dwQ
+gkv
+gkv
+vYT
 rBC
 fxx
 fxx
@@ -316780,12 +318861,11 @@ ygF
 ygF
 uDv
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 wKT
 eyJ
-cJz
 wKT
 wKT
 wKT
@@ -316793,17 +318873,18 @@ wKT
 wKT
 wKT
 wKT
-haB
-wbg
-wbg
-vXm
+wKT
+asE
+qEa
 gGZ
 gGZ
 gGZ
-xdw
-mwE
-mwE
-aOn
+ssF
+kzO
+wqq
+wqq
+wqq
+wqq
 wqq
 kjH
 kjH
@@ -316836,13 +318917,13 @@ qvR
 opc
 fxx
 fxx
-wOD
-ymh
-ltT
-ryI
-ltT
+hLK
+iLX
+gkv
+lcg
+gkv
 hnn
-wOD
+hLK
 tZv
 fxx
 fxx
@@ -317182,32 +319263,32 @@ ygF
 ygF
 uDv
 xdq
-wVI
+qls
 wbg
-wVI
+wbg
 wKT
-viq
-viq
+wBZ
+mTj
 ksK
 qRm
-hbc
-vQV
-bPv
-xbW
+ksK
+qRm
+ksK
+qRm
 wKT
-wVI
 wbg
 wbg
 wbg
 wbg
-aOn
-mwE
-qEa
-mwE
-mwE
-aOn
-auT
-wVI
+wbg
+wbg
+wbg
+wbg
+vJU
+wbg
+vJU
+vJU
+qPD
 wVI
 wVI
 wVI
@@ -317238,13 +319319,13 @@ qvR
 uaL
 fxx
 fxx
-ryI
-trG
-dwQ
-ryI
-vou
-ryI
-ryI
+lcg
+bdN
+vYT
+lcg
+rDU
+lcg
+lcg
 tZv
 fxx
 fxx
@@ -317584,9 +319665,9 @@ kaA
 wan
 vka
 xdq
-wVI
+qls
 wbg
-wVI
+wbg
 wKT
 iov
 viq
@@ -317597,18 +319678,18 @@ viq
 viq
 viq
 wKT
-wVI
+wbg
 wbg
 wbg
 wbg
 wbg
 rEo
-aOn
-mwE
-qCT
-mwE
-gaq
-mwE
+wbg
+wbg
+wbg
+wbg
+wbg
+wbg
 wbg
 wbg
 wbg
@@ -317650,7 +319731,7 @@ lcg
 woX
 axs
 axs
-ryI
+lcg
 trG
 uYV
 mun
@@ -317986,31 +320067,31 @@ pMj
 pPI
 xdq
 xdq
-wVI
+sIE
 wbg
-wVI
+wbg
 wKT
 rRB
 iQe
-xpM
-xpM
-xpM
-xpM
-xpM
-xpM
+viq
+viq
+viq
+viq
+viq
+viq
 wKT
-wVI
+wbg
 wbg
 usR
 ncb
 ncb
-vgA
+kem
 wbg
-mwE
-mwE
-mwE
-mwE
-gaq
+wVI
+wVI
+wVI
+wVI
+lJJ
 wVI
 wVI
 wbg
@@ -318052,7 +320133,7 @@ nNX
 fxx
 fxx
 fxx
-wOD
+hLK
 iEq
 ltT
 cjm
@@ -318388,20 +320469,20 @@ pOs
 pRW
 xdq
 qls
+jEe
 wbg
 wbg
-wVI
 wKT
 wKT
 jCs
-ovj
-rHj
-urF
+ksK
 wFp
-wTs
-xwi
+ksK
+wFp
+ksK
+wFp
 wKT
-wVI
+wbg
 wbg
 usR
 xAt
@@ -318454,7 +320535,7 @@ lcg
 fxx
 fxx
 fxx
-wOD
+hLK
 dwL
 ltT
 oLb
@@ -318789,10 +320870,10 @@ xdq
 xdq
 xdq
 xdq
+xWw
 wbg
 wbg
 wbg
-wVI
 wKT
 wKT
 wKT
@@ -318803,11 +320884,11 @@ wKT
 wKT
 wKT
 wKT
-wVI
+wbg
 wbg
 vAB
 bnQ
-ihW
+heK
 nWM
 wbg
 kjH
@@ -318819,12 +320900,12 @@ iLp
 kjH
 wbg
 wbg
-iEr
-iEr
-iEr
-iEr
-iEr
-iEr
+kjH
+kjH
+kjH
+kjH
+kjH
+kjH
 xAt
 xAt
 dCV
@@ -318856,7 +320937,7 @@ fxx
 jDE
 fxx
 qvR
-ryI
+lcg
 trG
 vrs
 trG
@@ -319191,21 +321272,21 @@ xMr
 xMr
 xMr
 xMr
+qeY
 wbg
 wbg
 wbg
-wVI
-wVI
+wbg
 fBF
-wVI
-wVI
-wVI
-wVI
-wVI
-wVI
+wbg
+wbg
+wbg
+wbg
+wbg
+wbg
 fBF
-wVI
-wVI
+wbg
+wbg
 wbg
 wbg
 iOq
@@ -319221,12 +321302,12 @@ bmi
 kjH
 wbg
 wbg
-xfP
-xvs
-qCJ
-iEr
-dNl
-iEr
+oVI
+bmi
+hyR
+kjH
+pfA
+kjH
 xAt
 xAt
 xAi
@@ -319593,6 +321674,7 @@ dCV
 csA
 dCV
 hXf
+sIE
 wbg
 wbg
 wbg
@@ -319608,8 +321690,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
-aoD
+wEd
 wEd
 wEd
 wbg
@@ -319623,12 +321704,12 @@ bmi
 kjH
 wbg
 wbg
-iEr
-jBw
-xvs
-alX
-fDk
-iEr
+kjH
+gDi
+bmi
+gTk
+tVN
+kjH
 xAt
 xAt
 xAi
@@ -319660,7 +321741,7 @@ wSn
 wSn
 wxd
 qvR
-ryI
+lcg
 xgU
 wlD
 wlD
@@ -319995,7 +322076,7 @@ dCV
 dCV
 dCV
 qee
-wbg
+jEe
 wbg
 wbg
 wbg
@@ -320025,12 +322106,12 @@ rdT
 kjH
 wbg
 wbg
-xld
-esE
-xvs
-gPE
-fDk
-iEr
+jXw
+xgi
+bmi
+fmn
+tVN
+kjH
 xAt
 xAt
 xAi
@@ -320062,7 +322143,7 @@ wSn
 kBk
 wxd
 qvR
-ryI
+lcg
 wlD
 wlD
 wlD
@@ -320397,7 +322478,7 @@ oTD
 csA
 dCV
 hXf
-wbg
+jHc
 wbg
 wbg
 wbg
@@ -320427,12 +322508,12 @@ kjH
 kjH
 asE
 wbg
-xld
-esE
-qNz
-fDk
-fDk
-iEr
+jXw
+xgi
+rYE
+tVN
+tVN
+kjH
 xAt
 xAt
 dCV
@@ -320464,7 +322545,7 @@ wSn
 wxd
 qqm
 qvR
-kIz
+iaf
 spk
 hIZ
 wlD
@@ -320783,7 +322864,7 @@ wSn
 nZj
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -320801,11 +322882,11 @@ xMr
 xMr
 gGZ
 qCy
-wbg
-wbg
-wbg
-wbg
-wbg
+bfE
+wVI
+weX
+wVI
+tJC
 wbg
 ekQ
 qDx
@@ -320829,12 +322910,12 @@ kjH
 cLW
 wbg
 iKR
-iEr
-iEr
-iEr
-iEr
-iEr
-iEr
+kjH
+kjH
+kjH
+kjH
+kjH
+kjH
 xAt
 xAt
 dCV
@@ -320866,12 +322947,12 @@ vDp
 vDp
 pbe
 pbe
-ryI
-kIz
+lcg
+iaf
 trG
 pZD
 trG
-ryI
+lcg
 bdN
 okq
 bdN
@@ -321185,7 +323266,7 @@ wSn
 nZj
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -321202,12 +323283,12 @@ bmi
 mgx
 xMr
 xAt
-qCy
+wjj
 wbg
-wbg
-wbg
-wbg
-wbg
+wVI
+wVI
+wVI
+wVI
 wbg
 hOh
 qDx
@@ -321231,12 +323312,12 @@ kjH
 cLW
 wbg
 wbg
-xfP
-xvs
-qCJ
-iEr
-dNl
-iEr
+oVI
+bmi
+hyR
+kjH
+pfA
+kjH
 xAt
 xAt
 cVN
@@ -321587,7 +323668,7 @@ uaL
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -321605,11 +323686,11 @@ oVp
 xMr
 qnO
 oZC
-wbg
-wbg
-wbg
-wbg
-wbg
+qRp
+wVI
+xbo
+wVI
+tJC
 wbg
 hOh
 qDx
@@ -321634,11 +323715,11 @@ odX
 wbg
 wbg
 cnp
-jBw
-xvs
-alX
-fDk
-iEr
+gDi
+bmi
+gTk
+tVN
+kjH
 xAt
 xAt
 cVN
@@ -321989,7 +324070,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -322007,11 +324088,11 @@ nTe
 qhC
 wbg
 wbg
-wbg
-wbg
-wRc
-wbg
-wbg
+qRp
+wVI
+wVI
+wVI
+tJC
 wbg
 hOh
 qDx
@@ -322035,12 +324116,12 @@ rfx
 rfx
 wbg
 wbg
-xld
+jXw
 wMi
-xvs
-gPE
-fDk
-iEr
+bmi
+fmn
+tVN
+kjH
 xAt
 xAt
 cVN
@@ -322391,7 +324472,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 wbg
 wbg
@@ -322407,13 +324488,13 @@ oXn
 oXn
 oXn
 xMr
-asE
+bqu
 wbg
 wbg
-wbg
-wbg
-wbg
-wbg
+wVI
+wVI
+wVI
+wVI
 wbg
 ekQ
 qDx
@@ -322437,12 +324518,12 @@ wJq
 qTQ
 wbg
 wbg
-xld
+jXw
 lIs
-qNz
-fDk
-fDk
-iEr
+rYE
+tVN
+tVN
+kjH
 xAt
 xAt
 cVN
@@ -322793,7 +324874,7 @@ uaL
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 xMr
@@ -322809,13 +324890,13 @@ paz
 bmi
 bmi
 xMr
+xWw
 wbg
-wbg
-wbg
-wbg
-wbg
-wbg
-wbg
+bfE
+wVI
+weX
+wVI
+tJC
 wbg
 lHf
 rfx
@@ -322839,18 +324920,18 @@ kYh
 qTQ
 wbg
 iKR
-iEr
-iEr
-iEr
-iEr
-iEr
-iEr
+kjH
+kjH
+kjH
+kjH
+kjH
+kjH
 xAt
 xAt
 dCV
 evo
 wSn
-uuW
+qvR
 lVe
 wlD
 iim
@@ -323195,7 +325276,7 @@ lgA
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 hcm
@@ -323211,7 +325292,7 @@ gVS
 gVS
 bmi
 xMr
-wbg
+sIE
 wbg
 wbg
 wbg
@@ -323236,17 +325317,17 @@ wbg
 ltk
 rSS
 lpq
-mwE
+nCh
 xEB
 axk
 wbg
 wbg
-xrl
+oVI
 avh
 uus
-iEr
-dNl
-iEr
+kjH
+pfA
+kjH
 xAt
 xAt
 dCV
@@ -323597,7 +325678,7 @@ nBq
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 jZn
@@ -323613,7 +325694,7 @@ poR
 pPs
 bmi
 qhR
-cqF
+xWw
 wbg
 wbg
 wbg
@@ -323643,12 +325724,12 @@ aOv
 aOv
 wbg
 wbg
-iEr
-xvs
-xvs
-alX
-fDk
-iEr
+kjH
+bmi
+bmi
+gTk
+tVN
+kjH
 xAt
 xAt
 dCV
@@ -323999,7 +326080,7 @@ qvR
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 cwN
@@ -324015,7 +326096,7 @@ ppo
 ssG
 bmi
 qkl
-cqF
+qls
 wbg
 wbg
 wbg
@@ -324039,18 +326120,18 @@ bJG
 wbg
 jpZ
 aOv
-cOV
+kMv
 aOv
 aOv
 aOv
 wbg
 wVI
-xld
+jXw
 kjU
-xvs
-fDk
-fDk
-iEr
+bmi
+tVN
+tVN
+kjH
 xAt
 dCV
 dCV
@@ -324401,7 +326482,7 @@ uaL
 uaL
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 cwN
@@ -324417,7 +326498,7 @@ orY
 orY
 bmi
 xMr
-wbg
+sIE
 wbg
 wbg
 wbg
@@ -324440,19 +326521,19 @@ ewt
 cEF
 wbg
 xll
-utL
+gHd
 aOn
 jHc
 mwE
 qTQ
 wVI
 wVI
-xld
+jXw
 aNW
-xvs
-fDk
+bmi
+tVN
 evb
-iEr
+kjH
 xAt
 dCV
 dCV
@@ -324803,7 +326884,7 @@ wSn
 paf
 xAt
 xAt
-wbg
+rfx
 wbg
 xMr
 hRy
@@ -324819,7 +326900,7 @@ bmi
 mou
 bmi
 xMr
-wbg
+sIE
 wbg
 wbg
 wbg
@@ -324850,11 +326931,11 @@ qTQ
 ptk
 ptk
 jsN
-iEr
-iEr
-iEr
-iEr
-iEr
+kjH
+kjH
+kjH
+kjH
+kjH
 dCV
 dCV
 dCV
@@ -325205,8 +327286,8 @@ uaL
 paf
 xAt
 xAt
+rfx
 wbg
-wbg
 xMr
 xMr
 xMr
@@ -325221,7 +327302,7 @@ xMr
 xMr
 xMr
 xMr
-wbg
+qeY
 wbg
 wbg
 wbg
@@ -325252,11 +327333,11 @@ qTQ
 xAt
 xAt
 iPJ
-qgD
-qgD
-qgD
-qgD
-qgD
+rfx
+rfx
+rfx
+rfx
+rfx
 dCV
 dCV
 dCV
@@ -325300,8 +327381,8 @@ wxd
 wxd
 wxd
 hcW
-hcW
-hcW
+cWT
+cWT
 tUO
 hcW
 tUO
@@ -325655,8 +327736,8 @@ lUv
 lUv
 rmD
 rfx
-qgD
-qgD
+rfx
+rfx
 rfx
 rfx
 rfx
@@ -325702,8 +327783,8 @@ wxd
 kVc
 kVc
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -326016,7 +328097,7 @@ xAt
 xAt
 xAt
 xAt
-fXg
+xAt
 xAt
 xAt
 xrd
@@ -326057,8 +328138,8 @@ rfx
 rfx
 rfx
 rfx
-kNg
-qgD
+rfx
+rfx
 rfx
 rfx
 rfx
@@ -326104,8 +328185,8 @@ kVc
 kVc
 kVc
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -326506,8 +328587,8 @@ kVc
 kVc
 kVc
 hcW
-hcW
-kVc
+cWT
+veW
 hcW
 hcW
 hcW
@@ -326908,8 +328989,8 @@ kVc
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -327216,24 +329297,24 @@ ujh
 xAt
 xAt
 vtw
-wOR
-wOR
-wOR
-wOR
 vtw
 vtw
 vtw
 vtw
 vtw
 vtw
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
-wOR
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
+vtw
 vtw
 wOR
 wOR
@@ -327310,8 +329391,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -327623,17 +329704,17 @@ vtw
 vtw
 vtw
 vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 vtw
 vtw
 vtw
@@ -327712,8 +329793,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -328019,20 +330100,20 @@ qvR
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+oqs
+oys
+hbc
+xKF
+xKF
+xKF
+xKF
 xKF
 xKF
 xKF
@@ -328114,8 +330195,8 @@ xqL
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -328421,19 +330502,19 @@ qvR
 uaL
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-iSJ
-iuo
-mGn
+xKF
+ueS
+oRp
+oRp
+rHj
+xKF
+xKF
+eBN
+eBN
+eBN
 iug
-ejY
+iug
+gse
 trI
 uHj
 uHj
@@ -328516,8 +330597,8 @@ wxd
 kVc
 kVc
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -328823,21 +330904,21 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-obq
+xKF
+xAh
+oRp
+oRp
+rHj
+xKF
+xKF
+ejY
+eBN
+eBN
+iug
+iug
+ejY
+trI
+uHj
 rTm
 uHj
 obL
@@ -328918,8 +330999,8 @@ sJZ
 wxd
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -329225,20 +331306,20 @@ uTf
 afX
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-ogC
-yiI
+xKF
+uiv
+oRp
+oRp
+rHj
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 uHj
 uHj
 uHj
@@ -329265,7 +331346,7 @@ uJF
 mzZ
 gGe
 ddH
-aOv
+beQ
 mwE
 nZQ
 oXE
@@ -329320,8 +331401,8 @@ sJZ
 sJZ
 feP
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -329627,20 +331708,20 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-vtw
-vtw
-vtw
-iuo
+xKF
+gvP
+oRp
+oRp
+rxS
+xKF
+ofq
+ofq
+xKF
+quy
+ofq
+eBN
 uHj
-uHj
+suN
 uHj
 bok
 uHj
@@ -329722,8 +331803,8 @@ sJZ
 sJZ
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -330029,18 +332110,18 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-iuo
+xKF
+nGn
+oRp
+oRp
+wLT
+xKF
+ofq
+ofq
 wVy
 ofq
 ofq
-iuo
+eBN
 bok
 suN
 uHj
@@ -330049,12 +332130,12 @@ idG
 obL
 xKF
 vtw
-wOR
+hKE
 wOR
 vtw
-ofq
+eEC
 iPY
-hRv
+aOv
 aOv
 xEB
 rfx
@@ -330124,8 +332205,8 @@ qet
 sJZ
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 kVc
 hcW
 hcW
@@ -330431,20 +332512,20 @@ aJj
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-iuo
+xKF
+bqt
+oRp
+sZk
+wLn
+xKF
+ofq
+ofq
 wVy
 ofq
 ofq
-iuo
+eBN
 uHj
-uHj
+suN
 uHj
 iIl
 xKF
@@ -330526,8 +332607,8 @@ qet
 qet
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -330833,32 +332914,32 @@ wSn
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
+mdB
+mdB
+xKF
+xFL
 xKF
 xKF
 xKF
 xKF
 xKF
 ofq
-ofq
-iuo
+eBN
 bok
 suN
 uHj
 tkZ
 xKF
-xKF
 vtw
 vtw
-wOR
+vtw
+hKE
 gLx
 vtw
 rkf
 mOT
-iPY
+aOv
 kJX
 jHc
 jHc
@@ -330928,8 +333009,8 @@ qet
 qet
 wxd
 kVc
-kVc
-kVc
+veW
+veW
 hcW
 hcW
 hcW
@@ -331235,20 +333316,20 @@ uaL
 afX
 xAt
 xAt
-vtw
-lAs
-lAs
-xKF
+eTc
+fCM
+fCM
+cNo
 twX
-dsW
-oIv
+cNo
+uVj
 eeO
-xKF
-ccY
-iuo
-iuo
+sKd
+vdj
+eBN
+eBN
 uHj
-uHj
+suN
 uHj
 vCr
 xKF
@@ -331330,8 +333411,8 @@ sJZ
 sJZ
 xSK
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -331637,21 +333718,21 @@ uaL
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
-xKF
+eTc
+fCM
+fCM
+fCM
+fCM
+sOY
+cPd
 dsW
-oIv
-oIv
-dsW
-vSM
-oIv
-oIv
-aem
-oIv
-cdn
-dsW
+sKd
+xgL
+uHj
+uHj
+uHj
+uHj
+nrx
 obL
 xKF
 vtw
@@ -331732,8 +333813,8 @@ sJZ
 sJZ
 wxd
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -332039,21 +334120,21 @@ afX
 uaL
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-oIv
-oIv
-oIv
-oIv
+bsh
+iuo
+iuo
+iuo
+sOY
+wPC
+dsW
+sKd
 xgL
-rRA
-oIv
-oIv
-oIv
-oIv
-oIv
+huL
+uHj
+uHj
+uHj
+uHj
 uHj
 xKF
 vtw
@@ -332134,8 +334215,8 @@ sJZ
 sJZ
 sJZ
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -332180,7 +334261,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 ovn
@@ -332441,22 +334522,22 @@ afX
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-oIv
-oIv
-oIv
-oIv
+auL
+auL
+auL
+iuo
+fCM
+sKd
+sKd
 vSM
-oIv
-oIv
-wDz
+pBC
+uHj
+uHj
 wIl
 dXw
 uHg
-oIv
+uHj
 xKF
 vtw
 vWe
@@ -332467,7 +334548,7 @@ vtw
 qZh
 ltk
 mwE
-mwE
+sLM
 mwE
 mwE
 aOv
@@ -332536,8 +334617,8 @@ sJZ
 sJZ
 sJZ
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -332583,7 +334664,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 ovn
@@ -332843,23 +334924,23 @@ tzK
 paf
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
-bzl
+gof
+bON
+vLA
+iuo
 oIv
-dsW
-oIv
+sKd
+sKd
 xKF
 xKF
+lma
 lma
 xKF
 xKF
 xKF
+hnd
 xKF
-jMf
-vtw
 vtw
 vtw
 feY
@@ -332938,13 +335019,13 @@ sJZ
 qet
 sJZ
 kVc
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
 whb
 whb
@@ -332985,7 +335066,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -333245,9 +335326,6 @@ uaL
 pOO
 xAt
 xAt
-vtw
-lAs
-lAs
 xKF
 xKF
 xKF
@@ -333255,13 +335333,16 @@ xKF
 xKF
 xKF
 xKF
+xKF
+xKF
+pkt
 eCn
-xKF
+eCn
 xKF
 wWK
 iuo
 iuo
-vtw
+xKF
 vtw
 vtw
 vtw
@@ -333340,13 +335421,13 @@ sJZ
 sJZ
 sJZ
 kVc
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+sue
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
 whb
 whb
@@ -333389,12 +335470,12 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
 whb
-whb
-whb
+qli
 whb
 whb
 whb
@@ -333638,11 +335719,11 @@ hcW
 uaL
 hcW
 hcW
+hcW
 uaL
 uaL
 uaL
-wSn
-wSn
+uaL
 uaL
 paf
 xAt
@@ -333658,12 +335739,12 @@ afz
 aHN
 sLc
 eCn
-xKF
+eCn
 xKF
 awJ
 iuo
 iuo
-vtw
+xKF
 iuo
 iuo
 vtw
@@ -333742,13 +335823,13 @@ sJZ
 qet
 sJZ
 kVc
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+sue
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
 whb
 whb
@@ -333793,13 +335874,13 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
-whb
-whb
-whb
-whb
+qli
+qli
+qli
 whb
 whb
 whb
@@ -334040,13 +336121,13 @@ hcW
 hcW
 hcW
 hcW
-sjP
-sjP
+hcW
 hcW
 uaL
-wSn
 uaL
 uaL
+uaL
+paf
 xAt
 xAt
 vtw
@@ -334060,12 +336141,12 @@ eCn
 eCn
 eCn
 eCn
-xKF
+eCn
 xKF
 gqN
 iuo
 iuo
-vtw
+xKF
 iuo
 iuo
 vtw
@@ -334144,13 +336225,13 @@ sJZ
 sJZ
 sJZ
 kVc
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+sue
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
 whb
 whb
@@ -334441,13 +336522,13 @@ hcW
 hcW
 hcW
 hcW
-fVM
-sjP
-jXZ
+hcW
+hcW
 hcW
 uaL
-wSn
-wSn
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -334462,18 +336543,18 @@ eCn
 vxf
 xSG
 eCn
+eCn
 xKF
 xKF
 xKF
+hnd
 xKF
-jNF
-vtw
 kPZ
-vtw
-vtw
-jMf
+xKF
+xKF
+hnd
 ofb
-vtw
+xKF
 vtw
 oAn
 wbg
@@ -334546,13 +336627,13 @@ sJZ
 sJZ
 wxd
 kVc
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+sue
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
 whb
 whb
@@ -334844,12 +336925,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
-wSn
-wSn
+uaL
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -334864,18 +336945,18 @@ eCn
 eCn
 eCn
 eCn
-xKF
+eCn
 euo
-oOU
+smO
 oOU
 smO
 buj
 smO
-vtw
-vtw
+hnd
+kSh
 sKd
 uHb
-vtw
+xKF
 vtw
 oAn
 swu
@@ -334948,13 +337029,13 @@ kVc
 kVc
 wxd
 kVc
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
-hcW
+cWT
+sue
+gdC
+gdC
+gdC
+gdC
+gdC
 hcW
 whb
 whb
@@ -335246,12 +337327,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-sjP
 hcW
 hcW
-wSn
-wSn
+hcW
+uaL
+uaL
+uaL
 paf
 xAt
 xAt
@@ -335266,18 +337347,18 @@ kAT
 aee
 sLc
 eCn
-lma
+eCn
 mty
-smO
 smO
 smO
 nXv
 smO
+smO
 hnd
-kSh
 sKd
 sKd
-vtw
+sKd
+xKF
 vtw
 oAn
 nvS
@@ -335350,8 +337431,8 @@ kVc
 kVc
 wxd
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -335648,13 +337729,13 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
-wSn
-nZj
+uaL
+uaL
+uaL
+paf
 xAt
 xAt
 vtw
@@ -335667,19 +337748,19 @@ xKF
 xKF
 xKF
 xKF
-jMf
+hnd
 xKF
-vtw
+xKF
 wnv
-tlQ
-vtw
-vtw
-jMf
-vtw
+xKF
+xKF
+hnd
+hnd
+xKF
 bJs
 sKd
 aqj
-vtw
+xKF
 vtw
 oAn
 xgy
@@ -335752,8 +337833,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -336050,11 +338131,11 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
+uaL
+uaL
 uaL
 paf
 xAt
@@ -336070,18 +338151,18 @@ oSY
 szN
 szN
 sKd
-abZ
-vtw
+xKF
 iuo
 iuo
 fXv
-vtw
+xKF
+bSm
 wOR
-vtw
+xKF
 alk
 alk
-vtw
-vtw
+xKF
+xKF
 vtw
 oAn
 vzm
@@ -336154,14 +338235,14 @@ kVc
 kVc
 kVc
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -336221,9 +338302,9 @@ whb
 whb
 whb
 whb
+qli
 whb
-whb
-whb
+qli
 dVO
 dVO
 ovn
@@ -336452,13 +338533,13 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
 hcW
 hcW
 hcW
-hcW
-hcW
+uaL
+uaL
+uaL
+uaL
 xAt
 xAt
 vtw
@@ -336472,18 +338553,18 @@ bau
 sKd
 sKd
 sKd
-sKd
-clr
+hnd
 iuo
 aFS
 iuo
-clr
+hnd
+wOR
 wOR
 rKn
 sKd
 tkq
-vtw
-lAs
+xKF
+xKF
 vtw
 rfx
 pwQ
@@ -336556,8 +338637,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -336854,8 +338935,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -336874,17 +338955,17 @@ lel
 szN
 szN
 sKd
-wPC
-vtw
+xKF
 bEo
 iuo
 iuo
-vtw
+xKF
+bSm
 wOR
 rKn
 sKd
 sKd
-vtw
+xKF
 vtw
 vtw
 rfx
@@ -336958,8 +339039,8 @@ wxd
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -337256,8 +339337,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -337276,17 +339357,17 @@ iuo
 iuo
 iuo
 sKd
-mQA
-vtw
-vtw
-clr
-vtw
-vtw
+xKF
+xKF
+hnd
+xKF
+xKF
 wOR
-vtw
+wOR
+xKF
 mfd
 sKd
-vtw
+xKF
 lAs
 lAs
 pQd
@@ -337360,14 +339441,14 @@ wxd
 wxd
 kVc
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -337426,7 +339507,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -337658,8 +339739,8 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -337679,16 +339760,16 @@ oHg
 iuo
 sKd
 wPC
-vtw
-qHe
+xKF
 wOR
 azQ
 qHe
 wOR
+wOR
 hnd
 sKd
-vtw
-vtw
+xKF
+xKF
 lAs
 lAs
 pQd
@@ -337762,14 +339843,14 @@ wxd
 wxd
 wxd
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -337829,7 +339910,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -337928,7 +340009,7 @@ wxD
 wxD
 wxD
 wxD
-jBv
+sme
 jis
 hpt
 hpt
@@ -338059,9 +340140,9 @@ hcW
 hcW
 hcW
 hcW
-fVM
-jXZ
-jXZ
+hcW
+hcW
+hcW
 hcW
 hcW
 hcW
@@ -338081,15 +340162,15 @@ bXB
 iuo
 sKd
 sKd
-vtw
+xKF
 wOR
 wOR
 wOR
 wOR
 lds
-vtw
-vtw
-vtw
+xKF
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -338164,14 +340245,14 @@ wxd
 wxd
 wxd
 kVc
+cWT
+cWT
 hcW
 hcW
 hcW
 hcW
 hcW
 hcW
-hcW
-hcW
 whb
 whb
 whb
@@ -338231,7 +340312,7 @@ whb
 whb
 whb
 whb
-whb
+qli
 whb
 whb
 whb
@@ -338462,12 +340543,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
-jXZ
-jXZ
-btl
-qbG
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 hcW
 xAt
 xAt
@@ -338483,14 +340564,14 @@ pDa
 iuo
 krp
 sBX
-jMf
+hnd
 wlI
 pHa
 odo
 oBB
 aTg
-vtw
-lAs
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -338566,8 +340647,8 @@ wxd
 wxd
 wxd
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -338864,12 +340945,12 @@ hcW
 hcW
 hcW
 hcW
-jXZ
-jXZ
-jXZ
-cwO
-btl
-qbG
+hcW
+hcW
+hcW
+hcW
+hcW
+hcW
 hcW
 xAt
 xAt
@@ -338882,17 +340963,17 @@ xKF
 xKF
 xKF
 xKF
-hjD
+clr
 xKF
 xKF
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-vtw
-lAs
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
+xKF
 lAs
 lAs
 lAs
@@ -338968,8 +341049,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -339034,6 +341115,10 @@ whb
 whb
 whb
 whb
+qli
+whb
+whb
+qli
 whb
 whb
 whb
@@ -339042,11 +341127,7 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+qli
 whb
 whb
 whb
@@ -339370,8 +341451,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -339438,17 +341519,17 @@ whb
 whb
 whb
 whb
+qli
 whb
 whb
 whb
+qli
 whb
+qli
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+qli
+qli
+qli
 whb
 whb
 whb
@@ -339772,8 +341853,8 @@ wxd
 wxd
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340174,8 +342255,8 @@ wxd
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340576,8 +342657,8 @@ kVc
 kVc
 kVc
 kVc
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -340978,8 +343059,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -341380,8 +343461,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -341782,8 +343863,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342184,8 +344265,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342586,8 +344667,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -342988,8 +345069,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -343390,8 +345471,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -343792,8 +345873,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344194,8 +346275,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344596,8 +346677,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -344998,8 +347079,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -345400,8 +347481,8 @@ hcW
 hcW
 hcW
 hcW
-hcW
-hcW
+cWT
+cWT
 hcW
 hcW
 hcW
@@ -347505,8 +349586,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -347907,8 +349988,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -348309,8 +350390,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -348711,8 +350792,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349113,8 +351194,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349515,8 +351596,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -349917,8 +351998,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -350319,8 +352400,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -350721,8 +352802,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351123,8 +353204,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351525,8 +353606,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -351927,8 +354008,8 @@ gAA
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -352329,8 +354410,8 @@ uuE
 gAA
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -352731,8 +354812,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353133,8 +355214,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353535,8 +355616,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -353937,8 +356018,8 @@ uuE
 uuE
 gAA
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -354339,8 +356420,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -354741,8 +356822,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355143,8 +357224,8 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355545,8 +357626,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -355947,8 +358028,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -356349,8 +358430,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -356751,8 +358832,8 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357153,9 +359234,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357555,9 +359636,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -357957,9 +360038,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -358359,9 +360440,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -358761,9 +360842,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359163,9 +361244,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359565,9 +361646,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -359967,9 +362048,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -360369,9 +362450,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -360771,9 +362852,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361173,9 +363254,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361575,9 +363656,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -361977,9 +364058,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -362379,9 +364460,9 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -362781,9 +364862,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -363183,9 +365264,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -363585,9 +365666,9 @@ uuE
 uuE
 uuE
 gAA
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -363988,7 +366069,7 @@ uuE
 uuE
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -364390,7 +366471,7 @@ uuE
 uuE
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -364792,7 +366873,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -365194,7 +367275,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -365596,7 +367677,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -365998,7 +368079,7 @@ uuE
 gAA
 gAA
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -366400,7 +368481,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -366802,7 +368883,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367204,7 +369285,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -367606,7 +369687,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -368008,7 +370089,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -368410,7 +370491,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -368812,7 +370893,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -369214,7 +371295,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -369612,11 +371693,11 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -370010,15 +372091,15 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -370411,12 +372492,12 @@ uuE
 uuE
 uuE
 uuE
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -370813,7 +372894,7 @@ uuE
 uuE
 uuE
 uuE
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371215,7 +373296,7 @@ uuE
 uuE
 uuE
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -371617,7 +373698,7 @@ uuE
 uuE
 uuE
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -372019,7 +374100,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -372421,7 +374502,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -372823,7 +374904,7 @@ uuE
 uuE
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373225,7 +375306,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -373627,7 +375708,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374029,7 +376110,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374431,7 +376512,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -374833,7 +376914,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375235,7 +377316,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -375637,7 +377718,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376039,7 +378120,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376441,7 +378522,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -376843,7 +378924,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377245,7 +379326,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -377647,7 +379728,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378049,7 +380130,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378451,7 +380532,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -378853,7 +380934,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379255,7 +381336,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -379657,7 +381738,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -380059,7 +382140,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -380461,7 +382542,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -380863,7 +382944,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381148,53 +383229,53 @@ tmH
 tmH
 tmH
 tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
-tmH
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
 uuE
 uuE
 uuE
@@ -381265,7 +383346,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -381446,6 +383527,111 @@ fyc
 (88,1,4) = {"
 aUc
 aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -381485,119 +383671,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -381664,10 +383745,10 @@ uuE
 uuE
 uuE
 uuE
-vIa
 vIa
 vIa
 vIa
+aUc
 vIa
 vIa
 vIa
@@ -381891,6 +383972,31 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -381904,6 +384010,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -381917,42 +384025,15 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -381992,14 +384073,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -382069,7 +384150,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -382293,6 +384374,46 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+nvV
+gNz
+oiE
+uFp
+xpM
+oiE
+oiE
+xpM
+fxH
+dAf
+hJj
+dAf
+lhy
+hJj
+hJj
+woV
+dAf
+dAf
+hJj
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -382307,54 +384428,14 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -382394,14 +384475,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -382471,7 +384552,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -382695,6 +384776,31 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+nvV
+wra
+oiE
+uFp
+xpM
+oiE
+oiE
+xpM
+abZ
+wou
+wou
+abZ
+xpM
+doN
+ijW
+xpM
+lhd
+dAf
+nvr
+pzi
 erZ
 erZ
 erZ
@@ -382709,6 +384815,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -382722,63 +384830,18 @@ erZ
 erZ
 erZ
 erZ
+erZ
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
 erZ
 erZ
 erZ
@@ -382796,6 +384859,15 @@ vIa
 vIa
 vIa
 vIa
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 vIa
 vIa
 vIa
@@ -382804,6 +384876,15 @@ vIa
 vIa
 vIa
 vIa
+vIa
+aUc
+aUc
+vIa
+vIa
+vIa
+vIa
+vIa
+vIa
 uuE
 uuE
 uuE
@@ -382873,7 +384954,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383097,6 +385178,47 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+dbt
+oiE
+xpM
+oiE
+oiE
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+qDn
+qDn
+xpM
+wUw
+ukL
+cld
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -383114,69 +385236,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
 vIa
 erZ
 erZ
@@ -383196,6 +385259,18 @@ vIa
 vIa
 vIa
 vIa
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 vIa
 vIa
 vIa
@@ -383204,6 +385279,12 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
+vIa
+vIa
+vIa
+vIa
 vIa
 vIa
 vIa
@@ -383275,7 +385356,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383499,6 +385580,31 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+dbt
+uFp
+xpM
+oiE
+oiE
+xpM
+wbT
+dAf
+dAf
+sbF
+xpM
+eWC
+eWC
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -383509,6 +385615,48 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+aUc
+aUc
+aUc
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+vIa
+vIa
 erZ
 erZ
 erZ
@@ -383533,75 +385681,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -383677,7 +385758,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -383901,6 +385982,72 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+egu
+oiE
+xpM
+oiE
+oiE
+xpM
+ehI
+dAf
+dAf
+sbF
+xpM
+lGI
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+aUc
+vIa
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -383935,75 +386082,9 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
 vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -384079,7 +386160,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -384303,6 +386384,47 @@ erZ
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+nfb
+xpM
+xpM
+xpM
+xpM
+kFr
+kvj
+dAf
+gbf
+xpM
+wou
+wou
+woV
+dAf
+nvr
+hJj
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384321,50 +386443,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384404,8 +386485,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -384481,7 +386562,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -384705,6 +386786,47 @@ vIa
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+gvi
+oiE
+dey
+oiE
+oiE
+sXG
+xpM
+hAc
+dAf
+dAf
+dAf
+wou
+abZ
+xpM
+dAf
+dAf
+xpM
+dAf
+dAf
+dAf
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384722,51 +386844,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -384806,8 +386887,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -384883,7 +386964,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385107,6 +387188,47 @@ vIa
 erZ
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+gba
+oiE
+oiE
+oiE
+uFp
+uXS
+xpM
+hAc
+dAf
+fqy
+dAf
+csE
+abZ
+xpM
+lGI
+dAf
+xpM
+loE
+tAs
+cld
+pzi
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385123,52 +387245,11 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385208,8 +387289,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -385285,7 +387366,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385509,6 +387590,47 @@ vIa
 vIa
 erZ
 erZ
+dAf
+dAf
+dAf
+xpM
+jcT
+oiE
+oiE
+uFp
+oiE
+uXS
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ajD
+ajD
+xpM
+xpM
+xpM
+xpM
+xpM
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
 erZ
 erZ
 erZ
@@ -385525,51 +387647,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -385610,8 +387691,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -385687,7 +387768,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -385914,6 +387995,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+iIA
+oiE
+oiE
+oiE
+oiE
+sXG
+xpM
+hjD
+lAK
+qzy
+dey
+qzy
+lAK
+mKz
+oiE
+pUQ
+htf
 erZ
 erZ
 erZ
@@ -385933,6 +388032,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -385948,28 +388048,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386012,14 +388093,14 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -386089,7 +388170,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -386316,6 +388397,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+vHh
+uFp
+oiE
+rGY
+oiE
+kTx
+xpM
+oiE
+xdw
+xdw
+oiE
+xAo
+xAo
+oiE
+uFp
+oiE
+htf
 erZ
 erZ
 erZ
@@ -386335,6 +388434,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -386350,28 +388450,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386414,13 +388495,13 @@ vIa
 vIa
 vIa
 vIa
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
 uuE
 uuE
 uuE
@@ -386491,7 +388572,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -386718,6 +388799,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+qSE
+oiE
+hjD
+fHr
+oiE
+vQV
+gGF
+oiE
+uFp
+oiE
+uFp
+oiE
+oiE
+oiE
+oiE
+oiE
+htf
 erZ
 erZ
 erZ
@@ -386737,6 +388836,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -386752,28 +388852,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ryI
-nqU
-oJO
-nqU
-nqU
-ryI
-nqU
-oJO
-nqU
-nqU
-cjJ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -386816,8 +388897,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -386893,7 +388974,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -387120,6 +389201,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+pdm
+oiE
+hjD
+tnh
+oiE
+kTx
+xpM
+oiE
+iSJ
+iSJ
+oiE
+oiE
+nIq
+nIq
+oiE
+uFp
+htf
 erZ
 erZ
 erZ
@@ -387139,6 +389238,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -387154,28 +389254,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-nqU
-bUi
-xbD
-xbD
-dwO
-nqU
-dTa
-xbD
-bUi
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387218,8 +389299,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -387295,7 +389376,7 @@ uuE
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -387522,6 +389603,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+tSN
+oiE
+oiE
+oiE
+oiE
+tKf
+xpM
+hjD
+qzy
+qzy
+mKz
+pUQ
+oiE
+gNz
+nuH
+oiE
+htf
 erZ
 erZ
 erZ
@@ -387541,6 +389640,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387554,30 +389655,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-ikM
-xbD
-xbD
-nBf
-nqU
-kvj
-xbD
-ikM
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387620,8 +389701,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -387697,7 +389778,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -387924,6 +390005,24 @@ erZ
 erZ
 erZ
 erZ
+xpM
+uje
+oiE
+hjD
+fHr
+oiE
+tKf
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+pLK
+pLK
+xpM
 erZ
 erZ
 erZ
@@ -387943,6 +390042,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -387956,30 +390057,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-cwd
-xbD
-xbD
-xkF
-nqU
-bVa
-xbD
-xbD
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388022,7 +390103,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -388099,7 +390180,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -388326,52 +390407,28 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
+xpM
+pdm
+oiE
+hjD
+tnh
+oiE
+uDw
+xpM
+vor
+rcr
+uVs
+fLK
+uVs
+rcr
+fLK
 nuH
-xbD
-xbD
-vdg
-nqU
-vdg
-xbD
-xbD
-nqU
-ebb
+oiE
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -388382,6 +390439,30 @@ erZ
 erZ
 erZ
 erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388424,7 +390505,7 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -388501,7 +390582,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -388725,7 +390806,31 @@ erZ
 erZ
 erZ
 erZ
-vIa
+aUc
+erZ
+xpM
+xpM
+dbt
+oiE
+oiE
+hzX
+oiE
+xwi
+xpM
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+vjs
+oiE
+woV
+dAf
+dAf
+hJj
+pzi
 erZ
 erZ
 erZ
@@ -388742,6 +390847,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -388755,35 +390861,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-ryI
-cld
-skP
-kHC
-nqU
-nqU
-nqU
-cld
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -388826,7 +390907,7 @@ erZ
 erZ
 erZ
 vIa
-vIa
+aUc
 aUc
 vIa
 vIa
@@ -388901,9 +390982,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
+aUc
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -389127,8 +391208,31 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
+xpM
+xpM
+dbt
+uFp
+oiE
+oiE
+oiE
+vQV
+xpM
+pKQ
+oiE
+oiE
+lXh
+oiE
+vjs
+oiE
+oiE
+oiE
+xpM
+hNk
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -389145,6 +391249,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -389158,34 +391263,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-woq
-xbD
-bqt
-jCh
-nqU
-xbD
-xbD
-xbD
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -389302,8 +391383,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -389529,10 +391610,31 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+eoz
+eoz
+dbt
+rfd
+vQV
+oiE
+uFp
+oiE
+iAh
+oiE
+vjs
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+xpM
+lhd
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -389549,6 +391651,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -389562,31 +391665,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-nqU
-jCr
-xbD
 ebe
 ebe
-xbD
-xbD
-jCr
-xbD
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
 erZ
 erZ
 erZ
@@ -389704,7 +391785,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 gxt
@@ -389933,10 +392014,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+eoz
+eoz
+eoz
+vQV
+vQV
+oiE
+oiE
+yjl
+xId
+oiE
+oiE
+oiE
+oiE
+oiE
+oiE
+vjs
+oiE
+xpM
+lGI
+dAf
+dAf
+pzi
 erZ
 erZ
 erZ
@@ -389953,6 +392053,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -389966,29 +392067,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-ebb
-nqU
-ryI
-cld
-skP
-kHC
-nqU
-nqU
-nqU
-nqU
-nqU
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390105,8 +392186,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -390336,10 +392417,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+eoz
+eoz
+hvo
+vQV
+vQV
+xpM
+xpM
+nJy
+nJy
+kOA
+nJy
+nuH
+oiE
+oiE
+oiE
+xpM
+ejA
+cld
+fsu
+pzi
 erZ
 erZ
 erZ
@@ -390356,6 +392455,7 @@ erZ
 erZ
 erZ
 erZ
+ebe
 erZ
 erZ
 erZ
@@ -390369,28 +392469,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-ebb
-nqU
-xbD
-xbD
-xbD
-cMs
-nqU
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390506,8 +392587,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -390739,11 +392820,27 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+eoz
+eoz
+eoz
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+yeA
+yeA
+yeA
+yeA
+xpM
+xpM
+xpM
+xpM
+xpM
 erZ
 erZ
 erZ
@@ -390760,6 +392857,8 @@ erZ
 erZ
 erZ
 erZ
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390772,27 +392871,9 @@ erZ
 erZ
 erZ
 erZ
-ebb
-nqU
-qYw
-kFh
-mVz
-xbD
-lGI
-ebb
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -390907,8 +392988,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -391142,11 +393223,12 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+ebe
 erZ
 erZ
 erZ
@@ -391174,14 +393256,12 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ryI
-nqU
-nqU
-nqU
-nqU
-ryI
-ebb
+erZ
+erZ
+erZ
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -391192,9 +393272,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -391309,7 +393390,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 uuE
@@ -391576,26 +393657,26 @@ erZ
 erZ
 erZ
 erZ
-ebb
-vLA
-vLA
-vLA
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -391710,8 +393791,8 @@ vIa
 vIa
 vIa
 gxt
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -391978,14 +394059,6 @@ erZ
 erZ
 erZ
 erZ
-ebb
-vLA
-erZ
-vLA
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -391996,7 +394069,15 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -392111,8 +394192,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 uuE
@@ -392381,9 +394462,6 @@ erZ
 erZ
 erZ
 erZ
-vLA
-vLA
-vLA
 erZ
 erZ
 erZ
@@ -392394,10 +394472,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -392512,8 +394593,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -392768,6 +394849,14 @@ erZ
 erZ
 erZ
 erZ
+jeb
+jeb
+jeb
+jeb
+jeb
+jeb
+jeb
+xKz
 erZ
 erZ
 erZ
@@ -392785,21 +394874,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -392911,10 +394992,10 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
-gxt
+aUc
+aUc
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -393163,6 +395244,21 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+lqm
+aen
+qof
+sXW
+maB
+qxO
+xKz
 erZ
 erZ
 erZ
@@ -393180,28 +395276,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -393312,7 +395393,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -393565,6 +395646,26 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+tdJ
+tCz
+tCz
+qzx
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+jeb
+jeb
+jeb
+jeb
+jeb
 erZ
 erZ
 erZ
@@ -393577,33 +395678,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+eza
+eSt
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -393713,8 +395794,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -393967,6 +396048,26 @@ vIa
 erZ
 erZ
 erZ
+fVQ
+fVQ
+xKz
+lLa
+lLa
+lLa
+lLa
+xKz
+fVQ
+fVQ
+jeb
+mVz
+fVQ
+xlb
+xKz
+fVQ
+bvN
+tYP
+kgt
+jeb
 erZ
 erZ
 erZ
@@ -393979,33 +396080,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394115,7 +396196,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -394369,6 +396450,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+xKz
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+oir
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+oir
+fVQ
+bvN
+tYP
+cRP
+jeb
 erZ
 erZ
 erZ
@@ -394381,33 +396482,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394516,7 +396597,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -394771,6 +396852,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+pLf
+cAj
+fVQ
+fVQ
+lLa
+dfz
+jeb
+dpr
+fkr
+oJH
+xQv
+fVQ
+lLa
+xKz
+fVQ
+tYP
+tYP
+bcO
+jeb
 erZ
 erZ
 erZ
@@ -394783,33 +396884,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -394917,8 +396998,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -395173,6 +397254,26 @@ vIa
 erZ
 erZ
 erZ
+xKz
+oLF
+cAj
+fVQ
+fVQ
+lLa
+dfz
+jeb
+xKz
+xKz
+xKz
+xKz
+nGw
+xKz
+xKz
+fVQ
+tYP
+tYP
+jlk
+jeb
 erZ
 erZ
 erZ
@@ -395185,33 +397286,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395318,8 +397399,8 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -395575,6 +397656,26 @@ erZ
 erZ
 erZ
 erZ
+xKz
+vXz
+cAj
+fVQ
+fVQ
+fVQ
+fVQ
+oir
+fVQ
+xjp
+rxa
+uOc
+fVQ
+sBJ
+xKz
+fVQ
+bvN
+tYP
+kgt
+jeb
 erZ
 erZ
 erZ
@@ -395587,33 +397688,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+eza
+eSt
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -395719,8 +397800,8 @@ uuE
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -395977,6 +398058,26 @@ erZ
 erZ
 erZ
 erZ
+xKz
+oTE
+cAj
+fVQ
+fGX
+fVQ
+fVQ
+jeb
+qEj
+fVQ
+fVQ
+fVQ
+fVQ
+guS
+xKz
+fVQ
+bvN
+tYP
+cRP
+jeb
 erZ
 erZ
 erZ
@@ -395989,33 +398090,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+eSt
+cdn
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -396121,7 +398202,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -396379,14 +398460,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
 xKz
-jeb
-jeb
 xKz
-jeb
-jeb
 xKz
+xKz
+xKz
+mWn
+xKz
+xKz
+wPd
+fVQ
+jeb
+mVz
+fVQ
+fjW
+xKz
+fVQ
+tYP
+tYP
+bcO
+jeb
 erZ
 erZ
 erZ
@@ -396399,25 +398492,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eza
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -396522,7 +398603,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -396781,13 +398862,25 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
+utx
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+rRM
 fVQ
 fVQ
 fVQ
 fVQ
 fVQ
+xKz
+fVQ
+tYP
+tYP
+jlk
 jeb
 erZ
 erZ
@@ -396801,25 +398894,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+eSt
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -396924,7 +399005,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -397183,13 +399264,25 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
-fVQ
+utx
 lLa
 vZP
 lLa
 fVQ
+xKz
+brt
+hrk
+hOM
+cbo
+fVQ
+tAT
+xKz
+fVQ
+fIB
+tYP
+kgt
 jeb
 erZ
 erZ
@@ -397203,25 +399296,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
+jIP
+jIP
+jIP
+jIP
+qCT
 erZ
 erZ
 erZ
@@ -397325,7 +399406,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -397585,42 +399666,42 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 xKz
 fVQ
 lLa
 noC
 lLa
+xlb
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
+xKz
 fVQ
+fIB
+fVQ
+fVQ
+jeb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+cxZ
+jIP
 xKz
-jeb
-jeb
-xKz
-jeb
-jeb
-xKz
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-xKz
-jeb
+jrn
 bOK
 jeb
 xKz
@@ -397726,8 +399807,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 gxt
@@ -397987,20 +400068,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
+qMJ
 jeb
 kHs
 tat
 xAL
 tat
 nIo
+xKz
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+xKz
+xKz
+mWn
+xKz
+xKz
+xKz
 jeb
-ufd
-ufd
-ufd
-ufd
-ufd
-jeb
 erZ
 erZ
 erZ
@@ -398013,14 +400100,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cxZ
+jIP
 jeb
 fVQ
 ugK
@@ -398127,7 +400208,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -398397,12 +400478,18 @@ bOK
 rOt
 fVQ
 kdM
-ufd
-ufd
-ufd
-ufd
-ufd
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 kdM
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 pty
 pty
 pty
@@ -398416,13 +400503,7 @@ pty
 pty
 pty
 pty
-pty
-pty
-pty
-pty
-pty
-pty
-pty
+rsd
 bOK
 kHs
 gGH
@@ -398528,7 +400609,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -398801,16 +400882,16 @@ vES
 xKz
 xKz
 kBs
-peN
-peN
+jeb
+jeb
 xKz
 xKz
 evw
-rsd
-rsd
-rsd
-rsd
-rsd
+fVQ
+fVQ
+fVQ
+fVQ
+fVQ
 rsd
 rsd
 rsd
@@ -398930,7 +401011,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -399331,7 +401412,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -399628,7 +401709,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-lat
+fZJ
 xqX
 ufd
 irc
@@ -399732,7 +401813,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 vIa
 gxt
@@ -400428,7 +402509,7 @@ fZJ
 xMr
 xMr
 xMr
-cyU
+xMr
 xMr
 xMr
 fZJ
@@ -400534,8 +402615,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -400934,8 +403015,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -401335,8 +403416,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 vIa
 gxt
 gxt
@@ -401737,7 +403818,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -402533,12 +404614,12 @@ uuE
 uuE
 pAV
 pAV
-mhg
-tGZ
+xou
+xou
 jCh
 ots
-tGZ
-rMd
+xou
+cqx
 pAV
 pAV
 pAV
@@ -402933,14 +405014,14 @@ uuE
 uuE
 uuE
 uuE
-xkD
-jjA
-ren
-tGZ
-rbn
-axR
-bZF
-ivo
+ksW
+xou
+xou
+xou
+jCh
+ots
+xou
+cqx
 pAV
 pAV
 pAV
@@ -403335,16 +405416,16 @@ uuE
 uuE
 uuE
 uuE
-cAu
-aOE
-xYg
-bZF
-bZF
-bZF
-syF
-aOE
-tGZ
-aRt
+pAV
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+aav
 pAV
 gxt
 gxt
@@ -403738,15 +405819,15 @@ uuE
 uuE
 uuE
 ksW
-tGZ
-bZF
-jmj
-qFJ
-gMB
-bZF
-tGZ
-tGZ
-xyo
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
 hHI
 gxt
 gxt
@@ -403972,7 +406053,7 @@ wtF
 wtF
 wtF
 wtF
-cBj
+npm
 wtF
 wtF
 wtF
@@ -404141,13 +406222,13 @@ uuE
 uuE
 hHI
 hHI
-tGZ
-tGZ
-tGZ
-xMI
-bZF
-tGZ
-xoe
+xou
+xou
+xou
+xou
+xou
+xou
+xou
 hHI
 hHI
 gxt
@@ -404541,13 +406622,13 @@ uuE
 uuE
 uuE
 uuE
-uuE
+rUt
 hHI
 hHI
 hHI
-tGZ
-jbp
-tGZ
+xou
+pAV
+xou
 pAV
 pAV
 hHI
@@ -404943,14 +407024,14 @@ uuE
 uuE
 uuE
 uuE
-uuE
-uuE
+ipd
+izW
 hHI
-muC
-bZF
-bZF
-bZF
-bZF
+xou
+xou
+xou
+xou
+xou
 pAV
 uuE
 uuE
@@ -405346,14 +407427,14 @@ uuE
 uuE
 uuE
 uuE
-uuE
+rUt
 ksW
-bZF
-bZF
-jmj
-jmh
-qMc
-xAQ
+xou
+xou
+xou
+xou
+xou
+ksW
 uuE
 uuE
 uuE
@@ -405654,7 +407735,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -405749,13 +407830,13 @@ uuE
 uuE
 uuE
 rUt
+ksW
 xou
-dkc
-kzO
-unk
-gMB
-qMc
-hVd
+xou
+xou
+xou
+xou
+ksW
 uuE
 uuE
 uuE
@@ -406056,7 +408137,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -406152,11 +408233,11 @@ uuE
 uuE
 rUt
 pAV
-oHB
-hLI
-tLP
-wbC
-bZF
+xou
+xou
+xou
+xou
+xou
 hHI
 uuE
 uuE
@@ -406385,7 +408466,7 @@ cUW
 xlm
 oPy
 xlm
-tmE
+ouN
 pqw
 iur
 twQ
@@ -406458,7 +408539,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -406554,12 +408635,12 @@ uuE
 uuE
 rUt
 ksW
-bZF
-jmj
-fKV
-qMc
-bZF
-xAQ
+xou
+xou
+xou
+xou
+xou
+ksW
 uuE
 uuE
 uuE
@@ -406956,12 +409037,12 @@ uuE
 uuE
 rUt
 ksW
-bZF
-jmj
-tnG
-qMc
-bZF
-aOE
+xou
+xou
+xou
+xou
+xou
+ksW
 uuE
 uuE
 uuE
@@ -407358,11 +409439,11 @@ uuE
 mjG
 mTO
 hHI
-bZF
-bZF
-bZF
-bZF
-bZF
+xou
+xou
+xou
+xou
+xou
 hHI
 uuE
 uuE
@@ -408162,12 +410243,12 @@ mTO
 hHI
 hHI
 hdL
-syF
-bZF
-jmj
-ncu
-bZF
-oLi
+xou
+xou
+xou
+xou
+xou
+xou
 pAV
 hHI
 gxt
@@ -408397,14 +410478,14 @@ nBW
 nBW
 dEA
 wtF
-cBj
+npm
 wtF
 wtF
 cpf
-cBj
+npm
 cpf
 wtF
-cBj
+npm
 cpf
 jTP
 fZJ
@@ -408562,15 +410643,15 @@ wSJ
 wSJ
 wSJ
 urP
-tGZ
-tGZ
-bZF
-ulG
-avF
-avF
-xqi
-bZF
-pDv
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
 hHI
 gxt
 gxt
@@ -408958,22 +411039,22 @@ uuE
 uuE
 uuE
 uuE
-uuE
+rUt
 wSJ
-uuE
-uuE
 wSJ
-pAV
-xoe
-tGZ
-eLM
-avF
-avF
-rbn
-rbn
-fKV
-tGZ
-xAQ
+wSJ
+wSJ
+hHI
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+hHI
 gxt
 gxt
 uuE
@@ -409363,18 +411444,18 @@ uuE
 rUt
 wSJ
 wSJ
-pVv
 wSJ
-hNP
-tGZ
-tGZ
-ulG
-rbn
-rbn
-ubK
-xqi
-wKv
-tGZ
+wSJ
+urP
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
+xou
 pAV
 gxt
 gxt
@@ -409763,19 +411844,19 @@ uuE
 uuE
 uuE
 rUt
-uuE
+wSJ
 wSJ
 wSJ
 wSJ
 pAV
 pAV
-tGZ
-tGZ
-tGZ
-tGZ
-tGZ
-diw
-nog
+xou
+xou
+xou
+xou
+xou
+xou
+xou
 pAV
 pAV
 gxt
@@ -410166,7 +412247,7 @@ uuE
 uuE
 rUt
 wSJ
-wSJ
+gkv
 vIa
 vIa
 vIa
@@ -410580,7 +412661,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -410981,8 +413062,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -411219,7 +413300,7 @@ ohU
 wKq
 duQ
 ohU
-tmE
+ouN
 fZJ
 fZJ
 fZJ
@@ -411282,12 +413363,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-mhU
-kOJ
-bEs
-bEs
-bEs
-bEs
+geq
+fZJ
+fZJ
+fZJ
+fZJ
+tkO
 xKz
 rsd
 rsd
@@ -411383,7 +413464,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -411689,7 +413770,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-fZJ
+hQJ
 loJ
 rsd
 rsd
@@ -411785,7 +413866,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -412023,7 +414104,7 @@ omr
 sFy
 pNf
 omr
-tmE
+ouN
 fZJ
 fZJ
 fZJ
@@ -412091,7 +414172,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-fZJ
+hQJ
 peN
 rsd
 rsd
@@ -412184,9 +414265,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 gxt
 gxt
 gxt
@@ -412493,7 +414574,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-fZJ
+hQJ
 peN
 rsd
 rsd
@@ -412585,7 +414666,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -412895,7 +414976,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-fZJ
+nxQ
 xKz
 rsd
 rsd
@@ -412986,7 +415067,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -413286,8 +415367,8 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
-nbz
+fZJ
+fZJ
 nbz
 nbz
 nbz
@@ -413329,10 +415410,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -413387,7 +415468,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 vIa
 gxt
 gxt
@@ -413719,23 +415800,23 @@ erZ
 erZ
 erZ
 erZ
-ryI
-wOD
-wOD
-ryI
-wOD
-wOD
-ryI
+hcg
+rST
+rST
+hcg
+rST
+rST
+hcg
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 lVe
@@ -413788,7 +415869,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 gxt
 gxt
 gxt
@@ -414121,23 +416202,23 @@ erZ
 erZ
 erZ
 erZ
-trG
+pPO
 lYv
-eng
-trG
+lwC
+pPO
 wdJ
-fQN
-trG
+xld
+pPO
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 pBL
@@ -414188,8 +416269,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -414524,22 +416605,22 @@ erZ
 erZ
 erZ
 bkW
-ltT
-ltT
-trG
-wBf
-ltT
+xvu
+xvu
+pPO
+xrl
+xvu
 uVC
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 lVe
 lVe
 lVe
@@ -414588,9 +416669,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-gxt
+aUc
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -414925,23 +417006,23 @@ erZ
 erZ
 erZ
 erZ
-trG
-dwL
-ltT
-trG
-ltT
-dwL
-trG
+pPO
+qoZ
+xvu
+pPO
+xvu
+qoZ
+pPO
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 lVe
 mpX
 xou
@@ -414989,8 +417070,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-gxt
+aUc
+fyc
 gxt
 gxt
 gxt
@@ -415258,7 +417339,7 @@ gPy
 gPy
 fZJ
 fZJ
-nxQ
+gHt
 vka
 kbk
 wan
@@ -415327,23 +417408,23 @@ erZ
 erZ
 erZ
 erZ
-ryI
-wOD
+hcg
+rST
 vou
-ryI
+hcg
 vou
-wOD
-ryI
+rST
+hcg
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 lVe
 jxc
 xou
@@ -415390,8 +417471,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -415704,7 +417785,7 @@ nxK
 nxK
 uDM
 xMr
-sba
+fZJ
 fZJ
 fZJ
 fZJ
@@ -415729,23 +417810,23 @@ erZ
 erZ
 erZ
 erZ
-trG
+pPO
 wYB
-ltT
-ltT
-ltT
+xvu
+xvu
+xvu
 jon
-trG
+pPO
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 lVe
 vPP
 xou
@@ -415790,8 +417871,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -416106,7 +418187,7 @@ qOf
 nxK
 fuw
 xMr
-lJH
+fZJ
 fZJ
 fZJ
 fZJ
@@ -416133,9 +418214,9 @@ erZ
 erZ
 cMU
 qaD
-ltT
-ltT
-ltT
+xvu
+xvu
+xvu
 fzS
 sjH
 erZ
@@ -416143,11 +418224,11 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 lVe
 lVe
 lVe
@@ -416191,8 +418272,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 gxt
 gxt
@@ -416489,7 +418570,7 @@ kkF
 wvE
 wvE
 wvE
-wsx
+ruI
 fZJ
 fZJ
 fZJ
@@ -416508,7 +418589,7 @@ xMr
 kgC
 xMr
 evo
-hbN
+fZJ
 fZJ
 fZJ
 fZJ
@@ -416533,23 +418614,23 @@ erZ
 erZ
 erZ
 erZ
-trG
+pPO
 kFj
-ltT
-ltT
-ltT
-ltT
-trG
+xvu
+xvu
+xvu
+xvu
+pPO
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 pBL
@@ -416593,7 +418674,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 gxt
 uuE
@@ -416910,7 +418991,7 @@ qkH
 qkH
 qkH
 lZh
-uuY
+gYV
 fZJ
 fZJ
 fZJ
@@ -416935,23 +419016,23 @@ erZ
 erZ
 erZ
 erZ
-ryI
+hcg
 fPa
-ltT
+xvu
 uoW
 qPm
 jPB
-ryI
+hcg
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 lVe
@@ -416994,8 +419075,8 @@ vIa
 vIa
 vIa
 vIa
-gxt
-gxt
+fyc
+fyc
 gxt
 uuE
 uuE
@@ -417275,7 +419356,7 @@ ygF
 ygF
 ygF
 ygF
-ygF
+rfO
 jYR
 lHe
 lHe
@@ -417337,23 +419418,23 @@ erZ
 erZ
 erZ
 erZ
-trG
-ltT
-ltT
+pPO
+xvu
+xvu
 lOP
+erZ
+erZ
+pPO
+erZ
+erZ
+erZ
+erZ
+erZ
 jCh
 jCh
-trG
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -417396,7 +419477,7 @@ vIa
 vIa
 vIa
 gxt
-gxt
+fyc
 gxt
 uuE
 uuE
@@ -417739,13 +419820,13 @@ erZ
 erZ
 erZ
 erZ
-trG
-ltT
-ltT
+pPO
+xvu
+xvu
 lOP
-jCh
-jCh
-trG
+erZ
+erZ
+pPO
 erZ
 erZ
 erZ
@@ -418141,13 +420222,13 @@ erZ
 erZ
 erZ
 erZ
-ryI
-phV
-phV
+hcg
+oFi
+oFi
 qvd
-jCh
-jCh
-ryI
+erZ
+erZ
+hcg
 erZ
 erZ
 erZ
@@ -418476,7 +420557,7 @@ wan
 liY
 xYz
 xYz
-jnv
+oCL
 yfr
 ygF
 scU
@@ -418499,7 +420580,7 @@ wvE
 wvE
 wvE
 wvE
-wsx
+ruI
 fZJ
 fZJ
 fZJ
@@ -418543,13 +420624,13 @@ erZ
 erZ
 erZ
 erZ
-trG
-jCh
-jCh
-jCh
-jCh
-jCh
-trG
+pPO
+erZ
+erZ
+erZ
+erZ
+erZ
+pPO
 erZ
 erZ
 erZ
@@ -418878,7 +420959,7 @@ wan
 yfo
 xYz
 xFE
-scF
+oCL
 yfr
 ygF
 vkY
@@ -418945,13 +421026,13 @@ erZ
 erZ
 erZ
 erZ
-trG
-jCh
-jCh
-jCh
-jCh
-jCh
-trG
+pPO
+erZ
+erZ
+erZ
+erZ
+erZ
+pPO
 erZ
 erZ
 erZ
@@ -419347,22 +421428,22 @@ erZ
 erZ
 erZ
 erZ
-trG
+pPO
+erZ
+erZ
+erZ
+erZ
+erZ
+pPO
+erZ
+erZ
+erZ
+erZ
+erZ
 jCh
 jCh
 jCh
 jCh
-jCh
-trG
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
 erZ
 erZ
 erZ
@@ -419706,7 +421787,6 @@ ous
 gVg
 ueL
 xMr
-oHA
 fZJ
 fZJ
 fZJ
@@ -419724,7 +421804,8 @@ fZJ
 fZJ
 fZJ
 fZJ
-lJH
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -419749,22 +421830,22 @@ erZ
 erZ
 erZ
 erZ
-ryI
-wOD
-wOD
-wOD
-wOD
-wOD
-ryI
+hcg
+rST
+rST
+rST
+rST
+rST
+hcg
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -420107,8 +422188,7 @@ kMn
 ous
 ous
 ous
-wle
-iTZ
+sKf
 fZJ
 fZJ
 fZJ
@@ -420126,7 +422206,8 @@ fZJ
 fZJ
 fZJ
 fZJ
-aAO
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -420163,11 +422244,11 @@ erZ
 erZ
 ybl
 iNS
-atT
-iNS
-iNS
-pyF
-erZ
+hdB
+hdB
+hdB
+vqc
+jCh
 erZ
 erZ
 erZ
@@ -420510,25 +422591,25 @@ ous
 ous
 qPt
 xMr
-ilM
-bEs
-bEs
-bEs
-bEs
-bEs
-bEs
-vju
-vju
-vju
-vju
-vju
-vju
-vju
-bEs
-nwK
 fZJ
 fZJ
-hbN
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+gYV
+gYV
+gYV
+gYV
+gYV
+gYV
+gYV
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -420565,10 +422646,10 @@ erZ
 erZ
 mpm
 wQI
-wQI
-wQI
-wQI
-jHj
+xbD
+xbD
+xbD
+uDh
 erZ
 erZ
 erZ
@@ -420900,7 +422981,7 @@ mZV
 bhy
 wyr
 vSF
-gjj
+lCO
 xMr
 xMr
 alY
@@ -420934,8 +423015,8 @@ gYV
 gYV
 gYV
 gYV
-ylU
-ivL
+fZJ
+hQJ
 ufd
 irc
 erZ
@@ -420967,10 +423048,10 @@ erZ
 erZ
 mpm
 wQI
-wQI
-wQI
-wQI
-jHj
+xbD
+xbD
+xbD
+uDh
 erZ
 erZ
 erZ
@@ -421307,7 +423388,7 @@ dHZ
 xMr
 xMr
 xMr
-uzS
+nIy
 xMr
 dHZ
 xMr
@@ -421329,13 +423410,13 @@ bmi
 ksu
 qkH
 fZJ
-bne
-pAV
-trG
-trG
-trG
-trG
-pAV
+gYV
+lZh
+qkH
+qkH
+qkH
+qkH
+lZh
 fZJ
 hQJ
 ufd
@@ -421369,9 +423450,9 @@ erZ
 erZ
 mpm
 wQI
-wQI
-wQI
-wQI
+xbD
+xbD
+xbD
 jHj
 erZ
 erZ
@@ -421731,13 +423812,13 @@ bmi
 bmi
 qkH
 fZJ
-bne
-wOD
+gYV
+hUa
 myB
-ktN
-nmu
-xvs
-wOD
+knU
+rQu
+bmi
+hUa
 fZJ
 hQJ
 ufd
@@ -421771,9 +423852,9 @@ erZ
 erZ
 mpm
 wQI
-wQI
-wQI
-wQI
+xbD
+xbD
+xbD
 jHj
 erZ
 erZ
@@ -422133,13 +424214,13 @@ bmi
 bmi
 qkH
 fZJ
-bne
-wOD
-xvs
-rcT
-xvs
-xvs
-wOD
+gYV
+hUa
+bmi
+jZJ
+bmi
+bmi
+hUa
 fZJ
 hQJ
 ufd
@@ -422173,9 +424254,9 @@ erZ
 erZ
 mpm
 wQI
-wQI
-wQI
-wQI
+xbD
+xbD
+xbD
 jHj
 erZ
 erZ
@@ -422535,13 +424616,13 @@ bmi
 hob
 qkH
 fZJ
-bne
-xld
+gYV
+jXw
 oxL
-xvs
-xvs
-xvs
-wOD
+bmi
+bmi
+bmi
+hUa
 fZJ
 hQJ
 ufd
@@ -422937,13 +425018,13 @@ bmi
 lpe
 qkH
 fZJ
-bne
-wOD
-aDk
+gYV
+hUa
+qIi
 xXQ
-pto
-tVJ
-wOD
+fQP
+pRE
+hUa
 fZJ
 hQJ
 ufd
@@ -423339,13 +425420,13 @@ bmi
 bmi
 qkH
 fZJ
-bne
-pAV
-trG
-trG
-trG
-trG
-pAV
+gYV
+lZh
+qkH
+qkH
+qkH
+qkH
+lZh
 fZJ
 hQJ
 ufd
@@ -423741,13 +425822,13 @@ bmi
 bmi
 qkH
 fZJ
-bne
-wOD
-tnW
-ktN
-nmu
-vtp
-wOD
+gYV
+hUa
+bIc
+knU
+rQu
+qny
+hUa
 fZJ
 hQJ
 ufd
@@ -424143,13 +426224,13 @@ bmi
 pDK
 qkH
 fZJ
-bne
-wOD
-tnW
-xvs
-xvs
-xvs
-wOD
+gYV
+hUa
+bIc
+bmi
+bmi
+bmi
+hUa
 fZJ
 hQJ
 ufd
@@ -424545,13 +426626,13 @@ qkH
 qkH
 kjH
 fZJ
-bne
-xld
-xvs
-xvs
-xvs
-rSN
-wOD
+gYV
+jXw
+bmi
+bmi
+bmi
+vCb
+hUa
 fZJ
 hQJ
 ufd
@@ -424947,13 +427028,13 @@ fZJ
 fZJ
 fZJ
 fZJ
-bne
-wOD
-aDk
-xvs
-pto
-tVJ
-wOD
+gYV
+hUa
+qIi
+bmi
+fQP
+pRE
+hUa
 fZJ
 hQJ
 ufd
@@ -425349,19 +427430,19 @@ fZJ
 fZJ
 fZJ
 fZJ
-bne
-pAV
-trG
-trG
-trG
-trG
-pAV
+gYV
+lZh
+qkH
+qkH
+qkH
+qkH
+lZh
 fZJ
 hQJ
 ufd
 irc
 erZ
-mlM
+erZ
 mpm
 nqU
 ryI
@@ -425751,13 +427832,13 @@ fZJ
 fZJ
 fZJ
 fZJ
-bne
-wOD
+gYV
+hUa
 vOU
 mDe
-nmu
-rSN
-wOD
+rQu
+vCb
+hUa
 fZJ
 hQJ
 ufd
@@ -426153,13 +428234,13 @@ fZJ
 fZJ
 fZJ
 fZJ
-bne
-xld
-xvs
-xvs
-xvs
-xvs
-wOD
+gYV
+jXw
+bmi
+bmi
+bmi
+bmi
+hUa
 fZJ
 mrP
 ufd
@@ -426555,15 +428636,15 @@ fZJ
 fZJ
 fZJ
 fZJ
-bne
-wOD
-pto
-vtp
-rcT
-tVJ
-wOD
+gYV
+hUa
+fQP
+qny
+jZJ
+pRE
+hUa
 fZJ
-hQJ
+fZJ
 ufd
 nYO
 erZ
@@ -426595,10 +428676,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -426957,15 +429038,15 @@ fZJ
 fZJ
 fZJ
 fZJ
-bne
-pAV
-trG
-trG
-reT
-trG
-pAV
 fZJ
-hQJ
+lZh
+qkH
+qkH
+xzP
+qkH
+lZh
+fZJ
+fZJ
 ufd
 nYO
 erZ
@@ -426985,22 +429066,22 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -427360,14 +429441,14 @@ fZJ
 fZJ
 fZJ
 fZJ
-wTU
+lZh
 uZM
-tyH
-tyH
-tyH
-wTU
+bmi
+bmi
+bmi
+lZh
 vIa
-hQJ
+fZJ
 ufd
 nYO
 erZ
@@ -427387,22 +429468,22 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -427762,12 +429843,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-wTU
+lZh
 cKr
-tyH
-tyH
-tyH
-wTU
+bmi
+bmi
+bmi
+lZh
 vIa
 vIa
 ufd
@@ -427789,22 +429870,22 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -428119,23 +430200,6 @@ erZ
 fZJ
 fZJ
 fZJ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
-squ
 fZJ
 fZJ
 fZJ
@@ -428164,18 +430228,35 @@ fZJ
 fZJ
 fZJ
 fZJ
-wTU
-mWE
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+lZh
+lZh
 aZZ
 rOe
 bpT
-wTU
+lZh
 vIa
 vIa
 ufd
 nYO
 erZ
-rwr
+erZ
 trT
 rUn
 rUn
@@ -428191,27 +430272,27 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -428566,12 +430647,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-wTU
-wTU
-bKj
-scl
-bKj
-wTU
+rTC
+rTC
+rTC
+rTC
+rTC
+rTC
 vIa
 xKz
 aPy
@@ -428593,29 +430674,29 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+gdC
+gdC
+gdC
 vIa
 vIa
 vIa
@@ -428995,30 +431076,30 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+gdC
+gdC
+gdC
+bQB
 vIa
 vIa
 vIa
@@ -429397,31 +431478,31 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+gdC
+gdC
+gdC
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -429731,12 +431812,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-squ
-squ
-squ
-squ
-squ
-squ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -429799,6 +431880,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -429811,19 +431899,12 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+gdC
+gdC
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -430135,8 +432216,8 @@ wAm
 wAm
 wAm
 wAm
-wAm
-qLF
+hTL
+hTL
 wAm
 wAm
 wAm
@@ -430148,12 +432229,12 @@ wAm
 wAm
 wAm
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430183,9 +432264,9 @@ rTC
 vIa
 xKz
 xKz
+bOK
+jeb
 xKz
-xKz
-xKz
 erZ
 erZ
 erZ
@@ -430201,6 +432282,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -430213,18 +432301,11 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -430534,28 +432615,28 @@ teW
 kwf
 nRx
 rwH
-uSx
+lMZ
 teW
 kqc
-wAm
-wAm
-wAm
+hEB
+jjS
+svL
 vMQ
 vsf
-sIE
+rwH
 nKu
-nSr
-sIE
+jiv
+rwH
 teW
-hqI
-fUr
-wte
+yjP
+dBO
+vMQ
 enq
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -430603,6 +432684,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -430615,18 +432703,11 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -430938,26 +433019,26 @@ jiv
 jiv
 uSx
 teW
-nSr
+obi
+vgH
 jiv
-jjS
 jiv
-nSr
-nSr
-nSr
+jiv
+jiv
+jiv
 bEL
 jiv
 jjS
 teW
 hqI
+cwd
 hqI
-uGf
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+vZc
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431005,6 +433086,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -431017,19 +433105,12 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -431338,28 +433419,28 @@ teW
 yhF
 jiv
 jiv
-uSx
 teW
-nSr
+teW
+vMQ
+vgH
 jiv
 jiv
 jiv
-nSr
-nSr
-nSr
+jiv
+jiv
 nKu
-nSr
+jiv
 vIX
 teW
-fUr
 hqI
-wUw
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+cwd
+hqI
+cwd
+sAC
+qab
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431407,6 +433488,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -431421,17 +433509,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -431737,31 +433818,31 @@ erZ
 fZJ
 fZJ
 teW
-yhF
+cBG
 jiv
 jiv
-teW
-teW
-sxM
+hcx
+cfw
+jiv
 jiv
 jiv
 jiv
 qfh
-nSr
+uYU
 xXN
 tML
 wAm
 wAm
 wAm
 jGT
+cwd
 hqI
-bPz
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+cwd
+cwd
+eAm
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -431809,6 +433890,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -431823,17 +433911,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -432144,26 +434225,26 @@ jiv
 jiv
 hcx
 cfw
-nSr
-nSr
+xSI
+jiv
+jiv
 jiv
 nSr
-nSr
-nSr
-nSr
+ojc
+htU
 teW
 ael
-cLL
-iRN
-fUr
 hqI
-uGf
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+hqI
+hqI
+cwd
+hqI
+lVF
+cwd
+mCT
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432211,6 +434292,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -432225,17 +434313,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -432541,31 +434622,31 @@ erZ
 fZJ
 fZJ
 teW
-mrE
+cBG
 vAK
 xSI
 tML
+wAm
+wAm
+kdg
+kdg
+wAm
+vND
 tML
-qpX
-teW
-fnF
-teW
-teW
-uzT
-fnF
-teW
+vND
+tML
 pDA
 hqI
-aac
 hqI
-gdJ
-uGf
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+hqI
+cwd
+hqI
+cwd
+cwd
+mCT
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -432613,6 +434694,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -432627,17 +434715,10 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -432947,27 +435028,27 @@ wAm
 wAm
 wAm
 wAm
+wAm
 tML
-teW
 nyc
-swm
+ntK
 gbA
 cAe
-ybm
-swm
-teW
+cAe
+bPv
+kqW
 ulu
 hqI
 fVE
 hqI
+lLK
 hqI
-wUw
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+cwd
+nfN
+wSl
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433015,6 +435096,13 @@ erZ
 erZ
 erZ
 erZ
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
+jCh
 erZ
 erZ
 erZ
@@ -433029,16 +435117,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -433347,29 +435428,29 @@ fZJ
 teW
 tML
 sdb
-ntK
+aur
 swm
 lPt
-ntK
-bkD
-vUf
-tak
-tak
-tak
 swm
+nyc
+ntK
+tak
+qGh
+qGh
+qGh
 teW
 uNz
 hqI
 hqI
-hqI
-hqI
+cwd
+wAL
 ojc
-enq
-ffv
-ffv
-ffv
-ffv
-ffv
+itC
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433438,9 +435519,9 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -433752,26 +435833,26 @@ tsB
 aur
 swm
 pLs
-ntK
-bkD
-vUf
-rSg
-rSg
-rSg
 swm
-teW
+nyc
+ntK
+rSg
+jNV
+jNV
+jNV
+tML
 ajj
 lLK
-hqI
-uPa
+lLK
+lLK
 tML
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -433840,7 +435921,7 @@ erZ
 erZ
 erZ
 erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -434155,25 +436236,25 @@ aur
 rVB
 vrG
 wtl
-wtl
-vUf
-lYl
+ntK
+ntK
 lYl
 xrf
-swm
-ohA
+xrf
+xrf
+wQn
 bcN
 bcN
 bcN
 vWe
+put
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434556,26 +436637,26 @@ uKB
 oBU
 sUQ
 xXs
+ntK
+vFy
+ntK
+uTT
 swm
 swm
-swm
-uTT
-uTT
-uTT
 swm
 wQn
 bcN
-dlV
+bcN
 bcN
 vWe
 ffv
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -434958,26 +437039,26 @@ uKB
 aur
 uZa
 cPw
+pho
+ntK
+ntK
+azR
 ybm
 ybm
-vUf
-tak
-tak
-tak
-swm
-ohA
+ybm
+wQn
 bcN
 bcN
 bcN
 vWe
+siG
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -435046,7 +437127,7 @@ erZ
 erZ
 erZ
 erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -435360,26 +437441,26 @@ sUb
 aur
 swm
 pLs
-ntK
-bkD
-vUf
-rSg
-rSg
-rSg
 swm
-teW
+nyc
+ntK
+gbA
+bPv
+bPv
+bPv
+tML
 eYI
 uZC
-vGN
-tML
-tML
+uZC
+wAm
+wAm
 ffv
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -435448,7 +437529,7 @@ erZ
 erZ
 erZ
 erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -435552,7 +437633,7 @@ uuE
 uuE
 uuE
 nqU
-tJC
+xkK
 lAB
 mKZ
 edk
@@ -435759,29 +437840,29 @@ fZJ
 teW
 gGI
 wYt
-ntK
+aur
 swm
 oyP
-ntK
-bkD
-vUf
-lYl
-lYl
-xrf
 swm
+nyc
+ntK
+tak
+qGh
+qGh
+qGh
+teW
+vWy
+vWy
+vWy
 tML
-wAm
-wAm
-wAm
-wAm
 tML
 tML
-ffv
-ffv
-ffv
-ffv
-ffv
-ffv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -435850,7 +437931,7 @@ erZ
 erZ
 erZ
 erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -436161,29 +438242,29 @@ fZJ
 teW
 ePd
 wAm
-tML
 wAm
-tML
-rRD
+wAm
+wAm
 aXE
-swm
-swm
-lDq
-swm
-swm
-tML
-rMM
-rMM
+nyc
+ntK
+pCH
+uRR
+uRR
+cMs
+teW
+wpm
+wpm
+wpm
 wAm
 wAm
-hKU
-hKU
-lug
-tML
-tWY
-tWY
-tWY
-tWY
+wAm
+wAm
+wAm
+wAm
+squ
+squ
+squ
 squ
 squ
 squ
@@ -436191,7 +438272,7 @@ squ
 squ
 squ
 rTC
-rTC
+jnO
 squ
 squ
 squ
@@ -436252,7 +438333,7 @@ erZ
 erZ
 erZ
 erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -436553,7 +438634,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -436567,33 +438648,33 @@ tML
 teW
 tML
 tML
-tML
+tox
 fnF
+wAm
+aGb
 tML
-tML
-ycz
 aGb
 tML
 cfY
 cfY
 cfY
 wpe
-eCn
+fQd
 eCn
 sNY
+ggG
 teW
 teW
 teW
 teW
 teW
-squ
 squ
 squ
 squ
 squ
 squ
 rTC
-rTC
+jnO
 rTC
 rTC
 rTC
@@ -436654,7 +438735,7 @@ erZ
 erZ
 erZ
 erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -436955,7 +439036,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
@@ -436968,33 +439049,34 @@ tML
 tML
 teW
 btc
-tUR
 bkD
 swm
-owz
-rMM
+swm
+fbf
+cfY
 cfY
 cfY
 vTd
 cfY
 cfY
 cfY
-teW
-aTF
+alk
 eCn
-sNY
-teW
+eCn
+eCn
+eCn
 teW
 aor
 xfh
+ebb
 teW
-squ
 squ
 squ
 squ
 squ
 squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -437034,29 +439116,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -437357,8 +439438,8 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -437370,24 +439451,25 @@ tML
 tML
 teW
 wVs
-ntK
 ujc
+swm
 swm
 fbf
 cfY
 cfY
-uZy
-uZy
-uZy
-uZy
 cfY
-alk
-eCn
-eCn
-eCn
-fQd
+cfY
+cfY
+cfY
+cfY
 teW
-htf
+aTF
+sQI
+jAJ
+eCn
+mYi
+gbX
+gbX
 gbX
 teW
 squ
@@ -437395,8 +439477,8 @@ squ
 squ
 squ
 squ
-squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -437436,29 +439518,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -437760,36 +439841,37 @@ vIa
 vIa
 vIa
 vIa
-vIa
+erZ
 erZ
 erZ
 erZ
 fZJ
-fZJ
+eQa
 teW
 wAm
 wAm
 wAm
-teW
+tML
 btc
-tUR
 bkD
+swm
 swm
 owz
 rMM
 cfY
-idu
-xAh
-lIc
-sNp
 cfY
-teW
+uZy
+uZy
+uZy
+cfY
+alk
 eCn
+pbg
+shJ
 eCn
-eCn
-eCn
-teW
-xET
+mYi
+gbX
+gbX
 gbX
 teW
 squ
@@ -437797,8 +439879,8 @@ squ
 squ
 squ
 squ
-squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -437838,29 +439920,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -438162,45 +440243,46 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
+vWY
+hIC
+jBh
 uKB
-nTR
 uBv
 tML
 tML
 tML
 xnv
-fnF
+hKt
 tML
 rMM
 cfY
-fPg
-pcQ
-nJX
-cpY
 cfY
-alk
+idu
+lIc
+sNp
+cfY
+teW
+aTF
 eCn
 eCn
-fLK
 eCn
-mYi
-gbX
-gbX
+teW
+aAo
+iVW
+wwM
 teW
 squ
 squ
 squ
 squ
 squ
-squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -438241,27 +440323,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -438564,17 +440645,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
+erZ
+erZ
 erZ
 erZ
 fZJ
-fZJ
-rxp
+vWY
 uKB
-nTR
-ntK
-bHX
+kcR
+uKB
+uKB
+uKB
 kNs
 htZ
 swm
@@ -438582,27 +440663,28 @@ swm
 tML
 tML
 lQT
-tcW
-tcW
-tcW
-tcW
 cfY
-teW
-sbF
+fPg
+nJX
+cpY
+cfY
+wpe
+qcC
+qcC
 eCn
-uxZ
 eCn
 teW
-wyA
-seC
 teW
-squ
+teW
+teW
+teW
 squ
 squ
 squ
 squ
 squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -438643,27 +440725,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -438966,18 +441047,18 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+erZ
+erZ
+erZ
+erZ
 fZJ
-fZJ
-rxp
+vWY
 uKB
-nTR
-ntK
-ntK
-ntK
+agV
+uKB
+vox
+iDV
+uKB
 nIr
 swm
 swm
@@ -438985,18 +441066,18 @@ jlM
 pzU
 cfY
 cfY
+tcW
+tcW
+tcW
 cfY
-cfY
-cfY
-cfY
-alk
+teW
 eCn
 eCn
-loE
-aym
 teW
+mYi
 teW
-teW
+xJe
+xJe
 teW
 squ
 squ
@@ -439005,6 +441086,7 @@ squ
 squ
 squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -439045,27 +441127,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -439370,35 +441451,35 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+lIW
+teW
+teW
 teW
 rou
-nTR
-cCS
-nJy
-ntK
+uKB
+uKB
+uKB
+uKB
+uKB
 nIr
 swm
 swm
 swm
 pzU
 cfY
-uZy
-uZy
-uZy
-uZy
+cfY
+cfY
+cfY
+cfY
 cfY
 teW
-aTF
-eCn
-tfp
+teW
+teW
+teW
 eCn
 teW
-lAs
-lAs
+xJe
+xJe
 teW
 squ
 squ
@@ -439407,6 +441488,7 @@ squ
 squ
 squ
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -439447,27 +441529,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -439772,35 +441853,35 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-pur
+jfV
+teW
+fgH
+uKB
+wkw
+sdl
+xJb
+qsC
 tML
-tML
-ydR
-tML
-cbQ
 swm
 swm
 lDq
 pzU
 cfY
-idu
-lIc
-sct
-sNp
 cfY
-alk
+uZy
+uZy
+uZy
+cfY
+mYi
 eCn
 eCn
+fQd
 eCn
-grk
 teW
-lAs
-lAs
+xJe
+xJe
 teW
 eQa
 rTC
@@ -439809,6 +441890,7 @@ rTC
 rTC
 rTC
 rTC
+aUc
 vIa
 vIa
 vIa
@@ -439849,27 +441931,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -440174,36 +442255,44 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-uKB
-cgD
+vyn
+teW
+eOo
+eOo
 tML
-gdJ
 tML
-pjB
+ydR
+tML
+tML
 swm
 swm
 tML
 tML
 lQT
-bWq
-iMA
-iMA
-pxR
 cfY
-wpe
-qcC
-qcC
-qcC
-tiH
+idu
+sct
+sNp
+cfY
+kuV
+tlQ
+oPp
+ecb
+eCn
 teW
-lAs
-lAs
-lAs
+xJe
+xJe
+xJe
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -440244,34 +442333,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -440576,34 +442657,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
 uKB
-tdJ
+hIC
+uKB
+uKB
+cgD
 tML
-gdJ
+bDN
+hqI
+pjB
+swm
+swm
 tML
-vaa
-lDq
-iWj
-tML
-rMM
+qQw
 cfY
-tcW
-tcW
-tcW
-tcW
 cfY
+bWq
+iMA
+pxR
+cfY
+kuV
+qYQ
+ilL
+tVu
+eCn
 teW
-eCn
-eCn
-eCn
-tiH
-teW
-lAs
+xJe
 lAs
 lAs
 vIa
@@ -440665,15 +442746,15 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -440978,36 +443059,36 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-fZJ
+aUc
 teW
-nMd
-xeO
+aTn
+uKB
+uKB
+uKB
+fEE
 tML
+gdJ
+hqI
+vaa
+swm
+lDq
 tML
-tML
-wAm
-wAm
-wAm
-wAm
-teW
+rMM
 eVa
-cfY
-cfY
-cfY
-cfY
+xXc
+tcW
+tcW
+tcW
 eVa
+alQ
+lLl
+hzl
+wMo
+eCn
 teW
-teW
-teW
-teW
-teW
+xJe
 lAs
 lAs
-lAs
-lAs
 vIa
 vIa
 vIa
@@ -441067,14 +443148,14 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -441380,34 +443461,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-tML
-tML
-tML
-tML
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
 teW
+pcQ
+nMd
+uKB
+uKB
+xeO
+tML
+tML
+tML
+wAm
+hKt
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
+wAm
 teW
-wAm
-wAm
-aSD
-wAm
-wAm
+aTF
+eCn
+grk
+eCn
 teW
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 lAs
 lAs
 vIa
@@ -441470,12 +443551,12 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -441782,36 +443863,36 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
 teW
-vsg
-xJe
-eBN
-xJe
-wAm
-wAm
-wAm
 teW
+teW
+iww
+uKB
+uKB
+ept
+iYx
+fGq
+vUf
+vUf
+iYx
+iYx
+iYx
+iYx
+iYx
+xJe
+xJe
+xJe
+teW
+teW
+teW
+teW
+teW
+teW
+teW
+xJe
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
 vIa
 vIa
 vIa
@@ -441874,9 +443955,9 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -442184,34 +444265,34 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-fZJ
-vIa
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+aUc
+xJe
+xJe
 teW
-lMZ
-eBN
-eBN
-eBN
-eBN
-eBN
-lMZ
-teW
-lAs
-lAs
-lAs
-lAs
+iDV
+uKB
+uKB
+syt
+iYx
+vaa
+vUf
+dmH
+iYx
+fVm
+eli
+llq
+iYx
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
 lAs
 lAs
 vIa
@@ -442587,29 +444668,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-fZJ
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 teW
-mQr
-eBN
-eBN
-eBN
-eBN
-eBN
-dbt
-teW
+qOT
+uKB
+uKB
+sZv
+iYx
+tcq
+vUf
+vUf
+iYx
+cOL
+vUf
+vUf
+iYx
+xJe
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -442989,29 +445070,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 teW
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
+anO
+uKB
+uKB
+pMn
+iYx
+aVU
+vUf
+vUf
+jHv
+vUf
+vUf
+vUf
+iYx
+xJe
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -443391,29 +445472,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-lAs
+xJe
 teW
-dbt
-eBN
-dbt
-eza
-dbt
-eBN
-dbt
 teW
+teW
+teW
+teW
+iYx
+baG
+vUf
+oqH
+iYx
+lXX
+jZY
+oLg
+iYx
+xJe
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 lAs
 lAs
 lAs
@@ -443793,29 +445874,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+xJe
+xJe
+xJe
+iYx
+iYx
+iYx
+iYx
+fGq
+vUf
+rCc
+iYx
+iYx
+iYx
+iYx
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-gip
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
 lAs
 lAs
 lAs
@@ -444195,29 +446276,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+rCc
+mJg
+iYx
+iYx
+vUf
+oqH
+iYx
+fVm
+eli
+llq
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-mQr
-eBN
-dbt
-eBN
-dbt
-eBN
-dbt
-teW
 lAs
 lAs
 lAs
@@ -444597,29 +446678,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+cOL
+vUf
+jHv
+vUf
+vUf
+vUf
+iYx
+cOL
+vUf
+vUf
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-eBN
-lMZ
-teW
 lAs
 lAs
 lAs
@@ -444999,29 +447080,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+vUf
+vUf
+iYx
+vUf
+vUf
+vUf
+jHv
+vUf
+vUf
+vUf
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-teW
-dbt
-ejY
-dbt
-ejY
-dbt
-wou
-dbt
-teW
 lAs
 lAs
 lAs
@@ -445401,29 +447482,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
+lAs
+lAs
+lAs
+xJe
+iYx
+fmV
+oLg
+iYx
+vUf
+hFs
+cPT
+iYx
+lXX
+jZY
+oLg
+iYx
+xJe
 lAs
 lAs
 lAs
 lAs
 lAs
 lAs
-lAs
-lAs
-lAs
-lAs
-lAs
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-wAm
-teW
 lAs
 lAs
 lAs
@@ -445806,20 +447887,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+juf
+iYx
+iYx
+iYx
+eDI
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
+juf
+aUc
 vIa
 vIa
 vIa
@@ -446208,20 +448289,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+iYx
+iYx
+sSL
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+xJe
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -446611,17 +448692,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+eSE
+iqs
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+xJe
 vIa
 vIa
 vIa
@@ -447013,17 +449094,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+qEq
+iqs
+tWY
+tWY
+iyd
+iyd
+iyd
+iYx
+xJe
 vIa
 vIa
 vIa
@@ -447415,17 +449496,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+iEB
+rPU
+uZC
+uZC
+uZC
+iYx
+iYx
+iYx
+xJe
 vIa
 vIa
 vIa
@@ -447817,17 +449898,17 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+iYx
+iYx
+iYx
+vcA
+vcA
+ufN
+iYx
+xJe
+xJe
+xJe
 vIa
 vIa
 vIa
@@ -448220,13 +450301,13 @@ aUc
 aUc
 aUc
 aUc
-aUc
-aUc
-aUc
-aUc
-aUc
-aUc
-aUc
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
+iYx
 aUc
 aUc
 aUc
@@ -449819,6 +451900,16 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -449922,17 +452013,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -450220,6 +452301,17 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -450323,18 +452415,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -450623,6 +452704,16 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -450726,17 +452817,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -451025,6 +453106,16 @@ iyK
 iyK
 iyK
 iyK
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
+ifg
 iyK
 iyK
 iyK
@@ -451128,17 +453219,7 @@ iyK
 iyK
 iyK
 iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -451540,7 +453621,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -451942,7 +454023,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452344,7 +454425,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -452746,7 +454827,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453148,7 +455229,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453550,7 +455631,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -453952,7 +456033,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -454354,7 +456435,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -454756,7 +456837,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455158,7 +457239,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455560,7 +457641,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -455962,7 +458043,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -456364,7 +458445,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -456766,7 +458847,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457168,7 +459249,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457570,7 +459651,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -457972,7 +460053,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -458374,7 +460455,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -458776,7 +460857,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459178,7 +461259,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459580,7 +461661,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -459982,7 +462063,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -460384,7 +462465,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -460786,7 +462867,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461188,7 +463269,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461590,7 +463671,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -461992,7 +464073,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -462394,7 +464475,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -462796,7 +464877,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463198,7 +465279,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -463600,7 +465681,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464002,7 +466083,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464404,7 +466485,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -464806,7 +466887,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465208,7 +467289,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -465610,7 +467691,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466012,7 +468093,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466414,7 +468495,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -466816,7 +468897,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467218,7 +469299,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -467620,7 +469701,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468022,7 +470103,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468424,7 +470505,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -468826,7 +470907,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469228,7 +471309,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -469630,7 +471711,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470032,7 +472113,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470434,7 +472515,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -470836,7 +472917,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471238,7 +473319,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -471640,7 +473721,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472042,7 +474123,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472444,7 +474525,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -472846,7 +474927,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473248,7 +475329,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -473650,7 +475731,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474052,7 +476133,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474454,7 +476535,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -474856,7 +476937,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475258,7 +477339,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -475660,7 +477741,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -476062,7 +478143,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -476464,7 +478545,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -476866,7 +478947,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -477268,7 +479349,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -477670,7 +479751,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -478072,7 +480153,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -478474,7 +480555,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -478876,7 +480957,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 gAA
@@ -479278,7 +481359,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -479680,7 +481761,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -480082,7 +482163,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -480484,7 +482565,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -480886,7 +482967,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -481288,7 +483369,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -481690,7 +483771,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482092,7 +484173,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482494,7 +484575,7 @@ iyK
 iyK
 iyK
 iyK
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -482896,7 +484977,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -483298,7 +485379,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -483700,7 +485781,7 @@ tmH
 tmH
 tmH
 tmH
-vIa
+aUc
 vIa
 vIa
 vIa
@@ -483992,89 +486073,89 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 eSw
 wQD
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+vIa
+vIa
+vIa
+vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -484394,9 +486475,39 @@ vIa
 vIa
 vIa
 vIa
-vIa
+aUc
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+obq
 erZ
 erZ
 erZ
@@ -484425,38 +486536,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
+aUc
+aUc
 vIa
 vIa
 vIa
@@ -484476,6 +486557,7 @@ vIa
 vIa
 vIa
 vIa
+aUc
 vIa
 vIa
 vIa
@@ -484486,24 +486568,23 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 aUc
 vIa
 vIa
@@ -484796,9 +486877,39 @@ vIa
 vIa
 vIa
 vIa
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+aok
+xpM
+xpM
+xpM
+hJj
+dAf
+dAf
+dAf
+hJj
+woV
+dAf
+xpM
+rps
+rcx
+bYH
+kRI
+uxV
+kRI
+aPR
 erZ
 erZ
 erZ
@@ -484828,55 +486939,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
 vIa
 vIa
 vIa
@@ -484889,7 +486952,25 @@ vIa
 vIa
 vIa
 vIa
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 vIa
+aUc
+vIa
+vIa
+vIa
+vIa
+vIa
+vIa
+vIa
+aUc
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -485198,11 +487279,39 @@ vIa
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+nmF
+xpM
+xpM
+xpM
+dAf
+dAf
+gEt
+flI
+flI
+xpM
+dAf
+ixg
+uxV
+mpr
+uxV
+mpr
+uxV
+uxV
+kFh
 erZ
 erZ
 erZ
@@ -485238,34 +487347,6 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 vIa
 vIa
 vIa
@@ -485280,15 +487361,15 @@ erZ
 erZ
 erZ
 erZ
+aUc
+aUc
 vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -485600,9 +487681,40 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+sbF
+xpM
+nBf
+sYv
+uxZ
+oiW
+xpM
+xpM
+xpM
+woV
+xpM
+ooP
+uxV
+uxV
+uxV
+uxV
+uxV
+sWi
+erZ
 erZ
 erZ
 erZ
@@ -485640,17 +487752,6 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -485663,32 +487764,12 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+aUc
+aUc
+aUc
+aUc
+aUc
+aUc
 erZ
 erZ
 erZ
@@ -486002,9 +488083,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+sbF
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+lGI
+ycz
+dAf
+xpM
+uTc
+sug
+fwJ
+uxV
+uxV
+uxV
+aPR
 erZ
 erZ
 erZ
@@ -486023,36 +488134,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -486404,9 +488485,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+woV
+xpM
+xpM
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+ycz
+dAf
+dAf
+obq
+mQA
+mzf
+tfW
+qoP
+uxV
+mpr
+kFh
 erZ
 erZ
 erZ
@@ -486425,36 +488536,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -486806,9 +488887,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+sGx
+sGx
+jtV
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+dAf
+uxZ
+ycz
+obq
+wQI
+plR
+wQI
+anS
+uxV
+uxV
+sWi
 erZ
 erZ
 erZ
@@ -486817,36 +488928,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -487208,11 +489289,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
+ebe
 fIL
 wQD
-vIa
-vIa
+aUc
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nBf
+kvj
+dAf
+oiW
+xpM
+jpw
+uxZ
+uxZ
+tiH
+xpM
+dAf
+dAf
+dAf
+obq
+wQI
+wQI
+iPI
+sxM
+uxV
+uxV
+aPR
 erZ
 erZ
 erZ
@@ -487220,34 +489329,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
 erZ
 erZ
 erZ
@@ -487610,39 +489691,39 @@ erZ
 erZ
 erZ
 vIa
-vIa
+aUc
 eNY
 hby
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+dAf
+ycz
+dAf
+obq
+vaQ
+wQI
+vaQ
+gaI
+uxV
+uxV
+kFh
 erZ
 erZ
 erZ
@@ -488012,39 +490093,39 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 eDN
 twI
-vIa
-vIa
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+aUc
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ehI
+dAf
+sGx
+sbF
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+lGI
+dAf
+uxZ
+xpM
+xpM
+xpM
+xpM
+iVA
+iVA
+iVA
+qyS
 erZ
 erZ
 erZ
@@ -488414,35 +490495,35 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 twI
 twI
 twI
-vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+aUc
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ryE
+kvj
+dAf
+gEt
+xpM
+ehI
+dAf
+dAf
+sbF
+xpM
+dAf
+uxZ
+dAf
+dAf
+dAf
+uPi
+bzl
 erZ
 erZ
 erZ
@@ -488816,35 +490897,35 @@ erZ
 erZ
 vIa
 vIa
-vIa
-vIa
+aUc
+aUc
 xGC
 oWI
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jEB
+kvj
+dAf
+oiW
+xpM
+jpw
+dAf
+dAf
+tiH
+xpM
+dAf
+dAf
+dAf
+dAf
+wDZ
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -489219,9 +491300,34 @@ erZ
 erZ
 vIa
 vIa
-vIa
+aUc
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+ehI
+sGx
+dAf
+tiH
+xpM
+nBf
+kvj
+dAf
+urF
+xpM
+dAf
+dAf
+uxZ
+dAf
+uPi
+saP
+bVa
 erZ
 erZ
 erZ
@@ -489245,31 +491351,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -489620,10 +491701,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+dAf
+sbF
+xpM
+sbF
+uxZ
+uxZ
+tiH
+xpM
+lGI
+dAf
+dAf
+dAf
+uPi
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -489647,31 +491753,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -490022,10 +492103,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nBf
+kvj
+dAf
+mUC
+mUC
+mUC
+dAf
+dAf
+mUC
+mUC
+uxZ
+dAf
+dAf
+wWE
+vdg
+nAy
+bzl
 erZ
 erZ
 erZ
@@ -490049,31 +492155,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -490424,10 +492505,35 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+sGx
+dAf
+lvF
+xpM
+kFr
+kvj
+dAf
+gbf
+xpM
+lGI
+uxZ
+dAf
+dAf
+dAf
+vdg
+bzl
 erZ
 erZ
 erZ
@@ -490451,31 +492557,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -490826,10 +492907,39 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
+bQB
+ebe
 uXW
 oRe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+jpw
+dAf
+sGx
+dAf
+woV
+dAf
+dAf
+dAf
+xpM
+xpM
+xpM
+xpM
+xpM
+cTb
+dAf
+dAf
+uLh
+uLh
+vFz
+gqj
+uLh
 erZ
 erZ
 erZ
@@ -490849,35 +492959,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -491228,45 +493309,40 @@ erZ
 erZ
 erZ
 erZ
-erZ
-lgg
+bQB
+ebe
 uXW
 oRe
-erZ
-erZ
-erZ
-erZ
-sri
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+nVf
+kvj
+dAf
+pDO
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ebe
+ebe
+xpM
+dAf
+ycz
+ycz
+uLh
+ssD
+dSP
+oBF
+uLh
+oMa
 erZ
 erZ
 erZ
@@ -491274,12 +493350,17 @@ erZ
 erZ
 erZ
 erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -491625,21 +493706,46 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-lgg
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 hqA
 pCW
-lgg
-lgg
-lgg
-lgg
-lgg
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+xpM
+xpM
+xpM
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+dAf
+vxV
+dSP
+dSP
+tUp
+gqj
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -491657,31 +493763,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -492022,13 +494103,13 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 lgg
 lgg
 lgg
@@ -492040,12 +494121,33 @@ lgg
 lgg
 lgg
 lgg
-lgg
-sri
-sri
-sri
-sri
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+xpM
+xpM
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+dAf
+dAf
+dAf
+vxV
+dSP
+dSP
+dSP
+vxV
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -492063,27 +494165,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -492420,13 +494501,13 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
 lgg
 lgg
 lgg
@@ -492446,10 +494527,29 @@ lgg
 lgg
 vIa
 vIa
-sri
-sri
-sri
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+lGI
+ycz
+dAf
+vxV
+dSP
+dSP
+dSP
+gqj
+dSP
+dSP
 erZ
 erZ
 erZ
@@ -492467,25 +494567,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -492825,7 +494906,7 @@ vIa
 erZ
 erZ
 erZ
-erZ
+ebe
 lgg
 lgg
 lgg
@@ -492851,8 +494932,25 @@ vIa
 vIa
 vIa
 vIa
-sri
-sri
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+ebe
+xpM
+wyA
+ttW
+dAf
+uLh
+vPA
+dSP
+dSP
+uLh
+oMa
 erZ
 erZ
 erZ
@@ -492871,23 +494969,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -493254,8 +495335,23 @@ vIa
 vIa
 vIa
 vIa
-vIa
-sri
+aUc
+ebe
+xpM
+xET
+xET
+xET
+xET
+xET
+xET
+xET
+woq
+woq
+uLh
+uLh
+mIC
+mIC
+mEy
 erZ
 erZ
 erZ
@@ -493275,21 +495371,6 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-ebb
-ebb
-ebb
-ebb
-ebb
-ebb
 erZ
 erZ
 erZ
@@ -493657,8 +495738,8 @@ vIa
 vIa
 vIa
 vIa
-sri
-sri
+ebe
+ebe
 erZ
 erZ
 erZ
@@ -493686,12 +495767,12 @@ erZ
 erZ
 erZ
 erZ
-ebb
-mdB
-ebb
-ebb
-ebb
-ebb
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -495279,14 +497360,14 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -495676,19 +497757,19 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -496078,24 +498159,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -496480,24 +498561,24 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -496880,26 +498961,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -497282,26 +499363,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -497684,26 +499765,26 @@ sri
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498086,26 +500167,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498488,26 +500569,26 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -498890,7 +500971,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 iJC
 bOK
 nEd
@@ -498898,18 +500979,18 @@ nEd
 nEd
 bOK
 iJC
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -499292,7 +501373,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 bOK
 fVQ
 fVQ
@@ -499300,18 +501381,18 @@ bmG
 fVQ
 fVQ
 bOK
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -499694,7 +501775,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 nEd
 fVQ
 lgN
@@ -499702,18 +501783,18 @@ jJC
 lgN
 fVQ
 nEd
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -500096,7 +502177,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 nEd
 fVQ
 qxZ
@@ -500110,12 +502191,12 @@ vxC
 vxC
 vxC
 ppx
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -500498,7 +502579,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+cLL
 nEd
 fVQ
 fVQ
@@ -500512,12 +502593,12 @@ fZJ
 fZJ
 fZJ
 kZS
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+cLL
+cLL
+cLL
+cLL
+cLL
+cLL
 erZ
 erZ
 erZ
@@ -501750,7 +503831,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
+bQB
 erZ
 erZ
 erZ
@@ -505447,8 +507528,8 @@ uuE
 rUt
 rOF
 rOF
-arx
-uuE
+rOF
+rOF
 rOF
 rOF
 uuE
@@ -505849,10 +507930,10 @@ uuE
 rUt
 rOF
 rOF
-lGt
-pVv
-uuE
-uuE
+rOF
+rOF
+rOF
+rOF
 rOF
 rOF
 rOF
@@ -506134,11 +508215,11 @@ lpR
 xwL
 xvv
 mDM
-wmv
-wmv
-wmv
-wmv
-wmv
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 iTZ
 jFM
 rKq
@@ -506252,8 +508333,8 @@ rUt
 rOF
 rOF
 rOF
-uuE
-uuE
+rOF
+rOF
 rOF
 rOF
 rOF
@@ -506654,9 +508735,9 @@ ipd
 izW
 rOF
 rOF
-uuE
-uuE
-uuE
+rOF
+rOF
+rOF
 rOF
 rOF
 hHN
@@ -507056,9 +509137,9 @@ uuE
 ipd
 izW
 rOF
-pVv
-pVv
-pVv
+rOF
+rOF
+rOF
 rOF
 hHN
 pfP
@@ -507458,9 +509539,9 @@ uuE
 uuE
 rUt
 rOF
-arx
-uuE
-uuE
+rOF
+rOF
+rOF
 rOF
 eFy
 uuE
@@ -507860,8 +509941,8 @@ uuE
 uuE
 rUt
 rOF
-uuE
-aoa
+rOF
+rOF
 rOF
 rOF
 eFy
@@ -508161,7 +510242,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-lWQ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -508263,7 +510344,7 @@ uuE
 rUt
 rOF
 rOF
-uuE
+rOF
 rOF
 rOF
 eFy
@@ -508563,7 +510644,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-lWQ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -508665,7 +510746,7 @@ uuE
 rUt
 rOF
 rOF
-uuE
+rOF
 rOF
 rOF
 eFy
@@ -508965,7 +511046,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-hbN
+fZJ
 fZJ
 fZJ
 fZJ
@@ -509468,8 +511549,8 @@ uuE
 uuE
 rUt
 rOF
-uuE
-aoa
+rOF
+rOF
 rOF
 rOF
 eFy
@@ -509871,7 +511952,7 @@ uuE
 rUt
 rOF
 rOF
-uuE
+rOF
 rOF
 rOF
 eFy
@@ -510273,8 +512354,8 @@ mjG
 mTO
 rOF
 rOF
-uuE
-uuE
+rOF
+rOF
 rOF
 vCE
 uXg
@@ -510675,8 +512756,8 @@ mTO
 rOF
 rOF
 rOF
-pVv
-pVv
+rOF
+rOF
 rOF
 rOF
 vCE
@@ -510932,7 +513013,7 @@ sXz
 sXz
 sXz
 kXp
-rTC
+fZJ
 fZJ
 fZJ
 fZJ
@@ -511076,9 +513157,9 @@ rUt
 rOF
 rOF
 rOF
-uuE
-uuE
-kCg
+rOF
+rOF
+rOF
 rOF
 rOF
 rOF
@@ -511334,7 +513415,7 @@ sXz
 sXz
 sXz
 kXp
-rTC
+fZJ
 fZJ
 fZJ
 fZJ
@@ -511363,9 +513444,9 @@ ydm
 ydm
 ydm
 ydm
-jMk
-jMk
-jMk
+fZJ
+fZJ
+fZJ
 jGz
 gUx
 xrI
@@ -511477,11 +513558,11 @@ uuE
 rUt
 rOF
 rOF
-arx
-uuE
-pVv
-pVv
-kCg
+rOF
+rOF
+rOF
+rOF
+rOF
 rOF
 rOF
 eFy
@@ -511736,7 +513817,7 @@ sXz
 sXz
 sXz
 kXp
-rTC
+fZJ
 fZJ
 fZJ
 fZJ
@@ -511880,11 +513961,11 @@ rUt
 rOF
 rOF
 rOF
-aoa
-aoa
-uuE
 rOF
-kCg
+rOF
+rOF
+rOF
+rOF
 rOF
 eFy
 gxt
@@ -513363,7 +515444,7 @@ bne
 bne
 bne
 fZJ
-gSK
+ydm
 ydm
 ydm
 ydm
@@ -513765,7 +515846,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-oJM
+fZJ
 fZJ
 fZJ
 fZJ
@@ -514167,7 +516248,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-oJM
+fZJ
 fZJ
 fZJ
 fZJ
@@ -514569,7 +516650,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-oJM
+fZJ
 fZJ
 fZJ
 fZJ
@@ -514971,7 +517052,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-oJM
+fZJ
 fZJ
 fZJ
 fZJ
@@ -516199,12 +518280,6 @@ fZJ
 fZJ
 fZJ
 fZJ
-sPV
-uvE
-uvE
-uvE
-uvE
-oHA
 fZJ
 fZJ
 fZJ
@@ -516213,6 +518288,12 @@ fZJ
 fZJ
 fZJ
 fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 erZ
 erZ
 erZ
@@ -516230,13 +518311,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -516601,12 +518682,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
-jFM
-jFM
-jFM
-jFM
-iTZ
+jGz
+jGz
+jGz
+jGz
+jGz
+jGz
 fZJ
 fZJ
 fZJ
@@ -516632,13 +518713,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -517003,12 +519084,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
+jGz
 jFM
 jFM
-ufU
 jFM
-iTZ
+jFM
+jGz
 fZJ
 fZJ
 fZJ
@@ -517034,13 +519115,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -517405,12 +519486,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
-jFM
-sRX
+jGz
 jFM
 jFM
-iTZ
+jFM
+jFM
+jGz
 fZJ
 fZJ
 fZJ
@@ -517436,13 +519517,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -517734,11 +519815,11 @@ dST
 naI
 naI
 naI
-npm
+dST
 naI
 naI
 naI
-npm
+dST
 naI
 naI
 wtF
@@ -517807,12 +519888,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
+jGz
 jFM
-aXQ
-sRX
 jFM
-iTZ
+jFM
+jFM
+jGz
 fZJ
 fZJ
 fZJ
@@ -517838,13 +519919,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -518209,12 +520290,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
+jGz
 jFM
 jFM
 jFM
 jFM
-iTZ
+jGz
 fZJ
 fZJ
 fZJ
@@ -518240,13 +520321,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -518611,12 +520692,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-nbz
+jGz
 jFM
 jFM
 jFM
 jFM
-iTZ
+jGz
 fZJ
 fZJ
 fZJ
@@ -518642,13 +520723,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -519013,12 +521094,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-vBZ
-awb
-awb
-awb
-awb
-ilM
+jGz
+jGz
+jGz
+jGz
+jGz
+jGz
 fZJ
 fZJ
 fZJ
@@ -519044,13 +521125,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -519415,13 +521496,13 @@ fZJ
 fZJ
 fZJ
 fZJ
-jGz
-ctS
-ctS
-ctS
-ctS
-jGz
-plz
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -519446,13 +521527,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -519799,12 +521880,12 @@ pDT
 pDT
 pDT
 pDT
-pDT
 wcx
 pDT
 pDT
 pDT
 pDT
+pDT
 jGz
 fZJ
 fZJ
@@ -519817,12 +521898,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-jGz
 ctS
 ctS
 ctS
 ctS
-jGz
+ctS
+ctS
 fZJ
 fZJ
 fZJ
@@ -519848,13 +521929,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -520201,8 +522282,8 @@ pDT
 pDT
 pDT
 pDT
-jws
 jML
+pDT
 pDT
 wcx
 pDT
@@ -520219,12 +522300,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-jGz
 ctS
 ctS
 ctS
 ctS
-jGz
+ctS
+ctS
 fZJ
 fZJ
 fZJ
@@ -520250,13 +522331,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -520603,7 +522684,7 @@ pDT
 pDT
 pDT
 pDT
-pDT
+vAE
 pDT
 pDT
 dLq
@@ -520621,12 +522702,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-jGz
 ctS
 ctS
 ctS
 ctS
-jGz
+ctS
+ctS
 fZJ
 fZJ
 fZJ
@@ -520652,13 +522733,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -521023,12 +523104,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-jGz
 ctS
 ctS
 ctS
 ctS
-jGz
+ctS
+ctS
 fZJ
 fZJ
 fZJ
@@ -521054,13 +523135,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -521425,12 +523506,12 @@ fZJ
 fZJ
 fZJ
 fZJ
-gYV
-vju
-vju
-vju
-vju
-gYV
+ctS
+ctS
+ctS
+ctS
+ctS
+ctS
 fZJ
 fZJ
 fZJ
@@ -521456,13 +523537,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -521827,6 +523908,12 @@ fZJ
 fZJ
 fZJ
 fZJ
+ctS
+ctS
+ctS
+ctS
+ctS
+ctS
 fZJ
 fZJ
 fZJ
@@ -521835,12 +523922,6 @@ fZJ
 fZJ
 fZJ
 fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
 erZ
 erZ
 erZ
@@ -521858,13 +523939,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -522260,13 +524341,13 @@ erZ
 erZ
 erZ
 erZ
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
-wQI
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
+erZ
 erZ
 erZ
 erZ
@@ -524213,9 +526294,9 @@ pDT
 pDT
 pDT
 pDT
-lPy
-lPy
-bpt
+fZJ
+fZJ
+fZJ
 jGz
 jGz
 jGz
@@ -526619,7 +528700,7 @@ pDT
 pDT
 pDT
 pDT
-rAP
+pDT
 pDT
 pDT
 pDT
@@ -527020,7 +529101,7 @@ pDT
 pDT
 pDT
 pDT
-mZB
+pDT
 pDT
 pDT
 pDT
@@ -530644,7 +532725,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -531046,7 +533127,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -531448,7 +533529,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -531527,9 +533608,9 @@ erZ
 bQB
 bQB
 bQB
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -531850,7 +533931,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -531929,10 +534010,10 @@ erZ
 bQB
 bQB
 bQB
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -532252,7 +534333,7 @@ fZJ
 fZJ
 fZJ
 fZJ
-bhp
+fZJ
 fZJ
 fZJ
 fZJ
@@ -532331,10 +534412,10 @@ erZ
 erZ
 bQB
 bQB
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -532733,9 +534814,9 @@ erZ
 erZ
 bQB
 bQB
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -533135,9 +535216,9 @@ erZ
 erZ
 bQB
 bQB
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -533537,10 +535618,10 @@ erZ
 erZ
 bQB
 bQB
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -533939,10 +536020,10 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -534341,10 +536422,10 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -534743,10 +536824,10 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -535072,7 +537153,7 @@ eZN
 rFc
 hjt
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -535145,10 +537226,10 @@ erZ
 erZ
 erZ
 erZ
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -535475,7 +537556,7 @@ pur
 udS
 udS
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -535521,6 +537602,11 @@ erZ
 erZ
 erZ
 erZ
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -535542,14 +537628,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -535876,7 +537957,7 @@ miM
 rFc
 hjt
 udS
-fZJ
+udS
 fZJ
 fZJ
 fZJ
@@ -535923,6 +538004,11 @@ erZ
 erZ
 erZ
 erZ
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -535944,14 +538030,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -536321,6 +538402,15 @@ vIa
 vIa
 vIa
 vIa
+rbn
+erZ
+erZ
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -536342,16 +538432,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -536725,13 +538806,13 @@ vIa
 vIa
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -537125,15 +539206,15 @@ vIa
 vIa
 vIa
 vIa
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -537527,6 +539608,15 @@ vIa
 vIa
 vIa
 vIa
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -537548,16 +539638,7 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
+bQB
 vIa
 vIa
 vIa
@@ -537929,6 +540010,15 @@ vIa
 vIa
 vIa
 vIa
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -537950,17 +540040,8 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -538331,6 +540412,15 @@ vIa
 vIa
 vIa
 vIa
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -538352,18 +540442,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -538733,6 +540814,15 @@ vIa
 vIa
 vIa
 vIa
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -538754,18 +540844,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -539135,6 +541216,15 @@ vIa
 vIa
 vIa
 vIa
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
+rbn
 erZ
 erZ
 erZ
@@ -539156,18 +541246,9 @@ erZ
 erZ
 erZ
 erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-erZ
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -539546,30 +541627,30 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -539869,7 +541950,7 @@ vIa
 vIa
 vIa
 vIa
-vIa
+rbn
 erZ
 erZ
 erZ
@@ -539948,29 +542029,29 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -540350,28 +542431,28 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -540753,26 +542834,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -541090,11 +543171,11 @@ qzV
 nLH
 pil
 aqS
-qTb
+jYn
 fCM
 fCM
 fCM
-pur
+mdB
 fCM
 nQU
 cGD
@@ -541155,26 +543236,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -541483,7 +543564,7 @@ vIa
 vIa
 fZJ
 fZJ
-uwn
+lAs
 woj
 qPA
 qPA
@@ -541557,26 +543638,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -541883,9 +543964,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 woj
 qPA
 qPA
@@ -541959,26 +544040,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -542285,9 +544366,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 woj
 qPA
 qPA
@@ -542361,26 +544442,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -542687,9 +544768,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 woj
 qPA
 qPA
@@ -542763,26 +544844,26 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -543089,9 +545170,9 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
+cbQ
+cbQ
+lAs
 eJN
 bHY
 bHY
@@ -543166,25 +545247,25 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -543491,27 +545572,27 @@ vIa
 vIa
 vIa
 vIa
-fZJ
-fZJ
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
-uwn
+cbQ
+cbQ
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
 pYj
 pYj
 pYj
@@ -543568,25 +545649,25 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -543893,7 +545974,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cbQ
 vIa
 vIa
 vIa
@@ -543971,22 +546052,22 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -544295,7 +546376,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cbQ
 vIa
 vIa
 vIa
@@ -544373,21 +546454,21 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -544697,7 +546778,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+cbQ
 vIa
 vIa
 vIa
@@ -544775,21 +546856,21 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -545099,7 +547180,7 @@ vIa
 vIa
 vIa
 vIa
-fZJ
+pYj
 vIa
 vIa
 vIa
@@ -545178,20 +547259,20 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa
@@ -545587,10 +547668,10 @@ vIa
 vIa
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
+bQB
+bQB
+bQB
+bQB
 vIa
 vIa
 vIa

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1282,11 +1282,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "ajj" = (
-/obj/structure/statue/saints/father,
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "ajo" = (
 /obj/effect/decal/cobbleedge,
@@ -1416,6 +1415,8 @@
 "anO" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder/r,
+/obj/item/rogueweapon/sword/iron,
+/obj/item/rogueweapon/sword/long,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "anS" = (
@@ -8179,7 +8180,6 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe/woodcut,
 /obj/item/rogueweapon/stoneaxe/woodcut,
-/obj/item/rogueweapon/stoneaxe/woodcut,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "epy" = (
@@ -8525,10 +8525,17 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/vikingarea)
 "eAm" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/loom,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/obj/item/paper,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "eAu" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 4
@@ -8635,11 +8642,13 @@
 "eDI" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church";
-	max_integrity = 9999;
-	name = "Eora's Chamber"
+	name = "Cathedral of Enigma"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/under/town/basement)
 "eDN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -9059,9 +9068,16 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/mountains)
 "eSE" = (
-/obj/structure/chair/bench/couchablack,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "eTc" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/woodturned,
@@ -9315,7 +9331,7 @@
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church";
-	max_integrity = 9999;
+	max_integrity = 2500;
 	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
@@ -9757,12 +9773,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "fnF" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "fnI" = (
 /obj/structure/chair/bench/church/mid{
 	dir = 1
@@ -10718,6 +10733,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
+/obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "fRP" = (
@@ -12718,7 +12734,8 @@
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
 	lockid = "church";
-	name = "Quarantine & Infirmary"
+	name = "Quarantine & Infirmary";
+	max_integrity = 2500
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -13421,10 +13438,9 @@
 /area/rogue/indoors/town/church/chapel)
 "htZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
 	lockid = "church";
-	desc = "Forges of Malum";
-	name = "Forges of Malum"
+	max_integrity = 2500;
+	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -13916,15 +13932,16 @@
 "hKt" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church";
-	max_integrity = 9999;
+	max_integrity = 2500;
 	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "hKE" = (
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "hKO" = (
 /obj/structure/flora/rogueflora/nettles,
 /obj/structure/fluff/railing/wood{
@@ -14822,8 +14839,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
 "iqs" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "iqv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -15315,11 +15337,8 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors)
 "iEB" = (
-/obj/structure/table/wood,
-/obj/item/candle/yellow,
-/obj/item/clothing/neck/roguetown/psicross/eora,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/under/cave)
 "iEF" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -16993,7 +17012,7 @@
 "jHv" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church";
-	max_integrity = 9999;
+	max_integrity = 2500;
 	name = "Eastern Wing"
 	},
 /turf/open/floor/rogue/wood,
@@ -17451,7 +17470,6 @@
 /area/rogue/under/cavewet/bogcaves)
 "jXc" = (
 /obj/machinery/light/rogue/torchholder/c,
-/obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "jXe" = (
@@ -17667,8 +17685,7 @@
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
 	lockid = "church";
-	name = "Western Wing";
-	max_integrity = 9999
+	name = "Western Wing"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
@@ -21433,11 +21450,6 @@
 /area/rogue/indoors/town/garrison)
 "mCT" = (
 /obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "mDe" = (
@@ -24857,6 +24869,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"oGj" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "oGv" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/effect/landmark/start/tribalcook,
@@ -26795,16 +26813,8 @@
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/thresher,
-/obj/item/rogueweapon/hoe,
-/obj/item/rogueweapon/hoe,
 /obj/item/rogueweapon/hoe,
 /obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/sickle,
-/obj/item/rogueweapon/shovel,
-/obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
@@ -27233,7 +27243,6 @@
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
-/obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "qad" = (
@@ -28289,8 +28298,12 @@
 	},
 /area/rogue/indoors/town/garrison)
 "qEq" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "church";
+	name = "Church Chest"
+	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church/chapel)
 "qEz" = (
 /turf/open/floor/rogue/metal,
@@ -28534,6 +28547,8 @@
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_y = 32
 	},
+/obj/item/rogueweapon/mace,
+/obj/item/rogueweapon/mace,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "qOW" = (
@@ -30100,6 +30115,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
+/obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road{
 	muddy = true
 	},
@@ -30115,9 +30131,11 @@
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
 "rPU" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rPX" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road{
@@ -31360,8 +31378,6 @@
 /area/rogue/indoors/town)
 "syt" = (
 /obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
@@ -31909,9 +31925,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
 "sSL" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/under/town/basement)
 "sSS" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave)
@@ -32637,13 +32652,17 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "tox" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+/obj/structure/table/wood,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	max_integrity = 99999
 	},
-/turf/closed,
-/area/rogue/indoors/town/church/chapel)
+/obj/item/natural/feather,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "toN" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/town/basement)
@@ -33718,8 +33737,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "tWY" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "tXd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -33941,9 +33963,13 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "ufN" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/mineral_door/bars{
+	lockid = "church"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "ufR" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
@@ -34009,8 +34035,6 @@
 /area/rogue/indoors/town/tavern)
 "uiv" = (
 /obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/sword/long,
-/obj/item/rogueweapon/mace/steel,
 /obj/item/listenstone,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/church/chapel)
@@ -35538,9 +35562,13 @@
 	},
 /area/rogue/under/cavewet/bogcaves)
 "vcA" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/church/chapel)
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "vcW" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -38529,17 +38557,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "wSl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
 	},
-/obj/structure/fluff/railing/wood,
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "church";
-	name = "Church Chest"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/under/cave)
 "wSn" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -38910,6 +38932,12 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/church/chapel)
+"xfp" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "wooden_floort"
+	},
+/area/rogue/under/cave)
 "xfG" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
@@ -39199,13 +39227,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "xnv" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	max_integrity = 9999;
-	name = "Eastern Wing"
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "wooden_floor2"
+	},
+/area/rogue/under/town/basement)
 "xny" = (
 /obj/item/flashlight/flare/torch,
 /obj/item/flashlight/flare/torch,
@@ -221585,15 +221614,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+iEB
+iEB
+iEB
+iEB
+iEB
+iEB
+iEB
+iEB
 vRu
 vRu
 gLf
@@ -221987,15 +222016,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+vcA
+iqs
+vcA
+iqs
+vcA
+iqs
+vcA
+iEB
 vRu
 vRu
 oQo
@@ -222389,15 +222418,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+wSl
+hKE
+wSl
+hKE
+wSl
+hKE
+wSl
+iEB
 vRu
 cTA
 iTw
@@ -222791,15 +222820,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+vcA
+hKE
+vcA
+hKE
+vcA
+hKE
+vcA
+iEB
 vRu
 cTA
 cBf
@@ -223193,15 +223222,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+tWY
+hKE
+tWY
+hKE
+tWY
+hKE
+tWY
+iEB
 vRu
 cTA
 cBf
@@ -223595,15 +223624,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+oGj
+hKE
+hKE
+hKE
+hKE
+hKE
+oGj
+iEB
 vRu
 cTA
 iyU
@@ -223997,15 +224026,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+hKE
+hKE
+hKE
+xfp
+hKE
+hKE
+hKE
+iEB
 vRu
 cTA
 cTA
@@ -224399,15 +224428,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+hKE
+iEB
+eAm
+tox
+eSE
+iEB
+hKE
+iEB
 vRu
 vRu
 vRu
@@ -224801,15 +224830,15 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+iEB
+fnF
+ufN
+hKE
+hKE
+hKE
+ufN
+fnF
+iEB
 vRu
 vRu
 vRu
@@ -225203,15 +225232,15 @@ cTA
 cTA
 cTA
 cTA
-jyI
-jyI
-cTA
-kzI
-kzI
-kzI
-cTA
-cTA
-cTA
+sSL
+sSL
+sSL
+xnv
+eDI
+xnv
+sSL
+sSL
+sSL
 cTA
 cTA
 jyI
@@ -225608,7 +225637,7 @@ jkK
 iTw
 iTw
 iTw
-jkK
+iTw
 iTw
 iTw
 iTw
@@ -297985,7 +298014,7 @@ kds
 sOh
 xKz
 xaD
-fVQ
+rPU
 xKz
 gUR
 nmC
@@ -308426,7 +308455,7 @@ vIJ
 vIJ
 vIJ
 xKz
-wbg
+qEa
 wbg
 wbg
 qFT
@@ -309230,7 +309259,7 @@ nIQ
 nIQ
 nIQ
 xKz
-wbg
+qEa
 wbg
 wbg
 jZe
@@ -310440,7 +310469,7 @@ wbg
 wbg
 wbg
 wbg
-wbg
+qEa
 kjH
 rwn
 rWO
@@ -310451,7 +310480,7 @@ sYf
 tux
 tux
 tYD
-wbg
+qEa
 wbg
 wVI
 yiU
@@ -332149,7 +332178,7 @@ idG
 obL
 xKF
 vtw
-hKE
+wOR
 wOR
 vtw
 eEC
@@ -332953,7 +332982,7 @@ xKF
 vtw
 vtw
 vtw
-hKE
+wOR
 gLx
 vtw
 rkf
@@ -433856,9 +433885,9 @@ wAm
 jGT
 cwd
 hqI
+qEq
 cwd
-cwd
-eAm
+mCT
 fZJ
 fZJ
 fZJ
@@ -434259,7 +434288,7 @@ hqI
 cwd
 hqI
 lVF
-cwd
+qEq
 mCT
 fZJ
 fZJ
@@ -434660,7 +434689,7 @@ hqI
 hqI
 cwd
 hqI
-cwd
+qEq
 cwd
 mCT
 fZJ
@@ -435064,7 +435093,7 @@ lLK
 hqI
 cwd
 nfN
-wSl
+itC
 fZJ
 fZJ
 fZJ
@@ -438271,7 +438300,7 @@ pCH
 uRR
 uRR
 cMs
-teW
+kqW
 wpm
 wpm
 wpm
@@ -438667,8 +438696,8 @@ tML
 teW
 tML
 tML
-tox
-fnF
+hKt
+hKt
 wAm
 aGb
 tML
@@ -440275,9 +440304,9 @@ uBv
 tML
 tML
 tML
-xnv
-hKt
-tML
+swm
+swm
+owz
 rMM
 cfY
 cfY
@@ -440679,7 +440708,7 @@ kNs
 htZ
 swm
 swm
-tML
+owz
 tML
 lQT
 cfY
@@ -440687,7 +440716,7 @@ fPg
 nJX
 cpY
 cfY
-wpe
+mYi
 qcC
 qcC
 eCn
@@ -447911,7 +447940,7 @@ juf
 iYx
 iYx
 iYx
-eDI
+iYx
 iYx
 iYx
 iYx
@@ -448310,15 +448339,15 @@ vIa
 vIa
 aUc
 aUc
-iYx
-iYx
-sSL
-tWY
-tWY
-iyd
-iyd
-iyd
-iYx
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
+xJe
 xJe
 aUc
 aUc
@@ -448711,19 +448740,19 @@ vIa
 vIa
 vIa
 vIa
+vIa
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+vIa
 aUc
-iYx
-eSE
-iqs
-tWY
-tWY
-iyd
-iyd
-iyd
-iYx
-xJe
-vIa
-vIa
 vIa
 vIa
 vIa
@@ -449113,19 +449142,19 @@ vIa
 vIa
 vIa
 vIa
+vIa
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+vIa
 aUc
-iYx
-qEq
-iqs
-tWY
-tWY
-iyd
-iyd
-iyd
-iYx
-xJe
-vIa
-vIa
 vIa
 vIa
 vIa
@@ -449515,19 +449544,19 @@ vIa
 vIa
 vIa
 vIa
+vIa
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+vIa
 aUc
-iYx
-iEB
-rPU
-uZC
-uZC
-uZC
-iYx
-iYx
-iYx
-xJe
-vIa
-vIa
 vIa
 vIa
 vIa
@@ -449917,19 +449946,19 @@ vIa
 vIa
 vIa
 vIa
+vIa
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+vIa
 aUc
-iYx
-iYx
-iYx
-vcA
-vcA
-ufN
-iYx
-xJe
-xJe
-xJe
-vIa
-vIa
 vIa
 vIa
 vIa
@@ -450319,18 +450348,18 @@ aUc
 aUc
 aUc
 aUc
-aUc
-iYx
-iYx
-iYx
-iYx
-iYx
-iYx
-iYx
-aUc
-aUc
-aUc
-aUc
+vIa
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+lAs
+vIa
+vIa
+vIa
+vIa
 aUc
 aUc
 aUc

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -5367,9 +5367,14 @@
 	},
 /area/rogue/indoors)
 "cJz" = (
-/obj/structure/fluff/walldeco/masonflag,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/rack/rogue,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/church/chapel)
 "cKj" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -6144,7 +6149,43 @@
 	},
 /area/rogue/indoors/town/garrison)
 "dfH" = (
-/obj/structure/roguemachine/scomm/r,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/tongs,
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
+/obj/item/rogueweapon/hammer{
+	color = gold;
+	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
+	name = "Hammer of Malum"
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "dfK" = (
@@ -8526,9 +8567,17 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet/bogcaves/chapel)
 "eBx" = (
-/obj/machinery/anvil{
-	pixel_x = -1
-	},
+/obj/structure/rack/rogue,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eBz" = (
@@ -14599,7 +14648,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "ijS" = (
-/obj/item/roguebin/water/gross,
+/obj/machinery/anvil{
+	pixel_x = 9
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "ijT" = (
@@ -15925,9 +15976,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
 "iYH" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/dwarfin)
 "iYN" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -17048,6 +17097,10 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "jMc" = (
@@ -17679,26 +17732,13 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/cavewet/bogcaves/sunkencity/psydon)
 "keW" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/hammer{
-	color = gold;
-	desc = "A mastercrafted smith's hammer carrying the blessing of Malum.";
-	name = "Hammer of Malum"
-	},
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/obj/item/rogueweapon/tongs,
-/turf/open/floor/rogue/blocks,
+/obj/structure/handcart,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "kfe" = (
 /obj/structure/rack/rogue,
@@ -17718,15 +17758,8 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "kfr" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/dwarfin)
 "kfv" = (
 /obj/structure/bars,
@@ -19705,16 +19738,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
 /area/rogue/outdoors/rtfield)
-"lqJ" = (
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick,
-/obj/item/rogueweapon/pick/steel,
-/obj/item/rogueweapon/pick/steel,
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/pick/steel,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "lqN" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -21014,7 +21037,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "mmb" = (
-/obj/machinery/anvil,
+/obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "mmd" = (
@@ -35610,8 +35633,8 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/bogcaves)
 "veE" = (
-/obj/structure/fluff/grindwheel,
-/turf/open/floor/rogue/blocks,
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "veK" = (
 /obj/structure/table/wood{
@@ -36560,9 +36583,7 @@
 /turf/closed,
 /area/rogue/indoors/town)
 "vGQ" = (
-/obj/machinery/light/rogue/forge{
-	pixel_x = -1
-	},
+/obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "vGT" = (
@@ -37298,11 +37319,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"wgf" = (
-/obj/structure/table/wood,
-/obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "wgn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -37488,10 +37504,13 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "wnE" = (
-/obj/structure/handcart,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile,
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/obj/item/rogueweapon/pick/steel,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "wnG" = (
 /obj/structure/spacevine,
@@ -314848,8 +314867,8 @@ ufu
 pUl
 pUl
 hGr
-fQm
-guP
+iYH
+kfr
 guP
 guP
 jjF
@@ -315651,7 +315670,7 @@ wbg
 dsR
 dTB
 tVP
-tVP
+keW
 jLX
 tCG
 tVP
@@ -316054,7 +316073,7 @@ wKT
 sSW
 tVP
 tVP
-tVP
+kEb
 tVP
 tVP
 tVP
@@ -316455,10 +316474,10 @@ wbg
 dsR
 rJC
 tVP
-wnE
-iYH
 tVP
-kEb
+tVP
+tVP
+tVP
 tVP
 tVP
 nnb
@@ -316858,9 +316877,9 @@ wKT
 kFS
 tVP
 veE
-lqJ
-keW
-wgf
+tVP
+tVP
+veE
 tVP
 tCG
 nnb
@@ -317257,12 +317276,12 @@ sIE
 wbg
 wbg
 wKT
-eWj
+yfY
 yfY
 ijS
 mmb
-tZZ
-vGQ
+mmb
+ijS
 yfY
 yfY
 wKT
@@ -318462,15 +318481,15 @@ xdq
 qeY
 wbg
 wbg
-cJz
-yfY
-dfH
-ijS
-eBx
+wKT
 vGQ
+dfH
 tZZ
-kfr
+eBx
 nBp
+tZZ
+eWj
+wnE
 wKT
 cIh
 wbg
@@ -444269,7 +444288,7 @@ aUc
 xJe
 xJe
 teW
-iDV
+cJz
 uKB
 uKB
 syt


### PR DESCRIPTION
## About The Pull Request

The following PR adds as followed for the server and fixes a number of issues.
>Fixes the voids in the Keep reported by Elizabeths player
>Adds a number of anti grief and QoL features to the keep (Hand gets an gemerald ring and choker. There are now bar'd windows in the Stewards area.
>Removes secretly mapped in items that gave certain people an advantage 
>Adds anti gref measures to the Smithy.
>Adds the Grandmasters chambers to the Church & revamps part of it.
>Adds a feeding line for the poor. 
>Adjusts around the beggar spawn.
>Adds a new segment of Rockhill known as "The Estate" which is guarded by the town watch utilizing a shutter gate system.
>Adds a mini dungeon crypt that has one dungeon chest but is surrounded by running water. Gl.
>Added anti tunneling measures and things like that in the map. If you wanna break in, find the statue or tunnel in from the undersea.
> Some other things I might have forgotten to mention besides some mining ore spots.
> Also adds a new dungeon that advs can clear out and claim as home.

## Why It's Good For The Game

Mentioned above. 

## Pictures in game:

![image](https://github.com/user-attachments/assets/4bbd96d5-bd80-4af1-922f-5c6169b63393)
![image](https://github.com/user-attachments/assets/0921ad70-f4d2-4bbb-bed8-5a41a327f29f)
![image](https://github.com/user-attachments/assets/085b8236-d982-4e51-bb91-3d46cbce8a61)
![image](https://github.com/user-attachments/assets/e8d3878b-6dd5-45ff-9837-79808148f516)
![image](https://github.com/user-attachments/assets/31aa7f02-de27-4782-94bd-7294346c59e9)
![image](https://github.com/user-attachments/assets/bf8aca72-a204-4c73-9f6d-fbd4030a9ba1)
