### PR TITLE
changed forester chestplate armor class to light

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -865,7 +865,7 @@
 	item_state = "foresterchestplate"
 	max_integrity = 100
 	smeltresult = /obj/item/ash
-	armor_class = ARMOR_CLASS_MEDIUM
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/suit/roguetown/armor/plate/fancycuirass
 	slot_flags = ITEM_SLOT_ARMOR


### PR DESCRIPTION
my friend asked me to change this with his justification being "so druids can use the damm thing but they should maybe get medium armor proficiency"