### PR TITLE
Attunement Points + Infusion Fixes + Artificer Added

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -305,6 +305,7 @@
 			to_chat(current, span_nicegreen("My [S.name] grows to [SSskills.level_names[known_skills[S]]]!"))
 		if(skill == /datum/skill/magic/arcane)
 			adjust_spellpoints(1)
+			current.calculate_attunement_points()
 	else
 		to_chat(current, span_warning("My [S.name] has weakened to [SSskills.level_names[known_skills[S]]]!"))
 
@@ -325,6 +326,7 @@
 	var/amt2gain = 0
 	if(skill == /datum/skill/magic/arcane)
 		adjust_spellpoints(amt)
+		current.calculate_attunement_points()
 	if(amt > 0) //positive at
 		for(var/i in 1 to amt)
 			switch(skill_experience[S])

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -211,6 +211,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	//can you infuse this item magically?
 	var/infusable = TRUE
 
+	var/attunement_cost = 0
+
 /obj/item/Initialize()
 	. = ..()
 	if(!pixel_x && !pixel_y && !bigboy)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -39,6 +39,9 @@
 
 
 /obj/item/book/granter/attack_self(mob/living/user)
+	if(user.attunement_points_used + attunement_cost > user.attunement_points_max)
+		to_chat(user, span_warning("A sharp arcyne pain stops me from using this currently!"))
+		return FALSE
 	if(reading)
 		to_chat(user, span_warning("You're already using this!"))
 		return FALSE
@@ -85,6 +88,7 @@
 	sellprice = 20
 	drop_sound = 'sound/items/gem.ogg'
 	pickup_sound =  list('sound/vo/mobs/ghost/whisper (1).ogg','sound/vo/mobs/ghost/whisper (2).ogg','sound/vo/mobs/ghost/whisper (3).ogg')
+	attunement_cost = 3
 
 /obj/item/book/granter/trait/already_known(mob/user)
 	if(!granted_trait)
@@ -114,6 +118,8 @@
 		var/datum/crafting_recipe/R = crafting_recipe_type
 		user.mind.teach_crafting_recipe(crafting_recipe_type)
 		to_chat(user,"<span class='notice'>You learned how to make [initial(R.name)].</span>")
+	user.attunement_points_used += attunement_cost
+	user.check_attunement_points()
 	onlearned(user)
 
 /obj/item/book/granter/trait/mobility
@@ -154,12 +160,14 @@
 	granted_trait2 = TRAIT_BLOODLOSS_IMMUNE
 	traitname = "the undying"
 	remarks = list("<span class ='colossus'>Curse, bless, me now with your fierce tears, I pray.</span>", "<span class ='colossus'>Rage, rage against the dying of the light.</span>", "<span class ='colossus'>Grave men, near death, who see with blinding sight.</span>", "<span class ='colossus'>Do not go gentle into that good night.</span>",)
+	attunement_cost = 5
+
 /obj/item/book/granter/trait/war/relentless
 	name = "Fragment of the Relentless"
 	granted_trait = TRAIT_NOROGSTAM
 	traitname = "the relentless"
 	remarks = list("<span class ='colossus'>Death can have me, when I am done.", "<span class ='colossus'>Rip and tear.", "<span class ='colossus'>This is where we hold them. This is where they die.", "<span class ='colossus'>Let go of everything.", "<span class ='colossus'>No surrender. No retreat.</span>",)
-
+	attunement_cost = 5
 
 /obj/item/book/granter/trait/acrobat
 	name = "Fragment of the Acrobat"
@@ -179,7 +187,8 @@
 	sellprice = 50
 	traitname = "the succubus"
 	remarks = list("<font color='#b028fffb'>They like what they see.", "<font color='#b028fffb'>I can't wait to hear you scream.", "<font color='#b028fffb'>So many hearts to break, so little time.","<font color='#b028fffb'>Without pain, how would they know pleasure?</font>",)
-
+	attunement_cost = 2
+	
 /obj/item/book/granter/trait/north
 	name = "Fragment of the North"
 	light_color = "#28d8fffb"
