### PR TITLE
Remove Stunmace from Loot Table

### DIFF
--- a/modular_hearthstone/code/game/objects/effects/dungeon_chest.dm
+++ b/modular_hearthstone/code/game/objects/effects/dungeon_chest.dm
@@ -495,7 +495,6 @@
 		/obj/item/rogueweapon/mace/steel/morningstar = 15,
 		/obj/item/rogueweapon/mace/goden = 15,
 		/obj/item/rogueweapon/mace/goden/steel = 15,
-		/obj/item/rogueweapon/mace/stunmace = 10,
 
 		/obj/item/clothing/ring/dragon_ring = 5,
 		/obj/item/clothing/ring/diamonds = 15,


### PR DESCRIPTION
Weapon is neither balanced nor fits the theme of Hearthstone, being Lifeweb scifantasy.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The Stunmace simply does not belong in the game, being a melee weapon balanced for Deathnet, if balanced at all.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The stunmace does not fit the setting. Its utility is already in the Master's Rod.
If we suppose the stunmace fits the setting, then it should be in the hands of the town sheriff, dungeoneer and other watch.
Instead it presently shows up in loot boxes.
This means a stun weapon intended for Deathnet law enforcement is in the hands of wandering combat migrants.
Wandering combat migrants should not have a weapon that will stun out royal guards with a tap.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
