### PR TITLE
Adds 3 sticks to 1 coal and small log into coal transmuatations.

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -169,6 +169,20 @@
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2)
 	craftdiff = 3
 
+//	Having a regular log to coal craft broke things by allowing an unintended exploit using bundled sticks to craft infinite coal, most likely because regular (large) logs are considered a containter item.
+
+/datum/crafting_recipe/roguetown/alchemy/st2coa
+	name = "transmute sticks to coal"
+	result = list(/obj/item/rogueore/coal = 1)
+	reqs = list(/obj/item/grown/log/tree/stick = 3)
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/alchemy/sl2coa
+	name = "transmute small log to coal"
+	result = list(/obj/item/rogueore/coal)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+	craftdiff = 1
+
 /datum/crafting_recipe/roguetown/alchemy/s2coa
 	name = "transmute stone to coal"
 	result = list(/obj/item/rogueore/coal = 1)


### PR DESCRIPTION
Adds 3 sticks into one coal and one small log into one coal alchemy transmutations.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds two alchemy transmutations: 3 sticks into one coal and one small log into one coal.
Adds a comment on WHY a regular log into coal transmutation is NOT included for future coders and posterity/documentation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows alchemists to directly convert wooden items into coal without needing the additional setup of a furnace, which a lot of alchemy players really liked but that package got reverted because of the other things the pull request was tied to due to my unfamiliarity with pull request practices.
Not really attached to the 3 sticks into one coal transmutation so that can be axed if it's OP, or made a higher difficulty so only higher level alchemists can use it.
While I would've like to also added a regular log to multiple coal transmutation, this broke things as a regular log was classed as a container and players were able to make infinite coal using bundled sticks somehow.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->