### PR TITLE
Removes forced Faithless for Warlock

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -10,7 +10,7 @@
 	category_tags = list(CTAG_ADVENTURER)
 
 /datum/outfit/job/roguetown/adventurer/warlock
-	allowed_patrons = list(/datum/patron/godless)
+
 
 /datum/outfit/job/roguetown/adventurer/warlock/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Yeah, so being forced into faithlessness as a Warlock turns out to be pretty shitty considering how the Church is, so, fixing it.

## Why It's Good For The Game

I'm kinda getting tired of the Church deciding to merk a Warlock just because they can't get healed by miracles.