@@ -188,6 +197,7 @@
 	sellprice = 150
 	traitname = "the north"
 	remarks = list("<font color='#28d8fffb'>It is important to stay warm.", "<font color='#28d8fffb'>Sail em high.", "<font color='#28d8fffb'>Plug the holes of your ship with a finger.","<font color='#28d8fffb'>Just follow the North Star.</font>",)
+	attunement_cost = 2
 ///ACTION BUTTONS///
 
 /obj/item/book/granter/action

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -249,6 +249,26 @@
 	smeltresult = /obj/item/ingot/steel
 	sellprice = 363
 	static_price = TRUE
+	attunement_cost = 5
+	var/active_item
+
+/obj/item/rogueweapon/sword/long/vlord/equipped(mob/living/user)
+	. = ..()
+	if(active_item)
+		return
+	else
+		active_item = TRUE
+		user.attunement_points_used += attunement_cost
+		user.check_attunement_points()
+		return
+
+/obj/item/rogueweapon/sword/long/vlord/dropped(mob/living/user)
+	if(active_item)
+		user.attunement_points_used -= attunement_cost
+		user.check_attunement_points()
+		active_item = FALSE
+		return
+
 
 /obj/item/rogueweapon/sword/long/vlord/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -250,6 +250,7 @@
 	sellprice = 363
 	static_price = TRUE
 	attunement_cost = 5
+	infusable = FALSE
 	var/active_item
 
 /obj/item/rogueweapon/sword/long/vlord/equipped(mob/living/user)

--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -103,6 +103,8 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/tracking, 1, TRUE) //Hearthstone change.
+	H.attunement_points_bonus = 7
+	H.calculate_attunement_points()
 	belt = /obj/item/storage/belt/rogue/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -162,6 +162,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE)
+	H.attunement_points_bonus = 7
+	H.calculate_attunement_points()
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	shirt = /obj/item/clothing/suit/roguetown/shirt/vampire
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -943,6 +943,7 @@
 	sellprice = 666
 	static_price = TRUE
 	var/active_item = FALSE
+	attunement_cost = 5
 
 /obj/item/clothing/neck/roguetown/blkknight/equipped(mob/living/user)
 	. = ..()
@@ -961,6 +962,8 @@
 	else
 		to_chat(user, span_notice("I feel an evil power about that necklace.."))
 		armor = getArmor("blunt" = 0, "slash" = 0, "stab" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	user.attunement_points_used += attunement_cost
+	user.check_attunement_points()
 
 /obj/item/clothing/neck/roguetown/blkknight/dropped(mob/living/user)
 	if(!active_item)
@@ -977,6 +980,8 @@
 	else
 		to_chat(user, span_notice("Strange, I don't feel that power anymore.."))
 		armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
+	user.attunement_points_used -= attunement_cost
+	user.check_attunement_points()
 
 /obj/item/clothing/suit/roguetown/armor/plate/blkknight
 	slot_flags = ITEM_SLOT_ARMOR

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -942,8 +942,10 @@
 	resistance_flags = FIRE_PROOF
 	sellprice = 666
 	static_price = TRUE
-	var/active_item = FALSE
 	attunement_cost = 5
+	infusable = FALSE
+	var/active_item = FALSE
+	
 
 /obj/item/clothing/neck/roguetown/blkknight/equipped(mob/living/user)
 	. = ..()

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -155,6 +155,7 @@
 	name = "Dragon Ring"
 	icon_state = "dragonring"
 	sellprice = 666
+	attunement_cost = 5
 	var/active_item
 
 /obj/item/clothing/ring/dragon_ring/equipped(mob/living/user)
@@ -167,6 +168,8 @@
 		user.change_stat("strength", 2)
 		user.change_stat("constitution", 2)
 		user.change_stat("endurance", 2)
+		user.attunement_points_used += attunement_cost
+		user.check_attunement_points()
 		return
 
 /obj/item/clothing/ring/dragon_ring/dropped(mob/living/user)
@@ -175,6 +178,8 @@
 		user.change_stat("strength", -2)
 		user.change_stat("constitution", -2)
 		user.change_stat("endurance", -2)
+		user.attunement_points_used -= attunement_cost
+		user.check_attunement_points()
 		active_item = FALSE
 		return
 

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -157,7 +157,8 @@
 	sellprice = 666
 	attunement_cost = 5
 	var/active_item
-
+	infusable = FALSE
+	
 /obj/item/clothing/ring/dragon_ring/equipped(mob/living/user)
 	. = ..()
 	if(active_item)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -515,6 +515,7 @@
 		
 	var/obj/item/item
 	item = new item_type
+	item.infusable = FALSE
 	item.AddComponent(/datum/component/pact_weapon, H, patronchoice)
 	item.AddComponent(/datum/component/singing_item, H)
 	item.AddComponent(/datum/component/spirit_holding, null, null)

--- a/code/modules/jobs/job_types/roguetown/goblin/tribalsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/tribalsmith.dm
@@ -27,6 +27,7 @@
 	backpack_contents = list(/obj/item/roguekey/tribe = 1)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NASTY_EATER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ARTIFICER, TRAIT_GENERIC)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1420,6 +1420,25 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "gutted", "gored")
 	// sharpness = SHARP_EDGED
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	var/active_item
+	attunement_cost = 5
+
+/obj/item/melee/sword_of_the_forsaken/equipped(mob/living/user)
+	. = ..()
+	if(active_item)
+		return
+	else
+		active_item = TRUE
+		user.attunement_points_used += attunement_cost
+		user.check_attunement_points()
+		return
+
+/obj/item/melee/sword_of_the_forsaken/dropped(mob/living/user)
+	if(active_item)
+		user.attunement_points_used -= attunement_cost
+		user.check_attunement_points()
+		active_item = FALSE
+		return
 
 //Enables the sword to butcher bodies
 /obj/item/melee/sword_of_the_forsaken/Initialize(mapload)
