### PR TITLE
Quickie PR #1 - Stockpiling Veggies

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -305,3 +305,36 @@
 	transport_fee = 5
 	export_price = 11
 	importexport_amt = 3
+
+/datum/roguestock/stockpile/onion
+	name = "Onion"
+	desc = "A spicy orb."
+	item_type = /obj/item/reagent_containers/food/snacks/grown/onion/rogue
+	held_items = list(8, 10)
+	payout_price = 2
+	withdraw_price = 4
+	transport_fee = 1
+	export_price = 4
+	importexport_amt = 5
+
+/datum/roguestock/stockpile/jackberry
+	name = "Jackberry"
+	desc = "A sweet berry."
+	item_type = /obj/item/reagent_containers/food/snacks/grown/berries/rogue
+	held_items = list(0, 0)
+	payout_price = 2
+	withdraw_price = 4
+	transport_fee = 1
+	export_price = 4
+	importexport_amt = 5
+
+/datum/roguestock/stockpile/cabbage
+	name = "Cabbage"
+	desc = "Grenzelhoftian classic"
+	item_type = /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue
+	held_items = list(4, 8)
+	payout_price = 3
+	withdraw_price = 5
+	transport_fee = 1
+	export_price = 5
+	importexport_amt = 5


### PR DESCRIPTION
Adds stockpiling additional veggies for sale and export so that farmers may achieve minimum wage without recreating the golden triangle or become a glorified hemp farmer for the Fiber addicts out there.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Adds Onions, Cabbages and Jackberries to the Stockpile for export.
- Onions and Jackberries are worth _slightly_ less than Cabbages and Potatos due to a shorter growth cycle/multiharvest capacity.
- Cabbages are at-peer to exporting potatos. The Irish are saved!
- Jackberries do not come pre-filled due to the _slight_ chance of immediately jumpstarting the medicine industry. Woe, alchemists!

## Why It's Good For The Game
This is really just QoL so that farmers are actually rewarded for growing more than red-tar heroin and fibers-with-food-technically-attached. (Which are still **superior** forms of cash-cropping!)

Bonus points: Vomitorium now provides even MORE overpriced taxed food for Innkeepers to cook at a marginal loss! Who doesn't love 10 mammon cabbage soup?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
