### PR TITLE
Moon Acolyte Money Gang

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -35,7 +35,7 @@
 			wrists = /obj/item/clothing/wrists/roguetown/wrappings
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
-		if(/datum/patron/divine/noc) //Nocalytes aren't real. Play Cleric.
+		if(/datum/patron/divine/noc) //Nocalytes are real, don't let them tell you otherwise, we love casting spells. (Hearthstone edit: simply gives Noc Acolytes the love that the Noc Clerics got, access to pick spells)
 			head = /obj/item/clothing/head/roguetown/roguehood/nochood
 			neck = /obj/item/clothing/neck/roguetown/psicross/noc
 			wrists = /obj/item/clothing/wrists/roguetown/nocwrappings
@@ -44,6 +44,9 @@
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE) // shouldn't be that bad.
 			H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
+			H.mind.adjust_spellpoints(1)
+					H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		if(/datum/patron/divine/dendor) //Dendorites all busted. Play Druid.
 			head = /obj/item/clothing/head/roguetown/helmet/dendorculthelm
 			neck = /obj/item/clothing/neck/roguetown/psicross/dendor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Let's be real, Noc Acolytes like their Clerical counterparts have some mild abilities compared to the kit of some of the other clerics. (A like two second blind that requires you to be able to aim, and invisibility that lasts for like 5 seconds that you can still LOUDLY hear them stomping around unless they're shoeless.) Recently Noc Clerics got a bit of love giving them access to the magical spell list, but the Acolytes were left untouched. I've decided to give them a bit of love to get them back on par to the Adventurer version of their class and hopefully encourage people to play them as Acolyte as well.

You're still not a mage, you've got access to TWO whole points (You could get fireball, but why not something more useful for the church like Message or Encode Thoughts, perfect for spreading the word of the great Lady Moon)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why wouldn't the follower of the goddess of Knowledge and Magic know magic? Also Prestidigitation is great for cleaning up the infinite amount of blood that appears in the church.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