@@ -1451,8 +1470,20 @@
 	icon_state = "necklace_forsaken_active"
 	actions_types = list(/datum/action/item_action/hands_free/necklace_of_the_forsaken)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	attunement_cost = 5
 	var/mob/living/carbon/active_owner
 	var/numUses = 1
+	var/active_item
+
+/obj/item/clothing/neck/roguetown/necklace_of_the_forsaken/equipped(mob/living/user)
+	. = ..()
+	if(active_item)
+		return
+	else
+		active_item = TRUE
+		user.attunement_points_used += attunement_cost
+		user.check_attunement_points()
+		return
 
 /obj/item/clothing/neck/roguetown/necklace_of_the_forsaken/item_action_slot_check(slot)
 	return (..() && (slot == ITEM_SLOT_NECK))
@@ -1461,6 +1492,10 @@
 	..()
 	if(active_owner)
 		remove_necklace()
+	if(active_item)
+		user.attunement_points_used -= attunement_cost
+		user.check_attunement_points()
+		active_item = FALSE
 
 //Apply a temp buff until the necklace is used
 /obj/item/clothing/neck/roguetown/necklace_of_the_forsaken/proc/temp_buff(mob/living/carbon/human/user)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1420,8 +1420,9 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "gutted", "gored")
 	// sharpness = SHARP_EDGED
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	var/active_item
+	infusable = FALSE
 	attunement_cost = 5
+	var/active_item
 
 /obj/item/melee/sword_of_the_forsaken/equipped(mob/living/user)
 	. = ..()
@@ -1471,6 +1472,7 @@
 	actions_types = list(/datum/action/item_action/hands_free/necklace_of_the_forsaken)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	attunement_cost = 5
+	infusable = FALSE
 	var/mob/living/carbon/active_owner
 	var/numUses = 1
 	var/active_item

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -26,6 +26,42 @@
 	var/list/statindex = list()
 	var/datum/patron/patron = /datum/patron/godless
 
