### PR TITLE
Allows cauterization to clear infections from wounds + skills are no longer wiped on zombification + zombies can't pat out their own flames anymore

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -147,8 +147,8 @@
 	return ..()
 
 /datum/antagonist/zombie/proc/transform_zombie()
-	if(owner)
-		owner.skill_experience = list()
+//	if(owner)
+//		owner.skill_experience = list()
 	var/mob/living/carbon/human/zombie = owner.current
 	if(!zombie)
 		qdel(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -355,6 +355,10 @@
 		buckled.user_unbuckle_mob(src,src)
 
 /mob/living/carbon/resist_fire()
+	if(HAS_TRAIT(src, TRAIT_ROTMAN))
+		visible_message(span_warning("[src] groans loudly, unable to remember how to put [p_them()]self out!"))
+		emote("idle")
+		return
 	fire_stacks -= 5
 	if(fire_stacks > 10)
 		Paralyze(60, TRUE, TRUE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -356,7 +356,7 @@
 
 /mob/living/carbon/resist_fire()
 	if(HAS_TRAIT(src, TRAIT_ROTMAN))
-		visible_message(span_warning("[src] groans loudly, unable to remember how to put [p_them()]self out!"))
+		visible_message(span_warning("[src] groans loudly, unable to remember how to put [p_them()]self out!"))//DIE VECNA DIE
 		emote("idle")
 		return
 	fire_stacks -= 5

--- a/code/modules/surgery/surgeries/organic_steps.dm
+++ b/code/modules/surgery/surgeries/organic_steps.dm
@@ -124,6 +124,19 @@
 	if(bodypart)
 		for(var/datum/wound/bleeder in bodypart.wounds)
 			bleeder.cauterize_wound()
+		for(var/datum/wound/infection in bodypart.wounds)
+			if(infection.zombie_infection_timer)
+				deltimer(infection.zombie_infection_timer)
+				infection.zombie_infection_timer = null
+				display_results(user, target, span_notice("I burn out an infection in [target]'s [parse_zone(target_zone)]."),
+					span_notice("[user] burns out an infection in [target]'s [parse_zone(target_zone)]."),
+					span_notice("[user] burns out an infection in [target]'s [parse_zone(target_zone)]."))
+			if(infection.werewolf_infection_timer)
+				deltimer(infection.werewolf_infection_timer)
+				infection.werewolf_infection_timer = null
+				display_results(user, target, span_notice("I burn out an infection in [target]'s [parse_zone(target_zone)]."),
+					span_notice("[user] burns out an infection in [target]'s [parse_zone(target_zone)]."),
+					span_notice("[user] burns out an infection in [target]'s [parse_zone(target_zone)]."))
 		bodypart.receive_damage(burn = 25) //painful, but the wounds go away eh?
 	target.emote("scream")
 	return TRUE
@@ -192,7 +205,7 @@
 	name = "Drill bone"
 	ignore_clothes = TRUE
 	implements = list(
-		TOOL_DRILL = 80, 
+		TOOL_DRILL = 80,
 		TOOL_SCREWDRIVER = 25,
 	)
 	time = 3 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
When surgery was implemented on Blackstone, it was the intent of its coders that infected wounds be impossible to heal without amputation or miracles. In Hearthstone, however, being able to restore a person from zombification is intentional. Therefore, it behooves me to also ensure that there is a way to remove infections from wounds, separately from the surgery that cures rot.

Why separate? Because curing the rot is not the same as curing the infection which led to the necrosis. I don't think it is a big ask for medical roles, who have diagnosis and can tell where the infection in a patient is, to have to cauterize that location. Most zombifications, after all, are not directly caused by bites.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
See above. This should fix an issue that people have had with surgery and a different one that is specific to deadites in general. This may as a side effect make zombies of people that have unarmed or wrestling skills more dangerous, but as a way to balance this, zombies can no longer pat themselves out if they get set on fire. They must lurk near water or forever fear Lesser Miracle.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