+	var/attunement_points_max = 0 //how many magic items can you wear, magic items cost 1 to 5
+	var/attunement_points_used = 0 //adjusted when equipping magic items
+	var/attunement_points_bonus = 0 //adjusted based on special roles, an artificer or antagonist should have this bonus, NOBODY ELSE...
+	var/magic_sickness = FALSE
+
+/mob/living/proc/calculate_attunement_points()
+	attunement_points_max = STAINT - 4 + mind.get_skill_level(/datum/skill/magic/arcane) + attunement_points_bonus
+
+/mob/living/proc/check_attunement_points()
+	if(attunement_points_used > attunement_points_max)
+		//debuff
+		apply_status_effect(/datum/status_effect/buff/magic_sickness/)
+		visible_message(span_info("[src] begins to look sick."), span_warning("I feel sick all of the sudden."))
+		magic_sickness = TRUE
+	else
+		if(magic_sickness)
+			magic_sickness = FALSE
+			remove_status_effect(/datum/status_effect/buff/magic_sickness/)
+			visible_message(span_info("[src] looks like they feel a bit better."), span_info("My nausea fades away."))
+
+/datum/status_effect/buff/magic_sickness
+	id = "arcyne sickness"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic_sickness
+	effectedstats = list("strength" = -2, "perception" = -2, "constitution" = -2, "endurance" = -2, "speed" = -2, "fortune" = -2) //int is not effected because int effects attunement points themselves, that could trap you with arcyne sickness
+	duration = -1
+
+/datum/status_effect/buff/magic_sickness/tick()
+	var/mob/living/target = owner
+	var/mob/living/carbon/M = target
+	M.add_nausea(5) //it's a lot, but get the fucking items off. That's the point.
+
+/atom/movable/screen/alert/status_effect/buff/magic_sickness
+	name = "Arcyne Sickness"
+	desc = "I am feeling sick due to powerful item enchantments."
+	icon_state = "debuff"
+
 /mob/living/proc/init_faith()
 	set_patron(/datum/patron/godless)
 
@@ -193,6 +229,7 @@
 				newamt--
 				BUFINT++
 			STAINT = newamt
+			calculate_attunement_points() //recalculate attunement points
 
 		if("constitution")
 			newamt = STACON + amt


### PR DESCRIPTION
## About The Pull Request
**Additions:**

- gave tribal smith the artificer trait (for now, they are the only ones who have it)
- added attunement points to all players. **attunement point maximum is equal to: intelligence - 4 + arcane skill + bonus** (a hypothetical artificer class would have the bonus, right now only bandits and vlords have a bonus of 7)
- added proper attunement point cost to all infusions, dragon ring, dragon scale necklace, necklace of the forsaken, sword of the forsaken and crimson fang based on speculative tier from 1 to 5 (see code comments)
- added attunement point costs to skill shards. These do not let you use them if it will cause you to go over your attunement point maximum so that you don't get stuck with arcyne sickness. This stops you from using the shard with a text notification.
- added arcyne sickness debuff: a -2 to all stats other than intelligence (since attunement points are based on intelligence) and nausea every tick. This debuff is applied if your total equipment attunement point cost goes over your attunement point maximum and is removed when your attunement point total is lower than your attunement point maximum. This is meant to stop you from equipping too much magic crap.
- added after attack to the infusions datum for future weapon infusions

**Changes:**

- fixed item of radiance
- fixed item of defense
- debuffed item of propulsion to 7.5% speed increase from 15% speed increased
- warlock pact weapons can no longer be infused
- already magical items can no longer be infused

## Why It's Good For The Game
Adds 30+ magic items to the game and stops players from maxing str and sacrificing int if they would like to use magical items.

A dragon ring for example is a tier 5 enchanted item. That means it costs 5 attunement points. Due to the attunement point maximum calculation, a dragon ring or any tier 5 magic item (shard of the undying and relentless are other examples) would require 9 intelligence minimum to use without getting arcyne sickness

## What is a magic tier?
Magic tier determines the gem tier required to infuse an item as well as the attunement points it costs to use it.
tier/cost 1, toper : flavor (it's a flavor item, instrument of the sewers which makes rats follow you is an example)
tier/cost 2, gemerald : minor effect (skill increases and okay traits)
tier/cost 3, saffira : normal effect or (okay spells, minor stat increases and good traits)
tier/cost 4, blortz : major effect (good spells and amazing traits)
tier/cost 5, dorpel or rontz or riddle of steel : (potentially game changing effect, major stat increases, dragon ring and shard of the undying are examples)

## Potential Roadmap
Make a standalone artificer class for towners
I am open to an extremely expensive shard that would grant the artificer trait
I am open to an expensive shard that increases your attunement points by 5.